### PR TITLE
Set up Slim 4 bootstrap project for job.smeird.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+APP_ENV=production
+APP_DEBUG=false
+APP_URL=https://job.smeird.com
+
+# Database configuration
+DB_HOST=localhost
+DB_PORT=3306
+DB_DATABASE=job
+DB_USERNAME=job
+DB_PASSWORD=secret
+
+# SMTP configuration
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USERNAME=apikey
+SMTP_PASSWORD=secret
+SMTP_ENCRYPTION=tls
+
+# OpenAI configuration
+OPENAI_API_KEY=sk-your-key
+OPENAI_ORG=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/vendor/
+/.env
+/.php-cs-fixer.cache
+/.idea/
+.DS_Store

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,35 @@
+{
+    "name": "smeird/job",
+    "description": "Slim 4 starter project for job.smeird.com",
+    "type": "project",
+    "require": {
+        "php": "^8.3",
+        "slim/slim": "^4.12",
+        "slim/psr7": "^1.7",
+        "vlucas/phpdotenv": "^5.6",
+        "respect/validation": "^2.3",
+        "guzzlehttp/guzzle": "^7.9",
+        "league/commonmark": "^2.4",
+        "dompdf/dompdf": "^2.0",
+        "phpoffice/phpword": "^1.1",
+        "ramsey/uuid": "^4.7",
+        "paragonie/constant_time_encoding": "^2.6",
+        "php-di/php-di": "^7.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    },
+    "scripts": {
+        "start-dev": "php -S localhost:8080 -t public public/index.php",
+        "test": [
+            "@php -l public/index.php",
+            "@php -l src/Bootstrap.php",
+            "@php -l src/Routes.php"
+        ],
+        "cs-fix": "@php -r \"echo 'Code style fixer not configured yet.' . PHP_EOL;\""
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true
+}

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Bootstrap;
+use App\Routes;
+use DI\Container;
+use Slim\Factory\AppFactory;
+use Slim\Middleware\ErrorMiddleware;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$rootPath = dirname(__DIR__);
+
+session_set_cookie_params([
+    'lifetime' => 0,
+    'path' => '/',
+    'domain' => '',
+    'secure' => true,
+    'httponly' => true,
+    'samesite' => 'Strict',
+]);
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+$container = new Container();
+AppFactory::setContainer($container);
+$app = AppFactory::create();
+
+Bootstrap::init($app, $rootPath);
+
+$app->addBodyParsingMiddleware();
+$app->addRoutingMiddleware();
+
+$displayErrorDetails = filter_var($_ENV['APP_DEBUG'] ?? false, FILTER_VALIDATE_BOOL);
+$errorMiddleware = new ErrorMiddleware(
+    $app->getCallableResolver(),
+    $app->getResponseFactory(),
+    $displayErrorDetails,
+    true,
+    true
+);
+$app->add($errorMiddleware);
+
+Routes::register($app);
+
+$app->run();

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use Dotenv\Dotenv;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Slim\App;
+
+class Bootstrap
+{
+    public static function init(App $app, string $rootPath): void
+    {
+        self::loadEnvironment($rootPath);
+        $appUrl = self::ensureAppUrl();
+        self::registerSecurityHeaders($app, $appUrl);
+    }
+
+    private static function loadEnvironment(string $rootPath): void
+    {
+        if (!is_dir($rootPath)) {
+            return;
+        }
+
+        if (!file_exists($rootPath . DIRECTORY_SEPARATOR . '.env')) {
+            Dotenv::createImmutable($rootPath)->safeLoad();
+
+            return;
+        }
+
+        Dotenv::createImmutable($rootPath)->safeLoad();
+    }
+
+    private static function ensureAppUrl(): string
+    {
+        $appUrl = $_ENV['APP_URL'] ?? getenv('APP_URL') ?: 'https://job.smeird.com';
+
+        putenv('APP_URL=' . $appUrl);
+        $_ENV['APP_URL'] = $appUrl;
+        $_SERVER['APP_URL'] = $appUrl;
+
+        return $appUrl;
+    }
+
+    private static function registerSecurityHeaders(App $app, string $appUrl): void
+    {
+        $headers = [
+            'Content-Security-Policy' => implode('; ', [
+                "default-src 'self' {$appUrl}",
+                "base-uri 'self'",
+                "connect-src 'self' {$appUrl}",
+                "frame-ancestors 'none'",
+                "img-src 'self' data: {$appUrl}",
+                "script-src 'self'",
+                "style-src 'self'",
+                "form-action 'self' {$appUrl}",
+            ]),
+            'Referrer-Policy' => 'strict-origin-when-cross-origin',
+            'Permissions-Policy' => 'accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()',
+        ];
+
+        $app->add(function (ServerRequestInterface $request, RequestHandlerInterface $handler) use ($headers): ResponseInterface {
+            $response = $handler->handle($request);
+
+            foreach ($headers as $name => $value) {
+                if (!$response->hasHeader($name)) {
+                    $response = $response->withHeader($name, $value);
+                }
+            }
+
+            return $response;
+        });
+    }
+}

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\App;
+
+class Routes
+{
+    public static function register(App $app): void
+    {
+        $app->get('/healthz', static function (Request $request, Response $response): Response {
+            $response->getBody()->write('ok');
+
+            return $response->withHeader('Content-Type', 'text/plain');
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- configure Composer for a PHP 8.3 Slim 4 application targeting job.smeird.com
- add environment bootstrapper that loads .env settings and injects security headers
- provide a front controller and routing stub with a /healthz health check endpoint

## Testing
- `php -l public/index.php`
- `php -l src/Bootstrap.php`
- `php -l src/Routes.php`
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d55e29fcc8832e9bbdec22122a9e6a