### PR TITLE
Implement secure document upload and preview

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "phpoffice/phpword": "^1.1",
         "ramsey/uuid": "^4.7",
         "paragonie/constant_time_encoding": "^2.6",
-        "php-di/php-di": "^7.0"
+        "php-di/php-di": "^7.0",
+        "smalot/pdfparser": "^2.6"
     },
     "autoload": {
         "psr-4": {

--- a/public/index.php
+++ b/public/index.php
@@ -12,6 +12,9 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 $rootPath = dirname(__DIR__);
 
+ini_set('upload_max_filesize', '1M');
+ini_set('post_max_size', '2M');
+
 session_set_cookie_params([
     'lifetime' => 0,
     'path' => '/',

--- a/src/Database.php
+++ b/src/Database.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use PDO;
+use RuntimeException;
+
+class Database
+{
+    private static ?PDO $connection = null;
+
+    public static function connection(): PDO
+    {
+        if (self::$connection instanceof PDO) {
+            return self::$connection;
+        }
+
+        $dsn = $_ENV['DB_DSN'] ?? getenv('DB_DSN');
+
+        if ($dsn === false || $dsn === null || $dsn === '') {
+            $host = $_ENV['DB_HOST'] ?? getenv('DB_HOST');
+            $database = $_ENV['DB_DATABASE'] ?? getenv('DB_DATABASE');
+
+            if ($host && $database) {
+                $port = $_ENV['DB_PORT'] ?? getenv('DB_PORT') ?: '3306';
+                $charset = $_ENV['DB_CHARSET'] ?? getenv('DB_CHARSET') ?: 'utf8mb4';
+                $dsn = sprintf('mysql:host=%s;port=%s;dbname=%s;charset=%s', $host, $port, $database, $charset);
+            }
+        }
+
+        if (!$dsn) {
+            throw new RuntimeException('Database configuration missing. Set DB_DSN or DB_HOST/DB_DATABASE.');
+        }
+
+        $username = $_ENV['DB_USERNAME'] ?? getenv('DB_USERNAME') ?: null;
+        $password = $_ENV['DB_PASSWORD'] ?? getenv('DB_PASSWORD') ?: null;
+
+        $options = [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            PDO::ATTR_EMULATE_PREPARES => false,
+        ];
+
+        self::$connection = new PDO($dsn, $username, $password, $options);
+
+        return self::$connection;
+    }
+}

--- a/src/Documents/Document.php
+++ b/src/Documents/Document.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Documents;
+
+use DateTimeImmutable;
+
+class Document
+{
+    public function __construct(
+        private readonly ?int $id,
+        private readonly string $filename,
+        private readonly string $mimeType,
+        private readonly int $sizeBytes,
+        private readonly string $sha256,
+        private readonly string $content,
+        private readonly DateTimeImmutable $createdAt,
+    ) {
+    }
+
+    public function id(): ?int
+    {
+        return $this->id;
+    }
+
+    public function withId(int $id): self
+    {
+        return new self(
+            $id,
+            $this->filename,
+            $this->mimeType,
+            $this->sizeBytes,
+            $this->sha256,
+            $this->content,
+            $this->createdAt,
+        );
+    }
+
+    public function filename(): string
+    {
+        return $this->filename;
+    }
+
+    public function mimeType(): string
+    {
+        return $this->mimeType;
+    }
+
+    public function sizeBytes(): int
+    {
+        return $this->sizeBytes;
+    }
+
+    public function sha256(): string
+    {
+        return $this->sha256;
+    }
+
+    public function content(): string
+    {
+        return $this->content;
+    }
+
+    public function createdAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/src/Documents/DocumentPreviewer.php
+++ b/src/Documents/DocumentPreviewer.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Documents;
+
+use Smalot\PdfParser\Parser;
+use ZipArchive;
+
+class DocumentPreviewer
+{
+    private Parser $pdfParser;
+
+    public function __construct(?Parser $parser = null)
+    {
+        $this->pdfParser = $parser ?? new Parser();
+    }
+
+    public function render(Document $document): string
+    {
+        $content = $document->content();
+
+        return match ($document->mimeType()) {
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => $this->renderDocx($content),
+            'application/pdf' => $this->renderPdf($content),
+            'text/markdown', 'text/plain' => $this->renderText($content),
+            default => '',
+        };
+    }
+
+    private function renderDocx(string $content): string
+    {
+        $resource = tmpfile();
+
+        if ($resource === false) {
+            return '';
+        }
+
+        fwrite($resource, $content);
+        $meta = stream_get_meta_data($resource);
+        $path = $meta['uri'] ?? null;
+
+        if (!$path) {
+            fclose($resource);
+
+            return '';
+        }
+
+        $zip = new ZipArchive();
+
+        if ($zip->open($path) !== true) {
+            fclose($resource);
+
+            return '';
+        }
+
+        $xml = $zip->getFromName('word/document.xml') ?: '';
+        $zip->close();
+        fclose($resource);
+
+        if ($xml === '') {
+            return '';
+        }
+
+        $xml = preg_replace('/<w:p[^>]*>/', '', $xml);
+        $xml = preg_replace('/<\/w:p>/', "\n", $xml);
+        $xml = preg_replace('/<w:tab[^>]*\/>/', "\t", $xml);
+        $xml = preg_replace('/<w:br[^>]*\/>/', "\n", $xml);
+
+        $text = strip_tags($xml ?? '');
+
+        return html_entity_decode($text, ENT_QUOTES | ENT_XML1, 'UTF-8');
+    }
+
+    private function renderPdf(string $content): string
+    {
+        try {
+            $pdf = $this->pdfParser->parseContent($content);
+
+            return $pdf->getText();
+        } catch (\Throwable) {
+            return '';
+        }
+    }
+
+    private function renderText(string $content): string
+    {
+        return $content;
+    }
+}

--- a/src/Documents/DocumentRepository.php
+++ b/src/Documents/DocumentRepository.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Documents;
+
+use DateTimeImmutable;
+use PDO;
+
+class DocumentRepository
+{
+    public function __construct(private readonly PDO $pdo)
+    {
+        $this->ensureSchema();
+    }
+
+    public function save(Document $document): Document
+    {
+        $statement = $this->pdo->prepare(
+            'INSERT INTO documents (filename, mime_type, size_bytes, sha256, content, created_at) VALUES (:filename, :mime_type, :size_bytes, :sha256, :content, :created_at)'
+        );
+
+        $createdAt = $document->createdAt()->format('Y-m-d H:i:s');
+
+        $statement->bindValue(':filename', $document->filename());
+        $statement->bindValue(':mime_type', $document->mimeType());
+        $statement->bindValue(':size_bytes', $document->sizeBytes(), PDO::PARAM_INT);
+        $statement->bindValue(':sha256', $document->sha256());
+        $statement->bindValue(':content', $document->content(), PDO::PARAM_LOB);
+        $statement->bindValue(':created_at', $createdAt);
+
+        $statement->execute();
+
+        $id = (int) $this->pdo->lastInsertId();
+
+        return $document->withId($id);
+    }
+
+    public function find(int $id): ?Document
+    {
+        $statement = $this->pdo->prepare('SELECT * FROM documents WHERE id = :id LIMIT 1');
+        $statement->bindValue(':id', $id, PDO::PARAM_INT);
+        $statement->execute();
+
+        $row = $statement->fetch();
+
+        if ($row === false) {
+            return null;
+        }
+
+        return new Document(
+            (int) $row['id'],
+            $row['filename'],
+            $row['mime_type'],
+            (int) $row['size_bytes'],
+            $row['sha256'],
+            is_resource($row['content']) ? stream_get_contents($row['content']) ?: '' : (string) $row['content'],
+            new DateTimeImmutable($row['created_at']),
+        );
+    }
+
+    private function ensureSchema(): void
+    {
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'mysql') {
+            $this->pdo->exec(
+                'CREATE TABLE IF NOT EXISTS documents (
+                    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                    filename VARCHAR(255) NOT NULL,
+                    mime_type VARCHAR(191) NOT NULL,
+                    size_bytes BIGINT UNSIGNED NOT NULL,
+                    sha256 CHAR(64) NOT NULL UNIQUE,
+                    content LONGBLOB NOT NULL,
+                    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'
+            );
+
+            return;
+        }
+
+        $this->pdo->exec(
+            'CREATE TABLE IF NOT EXISTS documents (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                filename TEXT NOT NULL,
+                mime_type TEXT NOT NULL,
+                size_bytes INTEGER NOT NULL,
+                sha256 TEXT NOT NULL UNIQUE,
+                content BLOB NOT NULL,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )'
+        );
+    }
+}

--- a/src/Documents/DocumentService.php
+++ b/src/Documents/DocumentService.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Documents;
+
+use DateTimeImmutable;
+use Psr\Http\Message\UploadedFileInterface;
+use RuntimeException;
+
+class DocumentService
+{
+    public function __construct(
+        private readonly DocumentRepository $repository,
+        private readonly DocumentValidator $validator,
+    ) {
+    }
+
+    public function storeUploadedDocument(UploadedFileInterface $uploadedFile): Document
+    {
+        $error = $uploadedFile->getError();
+
+        if ($error === UPLOAD_ERR_INI_SIZE || $error === UPLOAD_ERR_FORM_SIZE) {
+            throw new DocumentValidationException('The uploaded file exceeds the maximum allowed size.', 413);
+        }
+
+        if ($error !== UPLOAD_ERR_OK) {
+            throw new RuntimeException('File upload failed.');
+        }
+
+        $clientFilename = $uploadedFile->getClientFilename();
+
+        if ($clientFilename === null || $clientFilename === '') {
+            throw new RuntimeException('A file name is required.');
+        }
+
+        $stream = $uploadedFile->getStream();
+        $temporaryPath = $stream->getMetadata('uri');
+
+        $stream->rewind();
+        $hashContext = hash_init('sha256');
+        $buffer = '';
+
+        while (!$stream->eof()) {
+            $chunk = $stream->read(65536);
+
+            if ($chunk === '') {
+                break;
+            }
+
+            $buffer .= $chunk;
+            hash_update($hashContext, $chunk);
+        }
+
+        $sha256 = hash_final($hashContext);
+
+        $stream->close();
+
+        try {
+            $validation = $this->validator->validate($clientFilename, $buffer, is_string($temporaryPath) ? $temporaryPath : null);
+
+            $document = new Document(
+                null,
+                $clientFilename,
+                $validation['mime'],
+                $validation['size'],
+                $sha256,
+                $buffer,
+                new DateTimeImmutable(),
+            );
+
+            return $this->repository->save($document);
+        } finally {
+            if (is_string($temporaryPath) && !str_starts_with($temporaryPath, 'php://') && file_exists($temporaryPath)) {
+                @unlink($temporaryPath);
+            }
+        }
+    }
+
+    public function find(int $id): ?Document
+    {
+        return $this->repository->find($id);
+    }
+}

--- a/src/Documents/DocumentValidationException.php
+++ b/src/Documents/DocumentValidationException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Documents;
+
+use RuntimeException;
+
+class DocumentValidationException extends RuntimeException
+{
+    public function __construct(string $message, private readonly int $statusCode = 400)
+    {
+        parent::__construct($message);
+    }
+
+    public function statusCode(): int
+    {
+        return $this->statusCode;
+    }
+}

--- a/src/Documents/DocumentValidator.php
+++ b/src/Documents/DocumentValidator.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Documents;
+
+use ZipArchive;
+
+class DocumentValidator
+{
+    private const MAX_FILE_SIZE = 1048576; // 1 MiB
+
+    /**
+     * @return array{mime: string, size: int}
+     */
+    public function validate(string $filename, string $content, ?string $temporaryPath): array
+    {
+        $size = strlen($content);
+
+        if ($size > self::MAX_FILE_SIZE) {
+            throw new DocumentValidationException('The uploaded file exceeds the maximum allowed size.', 413);
+        }
+
+        $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+
+        if (!in_array($extension, ['docx', 'pdf', 'md', 'txt'], true)) {
+            throw new DocumentValidationException('Unsupported file type.');
+        }
+
+        return match ($extension) {
+            'docx' => [
+                'mime' => $this->validateDocx($content, $temporaryPath),
+                'size' => $size,
+            ],
+            'pdf' => [
+                'mime' => $this->validatePdf($content),
+                'size' => $size,
+            ],
+            'md' => [
+                'mime' => $this->validateTextLike($content, 'text/markdown'),
+                'size' => $size,
+            ],
+            default => [
+                'mime' => $this->validateTextLike($content, 'text/plain'),
+                'size' => $size,
+            ],
+        };
+    }
+
+    private function validateDocx(string $content, ?string $temporaryPath): string
+    {
+        if (!str_starts_with($content, "PK")) {
+            throw new DocumentValidationException('The DOCX archive is malformed.');
+        }
+
+        $path = $temporaryPath;
+
+        if (!$path || !is_string($path) || !file_exists($path)) {
+            $resource = tmpfile();
+
+            if ($resource === false) {
+                throw new DocumentValidationException('Unable to create a temporary file for validation.');
+            }
+
+            fwrite($resource, $content);
+            $meta = stream_get_meta_data($resource);
+            $path = $meta['uri'] ?? null;
+        } else {
+            $resource = null;
+        }
+
+        if (!$path) {
+            if (isset($resource)) {
+                fclose($resource);
+            }
+
+            throw new DocumentValidationException('Unable to inspect DOCX archive.');
+        }
+
+        $zip = new ZipArchive();
+
+        $openResult = $zip->open($path);
+
+        if ($openResult !== true) {
+            if (isset($resource)) {
+                fclose($resource);
+            }
+
+            throw new DocumentValidationException('Unable to open DOCX archive.');
+        }
+
+        if ($zip->locateName('word/vbaProject.bin', ZipArchive::FL_NODIR) !== false) {
+            $zip->close();
+
+            if (isset($resource)) {
+                fclose($resource);
+            }
+
+            throw new DocumentValidationException('DOCX files containing macros are not allowed.');
+        }
+
+        $contentTypes = $zip->getFromName('[Content_Types].xml');
+
+        if ($contentTypes !== false && str_contains($contentTypes, 'macroEnabled')) {
+            $zip->close();
+
+            if (isset($resource)) {
+                fclose($resource);
+            }
+
+            throw new DocumentValidationException('DOCX files containing macros are not allowed.');
+        }
+
+        if ($zip->getFromName('word/document.xml') === false) {
+            $zip->close();
+
+            if (isset($resource)) {
+                fclose($resource);
+            }
+
+            throw new DocumentValidationException('The DOCX archive is missing required components.');
+        }
+
+        $zip->close();
+
+        if (isset($resource)) {
+            fclose($resource);
+        }
+
+        return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+    }
+
+    private function validatePdf(string $content): string
+    {
+        if (!str_starts_with($content, "%PDF")) {
+            throw new DocumentValidationException('Invalid PDF file.');
+        }
+
+        $finfo = finfo_open(FILEINFO_MIME_TYPE);
+
+        if ($finfo === false) {
+            throw new DocumentValidationException('Unable to inspect file type.');
+        }
+
+        $mime = finfo_buffer($finfo, $content);
+        finfo_close($finfo);
+
+        if ($mime !== 'application/pdf') {
+            throw new DocumentValidationException('Invalid PDF file.');
+        }
+
+        return 'application/pdf';
+    }
+
+    private function validateTextLike(string $content, string $expectedMime): string
+    {
+        if (preg_match('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', $content)) {
+            throw new DocumentValidationException('Text files must not contain binary data.');
+        }
+
+        return $expectedMime;
+    }
+}

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace App;
 
+use App\Documents\DocumentPreviewer;
+use App\Documents\DocumentService;
+use App\Documents\DocumentValidationException;
+use App\Documents\DocumentValidator;
+use App\Documents\DocumentRepository;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\App;
@@ -12,10 +17,87 @@ class Routes
 {
     public static function register(App $app): void
     {
+        $documentRepository = new DocumentRepository(Database::connection());
+        $documentService = new DocumentService($documentRepository, new DocumentValidator());
+        $documentPreviewer = new DocumentPreviewer();
+
         $app->get('/healthz', static function (Request $request, Response $response): Response {
             $response->getBody()->write('ok');
 
             return $response->withHeader('Content-Type', 'text/plain');
+        });
+
+        $app->post('/documents/upload', static function (Request $request, Response $response) use ($documentService): Response {
+            $files = $request->getUploadedFiles();
+            $uploadedFile = $files['document'] ?? null;
+
+            if ($uploadedFile === null) {
+                $response->getBody()->write((string) json_encode(['error' => 'No document uploaded.']));
+
+                return $response
+                    ->withStatus(400)
+                    ->withHeader('Content-Type', 'application/json');
+            }
+
+            try {
+                $document = $documentService->storeUploadedDocument($uploadedFile);
+            } catch (DocumentValidationException $exception) {
+                $response->getBody()->write((string) json_encode(['error' => $exception->getMessage()]));
+
+                return $response
+                    ->withStatus($exception->statusCode())
+                    ->withHeader('Content-Type', 'application/json');
+            } catch (\Throwable $exception) {
+                $response->getBody()->write((string) json_encode(['error' => 'Unable to process the uploaded document.']));
+
+                return $response
+                    ->withStatus(400)
+                    ->withHeader('Content-Type', 'application/json');
+            }
+
+            $payload = json_encode([
+                'id' => $document->id(),
+                'filename' => $document->filename(),
+                'mime_type' => $document->mimeType(),
+                'size_bytes' => $document->sizeBytes(),
+                'sha256' => $document->sha256(),
+            ]);
+
+            $response->getBody()->write($payload === false ? '{}' : $payload);
+
+            return $response
+                ->withStatus(201)
+                ->withHeader('Content-Type', 'application/json');
+        });
+
+        $app->get('/documents/{id}/preview', static function (Request $request, Response $response, array $args) use ($documentService, $documentPreviewer): Response {
+            $id = isset($args['id']) ? (int) $args['id'] : 0;
+
+            if ($id <= 0) {
+                $response->getBody()->write('Document not found.');
+
+                return $response->withStatus(404)->withHeader('Content-Type', 'text/plain; charset=utf-8');
+            }
+
+            $document = $documentService->find($id);
+
+            if ($document === null) {
+                $response->getBody()->write('Document not found.');
+
+                return $response->withStatus(404)->withHeader('Content-Type', 'text/plain; charset=utf-8');
+            }
+
+            $preview = $documentPreviewer->render($document);
+
+            if (function_exists('mb_substr')) {
+                $preview = mb_substr($preview, 0, 5000);
+            } else {
+                $preview = substr($preview, 0, 5000);
+            }
+
+            $response->getBody()->write($preview);
+
+            return $response->withHeader('Content-Type', 'text/plain; charset=utf-8');
         });
     }
 }


### PR DESCRIPTION
## Summary
- enforce strict upload size limits at bootstrap and add secure document upload endpoint with allow-listed validation and macro detection
- persist uploaded document binaries and metadata in MySQL via a new repository layer and compute SHA-256 hashes
- expose document preview endpoint that returns a plain-text excerpt for PDF, DOCX, Markdown, and text files using safe parsing

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d55f7ec434832eb34cc81a11560b22