### PR TITLE
Add embedded CV prompts and draft validator

### DIFF
--- a/prompts/system.txt
+++ b/prompts/system.txt
@@ -1,0 +1,3 @@
+You are a truthful CV editor who must use UK spelling conventions.
+Never fabricate achievements, employers, or qualifications.
+When you detect employment or education gaps, add a section titled "Optional evidence to add" that suggests documents or references the candidate could supply.

--- a/prompts/tailor.txt
+++ b/prompts/tailor.txt
@@ -1,0 +1,18 @@
+Inputs you receive:
+- Job title: {{title}}
+- Hiring company: {{company}}
+- Priority competencies: {{competencies}}
+- Candidate CV sections (Markdown):
+{{cv_sections}}
+
+Tasks:
+1. Draft a role-specific summary that links the candidate's experience to the job title and company.
+2. Reorder or trim the supplied CV sections so the most relevant accomplishments for the listed competencies appear first.
+3. Only quantify achievements when the original CV already provides the numbers.
+4. For any employment or education gap you notice, create an "Optional evidence to add" note with appropriate supporting material.
+5. Never introduce employers or qualifications that are absent from the source CV.
+
+Output:
+- Return the tailored CV as valid Markdown.
+- Use British English throughout.
+- Preserve factual accuracy and clearly flag any gaps.

--- a/src/Prompts/PromptLibrary.php
+++ b/src/Prompts/PromptLibrary.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Prompts;
+
+final class PromptLibrary
+{
+    private const SYSTEM_PROMPT = <<<'SYSTEM'
+You are a truthful CV editor who must use UK spelling conventions.
+Never fabricate achievements, employers, or qualifications.
+When you detect employment or education gaps, add a section titled "Optional evidence to add" that suggests documents or references the candidate could supply.
+SYSTEM;
+
+    private const TAILOR_PROMPT = <<<'TAILOR'
+Inputs you receive:
+- Job title: {{title}}
+- Hiring company: {{company}}
+- Priority competencies: {{competencies}}
+- Candidate CV sections (Markdown):
+{{cv_sections}}
+
+Tasks:
+1. Draft a role-specific summary that links the candidate's experience to the job title and company.
+2. Reorder or trim the supplied CV sections so the most relevant accomplishments for the listed competencies appear first.
+3. Only quantify achievements when the original CV already provides the numbers.
+4. For any employment or education gap you notice, create an "Optional evidence to add" note with appropriate supporting material.
+5. Never introduce employers or qualifications that are absent from the source CV.
+
+Output:
+- Return the tailored CV as valid Markdown.
+- Use British English throughout.
+- Preserve factual accuracy and clearly flag any gaps.
+TAILOR;
+
+    public static function systemPrompt(): string
+    {
+        return self::SYSTEM_PROMPT;
+    }
+
+    public static function tailorPrompt(): string
+    {
+        return self::TAILOR_PROMPT;
+    }
+}

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace App;
 
+use App\Prompts\PromptLibrary;
+use App\Validation\DraftValidator;
+use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\App;
+use Slim\Exception\HttpBadRequestException;
 
 class Routes
 {
@@ -16,6 +20,53 @@ class Routes
             $response->getBody()->write('ok');
 
             return $response->withHeader('Content-Type', 'text/plain');
+        });
+
+        $app->get('/prompts', static function (Request $request, Response $response): Response {
+            $payload = [
+                'system' => PromptLibrary::systemPrompt(),
+                'tailor' => PromptLibrary::tailorPrompt(),
+            ];
+
+            $response->getBody()->write((string) json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return $response->withHeader('Content-Type', 'application/json');
+        });
+
+        $app->post('/draft/validate', static function (Request $request, Response $response): Response {
+            $parsed = $request->getParsedBody();
+
+            if (!is_array($parsed)) {
+                throw new HttpBadRequestException($request, 'Invalid request payload.');
+            }
+
+            $sourceCv = isset($parsed['source_cv']) ? trim((string) $parsed['source_cv']) : '';
+            $draft = isset($parsed['draft_markdown']) ? trim((string) $parsed['draft_markdown']) : '';
+
+            if ($sourceCv === '' || $draft === '') {
+                throw new HttpBadRequestException($request, 'Both source_cv and draft_markdown are required.');
+            }
+
+            $validator = new DraftValidator();
+
+            try {
+                $validator->ensureNoUnknownOrganisations($sourceCv, $draft);
+            } catch (InvalidArgumentException $exception) {
+                $response->getBody()->write((string) json_encode([
+                    'status' => 'rejected',
+                    'reason' => $exception->getMessage(),
+                ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+                return $response
+                    ->withStatus(422)
+                    ->withHeader('Content-Type', 'application/json');
+            }
+
+            $response->getBody()->write((string) json_encode([
+                'status' => 'accepted',
+            ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return $response->withHeader('Content-Type', 'application/json');
         });
     }
 }

--- a/src/Validation/DraftValidator.php
+++ b/src/Validation/DraftValidator.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validation;
+
+use InvalidArgumentException;
+
+final class DraftValidator
+{
+    private const STOPWORDS = [
+        'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December',
+        'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday',
+        'University', 'College', 'School', 'Optional', 'Evidence', 'Add',
+        'Curriculum', 'Vitae', 'Professional', 'Summary', 'Education', 'Experience',
+        'Skills', 'References', 'Interests', 'Profile', 'Overview', 'Employment',
+    ];
+
+    private const ROLE_WORDS = [
+        'Assistant', 'Associate', 'Consultant', 'Coordinator', 'Designer', 'Developer', 'Director', 'Engineer',
+        'Executive', 'Lead', 'Leader', 'Manager', 'Officer', 'Partner', 'Principal', 'Specialist', 'Supervisor', 'Technician',
+        'Analyst', 'Architect', 'Administrator', 'Advisor', 'Strategist', 'Scientist', 'Researcher', 'Teacher', 'Lecturer',
+        'Tutor', 'Intern', 'Contractor', 'Volunteer', 'Mentor', 'Coach', 'Trainer', 'Consultant', 'Head', 'Chief',
+        'Project', 'Product', 'Programme', 'Program', 'Service', 'Support', 'Operations', 'Operational', 'Customer', 'Client',
+    ];
+
+    /**
+     * @throws InvalidArgumentException when the draft contains organisations not present in the source CV.
+     */
+    public function ensureNoUnknownOrganisations(string $sourceCv, string $draftMarkdown): void
+    {
+        $sourceOrganisations = $this->extractOrganisations($sourceCv);
+        $draftOrganisations = $this->extractOrganisations($draftMarkdown);
+
+        $unknown = array_values(array_diff($draftOrganisations, $sourceOrganisations));
+
+        if ($unknown !== []) {
+            throw new InvalidArgumentException('Draft introduces unrecognised organisations: ' . implode(', ', $unknown));
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function extractOrganisations(string $text): array
+    {
+        $matches = [];
+        preg_match_all('/\b([A-Z][A-Za-z&\'"-]*(?:\s+(?:of|and|&|the|for|in|on|de|da|di|la|le|von|van)?\s*[A-Z][A-Za-z&\'"-]*)*)\b/u', $text, $matches);
+
+        if (!isset($matches[1])) {
+            return [];
+        }
+
+        $organisations = [];
+
+        foreach ($matches[1] as $match) {
+            $cleaned = trim(preg_replace('/\s+/', ' ', (string) $match));
+
+            if ($cleaned === '' || mb_strlen($cleaned) < 3) {
+                continue;
+            }
+
+            $words = preg_split('/\s+/', $cleaned);
+
+            if ($words === false || $words === []) {
+                continue;
+            }
+
+            if ($this->shouldSkip($words)) {
+                continue;
+            }
+
+            $organisations[] = mb_strtolower($cleaned);
+        }
+
+        $organisations = array_values(array_unique($organisations));
+
+        return $organisations;
+    }
+
+    /**
+     * @param list<string> $words
+     */
+    private function shouldSkip(array $words): bool
+    {
+        $upperWords = array_map(
+            static fn (string $word): string => preg_replace('/[^A-Za-z]/', '', $word) ?? '',
+            $words
+        );
+
+        $allStopwords = true;
+        $allRoleWords = true;
+
+        foreach ($upperWords as $word) {
+            if ($word === '') {
+                continue;
+            }
+
+            if (!in_array($word, self::STOPWORDS, true)) {
+                $allStopwords = false;
+            }
+
+            if (!in_array($word, self::ROLE_WORDS, true)) {
+                $allRoleWords = false;
+            }
+        }
+
+        if ($allStopwords || $allRoleWords) {
+            return true;
+        }
+
+        if (count($words) === 1) {
+            $word = $upperWords[0];
+
+            if (in_array($word, self::STOPWORDS, true) || in_array($word, self::ROLE_WORDS, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- add system and tailoring prompts defined in PHP heredocs and commit matching text references
- expose prompts via a new /prompts endpoint
- implement a draft validator and endpoint to block CV drafts that introduce unknown organisations

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d5610aa658832eb5d9df69356315d9