### PR TITLE
Add database migrations and PDO helper

### DIFF
--- a/bin/migrate.php
+++ b/bin/migrate.php
@@ -1,0 +1,76 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use App\DB;
+use Dotenv\Dotenv;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$rootPath = dirname(__DIR__);
+
+if (is_dir($rootPath)) {
+    if (is_file($rootPath . '/.env')) {
+        Dotenv::createImmutable($rootPath)->safeLoad();
+    } else {
+        Dotenv::createImmutable($rootPath)->safeLoad();
+    }
+}
+
+$pdo = DB::getConnection();
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS schema_migrations (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    migration VARCHAR(255) NOT NULL UNIQUE,
+    applied_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
+
+$migrationsDirectory = $rootPath . '/database/migrations';
+
+if (!is_dir($migrationsDirectory)) {
+    fwrite(STDERR, "No migrations directory found at {$migrationsDirectory}\n");
+    exit(1);
+}
+
+$files = glob($migrationsDirectory . '/*.php');
+sort($files);
+
+foreach ($files as $file) {
+    /** @var array{id?: string, up: array<int, string>, down?: array<int, string>} $migration */
+    $migration = require $file;
+
+    if (!isset($migration['up']) || !is_array($migration['up'])) {
+        throw new RuntimeException(sprintf('Migration file %s is missing an up() definition.', basename($file)));
+    }
+
+    $migrationId = $migration['id'] ?? basename($file, '.php');
+
+    $statement = $pdo->prepare('SELECT 1 FROM schema_migrations WHERE migration = :migration LIMIT 1');
+    $statement->execute(['migration' => $migrationId]);
+
+    if ($statement->fetchColumn()) {
+        continue;
+    }
+
+    echo sprintf("Applying migration %s...\n", $migrationId);
+
+    $pdo->beginTransaction();
+
+    try {
+        foreach ($migration['up'] as $sql) {
+            $pdo->exec($sql);
+        }
+
+        $insert = $pdo->prepare('INSERT INTO schema_migrations (migration) VALUES (:migration)');
+        $insert->execute(['migration' => $migrationId]);
+
+        $pdo->commit();
+    } catch (Throwable $throwable) {
+        $pdo->rollBack();
+
+        throw $throwable;
+    }
+}
+
+echo "Migrations complete.\n";

--- a/bin/rollback.php
+++ b/bin/rollback.php
@@ -1,0 +1,71 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use App\DB;
+use Dotenv\Dotenv;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$rootPath = dirname(__DIR__);
+
+if (is_dir($rootPath)) {
+    if (is_file($rootPath . '/.env')) {
+        Dotenv::createImmutable($rootPath)->safeLoad();
+    } else {
+        Dotenv::createImmutable($rootPath)->safeLoad();
+    }
+}
+
+$pdo = DB::getConnection();
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS schema_migrations (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    migration VARCHAR(255) NOT NULL UNIQUE,
+    applied_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
+
+$statement = $pdo->query('SELECT migration FROM schema_migrations ORDER BY applied_at DESC, id DESC LIMIT 1');
+$migrationId = $statement->fetchColumn();
+
+if (!$migrationId) {
+    echo "No migrations to rollback.\n";
+
+    return;
+}
+
+$migrationsDirectory = $rootPath . '/database/migrations';
+$filePath = $migrationsDirectory . '/' . $migrationId . '.php';
+
+if (!is_file($filePath)) {
+    throw new RuntimeException(sprintf('Migration file for %s not found.', $migrationId));
+}
+
+/** @var array{id?: string, up: array<int, string>, down?: array<int, string>} $migration */
+$migration = require $filePath;
+
+if (!isset($migration['down']) || !is_array($migration['down'])) {
+    throw new RuntimeException(sprintf('Migration %s does not support rollback.', $migrationId));
+}
+
+echo sprintf("Rolling back migration %s...\n", $migrationId);
+
+$pdo->beginTransaction();
+
+try {
+    foreach ($migration['down'] as $sql) {
+        $pdo->exec($sql);
+    }
+
+    $delete = $pdo->prepare('DELETE FROM schema_migrations WHERE migration = :migration');
+    $delete->execute(['migration' => $migrationId]);
+
+    $pdo->commit();
+} catch (Throwable $throwable) {
+    $pdo->rollBack();
+
+    throw $throwable;
+}
+
+echo "Rollback complete.\n";

--- a/database/migrations/20240326000000_initial.php
+++ b/database/migrations/20240326000000_initial.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'id' => '20240326000000_initial',
+    'up' => [
+        "CREATE TABLE IF NOT EXISTS users (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            email VARCHAR(255) NOT NULL UNIQUE,
+            password_hash VARCHAR(255) NOT NULL,
+            name VARCHAR(255) NULL,
+            status VARCHAR(32) NOT NULL DEFAULT 'active',
+            last_login_at DATETIME NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            KEY idx_users_created_at (created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "CREATE TABLE IF NOT EXISTS passcodes (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            user_id BIGINT UNSIGNED NOT NULL,
+            passcode CHAR(12) NOT NULL,
+            context VARCHAR(64) NOT NULL,
+            expires_at DATETIME NOT NULL,
+            consumed_at DATETIME NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY fk_passcodes_user (user_id) REFERENCES users(id) ON DELETE CASCADE,
+            KEY idx_passcodes_user_id (user_id),
+            KEY idx_passcodes_created_at (created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "CREATE TABLE IF NOT EXISTS backup_codes (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            user_id BIGINT UNSIGNED NOT NULL,
+            code CHAR(32) NOT NULL,
+            consumed_at DATETIME NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY fk_backup_codes_user (user_id) REFERENCES users(id) ON DELETE CASCADE,
+            UNIQUE KEY uq_backup_codes_user_code (user_id, code),
+            KEY idx_backup_codes_user_id (user_id),
+            KEY idx_backup_codes_created_at (created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "CREATE TABLE IF NOT EXISTS documents (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            user_id BIGINT UNSIGNED NOT NULL,
+            title VARCHAR(255) NOT NULL,
+            filename VARCHAR(255) NOT NULL,
+            mime_type VARCHAR(127) NOT NULL,
+            size_bytes BIGINT UNSIGNED NOT NULL,
+            checksum CHAR(64) NULL,
+            content LONGBLOB NULL,
+            extracted_text LONGTEXT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            FOREIGN KEY fk_documents_user (user_id) REFERENCES users(id) ON DELETE CASCADE,
+            KEY idx_documents_user_id (user_id),
+            KEY idx_documents_created_at (created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "CREATE TABLE IF NOT EXISTS generations (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            user_id BIGINT UNSIGNED NOT NULL,
+            document_id BIGINT UNSIGNED NULL,
+            model VARCHAR(128) NOT NULL,
+            prompt LONGTEXT NOT NULL,
+            status VARCHAR(32) NOT NULL DEFAULT 'pending',
+            cost_pence BIGINT UNSIGNED NOT NULL DEFAULT 0,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            FOREIGN KEY fk_generations_user (user_id) REFERENCES users(id) ON DELETE CASCADE,
+            FOREIGN KEY fk_generations_document (document_id) REFERENCES documents(id) ON DELETE SET NULL,
+            KEY idx_generations_user_id (user_id),
+            KEY idx_generations_created_at (created_at),
+            KEY idx_generations_user_created (user_id, created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "CREATE TABLE IF NOT EXISTS generation_outputs (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            generation_id BIGINT UNSIGNED NOT NULL,
+            mime_type VARCHAR(127) NULL,
+            content LONGBLOB NULL,
+            output_text LONGTEXT NULL,
+            tokens_used INT UNSIGNED NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY fk_generation_outputs_generation (generation_id) REFERENCES generations(id) ON DELETE CASCADE,
+            KEY idx_generation_outputs_generation_id (generation_id),
+            KEY idx_generation_outputs_created_at (created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "CREATE TABLE IF NOT EXISTS api_usage (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            user_id BIGINT UNSIGNED NOT NULL,
+            provider VARCHAR(128) NOT NULL,
+            endpoint VARCHAR(255) NOT NULL,
+            tokens_used INT UNSIGNED NULL,
+            cost_pence BIGINT UNSIGNED NOT NULL DEFAULT 0,
+            metadata JSON NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY fk_api_usage_user (user_id) REFERENCES users(id) ON DELETE CASCADE,
+            KEY idx_api_usage_user_id (user_id),
+            KEY idx_api_usage_created_at (created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "CREATE TABLE IF NOT EXISTS audit_logs (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            user_id BIGINT UNSIGNED NULL,
+            action VARCHAR(128) NOT NULL,
+            ip_address VARCHAR(45) NULL,
+            user_agent VARCHAR(255) NULL,
+            details JSON NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY fk_audit_logs_user (user_id) REFERENCES users(id) ON DELETE SET NULL,
+            KEY idx_audit_logs_user_id (user_id),
+            KEY idx_audit_logs_created_at (created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "CREATE TABLE IF NOT EXISTS retention_policies (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            user_id BIGINT UNSIGNED NULL,
+            resource_type VARCHAR(64) NOT NULL,
+            retention_days INT UNSIGNED NOT NULL,
+            is_active TINYINT(1) NOT NULL DEFAULT 1,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            FOREIGN KEY fk_retention_policies_user (user_id) REFERENCES users(id) ON DELETE CASCADE,
+            KEY idx_retention_policies_user_id (user_id),
+            KEY idx_retention_policies_created_at (created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        "CREATE TABLE IF NOT EXISTS jobs (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            queue VARCHAR(64) NOT NULL,
+            payload LONGTEXT NOT NULL,
+            attempts INT UNSIGNED NOT NULL DEFAULT 0,
+            available_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            reserved_at DATETIME NULL,
+            completed_at DATETIME NULL,
+            last_error TEXT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            KEY idx_jobs_queue_available (queue, available_at),
+            KEY idx_jobs_created_at (created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"
+    ],
+    'down' => [
+        'DROP TABLE IF EXISTS generation_outputs',
+        'DROP TABLE IF EXISTS generations',
+        'DROP TABLE IF EXISTS documents',
+        'DROP TABLE IF EXISTS jobs',
+        'DROP TABLE IF EXISTS retention_policies',
+        'DROP TABLE IF EXISTS audit_logs',
+        'DROP TABLE IF EXISTS api_usage',
+        'DROP TABLE IF EXISTS backup_codes',
+        'DROP TABLE IF EXISTS passcodes',
+        'DROP TABLE IF EXISTS users'
+    ],
+];

--- a/src/DB.php
+++ b/src/DB.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use PDO;
+use PDOException;
+use RuntimeException;
+
+class DB
+{
+    public static function getConnection(): PDO
+    {
+        $config = self::resolveConfig();
+
+        try {
+            $pdo = new PDO(
+                $config['dsn'],
+                $config['username'],
+                $config['password'],
+                $config['options']
+            );
+        } catch (PDOException $exception) {
+            throw new RuntimeException('Unable to connect to the database.', 0, $exception);
+        }
+
+        return $pdo;
+    }
+
+    /**
+     * @return array{dsn: string, username: string|null, password: string|null, options: array<int, mixed>}
+     */
+    private static function resolveConfig(): array
+    {
+        $dsn = self::env('DB_DSN');
+        $username = self::env('DB_USERNAME');
+        $password = self::env('DB_PASSWORD');
+
+        if ($dsn === null || $dsn === '') {
+            $driver = self::env('DB_DRIVER') ?? 'mysql';
+
+            if ($driver === 'sqlite') {
+                $database = self::env('DB_DATABASE') ?? ':memory:';
+                $dsn = sprintf('sqlite:%s', $database);
+            } else {
+                $host = self::env('DB_HOST') ?? '127.0.0.1';
+                $port = self::env('DB_PORT') ?? '3306';
+                $database = self::env('DB_DATABASE') ?? 'app';
+                $charset = self::env('DB_CHARSET') ?? 'utf8mb4';
+                $unixSocket = self::env('DB_SOCKET');
+
+                if ($unixSocket !== null && $unixSocket !== '') {
+                    $dsn = sprintf('%s:unix_socket=%s;dbname=%s;charset=%s', $driver, $unixSocket, $database, $charset);
+                } else {
+                    $dsn = sprintf('%s:host=%s;port=%s;dbname=%s;charset=%s', $driver, $host, $port, $database, $charset);
+                }
+            }
+        }
+
+        $options = [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_EMULATE_PREPARES => false,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            PDO::ATTR_STRINGIFY_FETCHES => false,
+        ];
+
+        if (str_starts_with($dsn, 'mysql:')) {
+            $options[PDO::MYSQL_ATTR_INIT_COMMAND] = 'SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci';
+        }
+
+        return [
+            'dsn' => $dsn,
+            'username' => $username,
+            'password' => $password,
+            'options' => $options,
+        ];
+    }
+
+    private static function env(string $key): ?string
+    {
+        $value = $_ENV[$key] ?? $_SERVER[$key] ?? getenv($key);
+
+        if ($value === false) {
+            return null;
+        }
+
+        $trimmed = is_string($value) ? trim($value) : null;
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+}


### PR DESCRIPTION
## Summary
- add a hardened PDO helper for consistent connection handling
- define the initial database schema and indexes in a migration file
- provide CLI scripts to run and rollback migrations using PDO

## Testing
- composer test
- php -l bin/migrate.php
- php -l bin/rollback.php
- php -l src/DB.php

------
https://chatgpt.com/codex/tasks/task_e_68d55f6550c0832e96a28ba94ac35255