### PR TITLE
Implement queue worker and tailor CV job pipeline

### DIFF
--- a/bin/worker.php
+++ b/bin/worker.php
@@ -1,0 +1,68 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use App\DB;
+use App\Queue\Handler\TailorCvJobHandler;
+use App\Queue\JobRepository;
+use App\Queue\JobWorker;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+if (!extension_loaded('pcntl')) {
+    fwrite(STDERR, "The pcntl extension is required to run the worker." . PHP_EOL);
+    exit(1);
+}
+
+pcntl_async_signals(true);
+
+$stop = false;
+
+pcntl_signal(SIGTERM, static function () use (&$stop): void {
+    $stop = true;
+});
+pcntl_signal(SIGINT, static function () use (&$stop): void {
+    $stop = true;
+});
+
+$pdo = DB::getConnection();
+$repository = new JobRepository($pdo);
+$handlers = [
+    'tailor_cv' => new TailorCvJobHandler($pdo),
+];
+$worker = new JobWorker($repository, $handlers, 5);
+
+$backoffSeconds = 1;
+$maxIdleBackoff = 30;
+
+while (!$stop) {
+    try {
+        $job = $repository->reserveNextPending();
+    } catch (Throwable $exception) {
+        fwrite(STDERR, sprintf('[%s] Failed to reserve job: %s%s', date('c'), $exception->getMessage(), PHP_EOL));
+        sleep($backoffSeconds);
+        $backoffSeconds = min($backoffSeconds * 2, $maxIdleBackoff);
+        continue;
+    }
+
+    if ($job === null) {
+        sleep($backoffSeconds);
+        $backoffSeconds = min($backoffSeconds * 2, $maxIdleBackoff);
+        continue;
+    }
+
+    $backoffSeconds = 1;
+
+    try {
+        $worker->process($job);
+    } catch (Throwable $exception) {
+        fwrite(STDERR, sprintf('[%s] Unexpected worker error: %s%s', date('c'), $exception->getMessage(), PHP_EOL));
+    }
+
+    if ($stop) {
+        break;
+    }
+}
+
+fwrite(STDOUT, 'Worker shutting down' . PHP_EOL);

--- a/database/migrations/20240401000000_jobs_overhaul.php
+++ b/database/migrations/20240401000000_jobs_overhaul.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'id' => '20240401000000_jobs_overhaul',
+    'up' => [
+        'DROP TABLE IF EXISTS jobs',
+        "CREATE TABLE jobs (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            type VARCHAR(100) NOT NULL,
+            payload_json JSON NOT NULL,
+            run_after DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            attempts INT UNSIGNED NOT NULL DEFAULT 0,
+            status VARCHAR(32) NOT NULL DEFAULT 'pending',
+            error TEXT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            KEY idx_jobs_status_run_after (status, run_after),
+            KEY idx_jobs_created_at (created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+    ],
+    'down' => [
+        'DROP TABLE IF EXISTS jobs',
+        "CREATE TABLE jobs (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            queue VARCHAR(64) NOT NULL,
+            payload LONGTEXT NOT NULL,
+            attempts INT UNSIGNED NOT NULL DEFAULT 0,
+            available_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            reserved_at DATETIME NULL,
+            completed_at DATETIME NULL,
+            last_error TEXT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            KEY idx_jobs_queue_available (queue, available_at),
+            KEY idx_jobs_created_at (created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+    ],
+];

--- a/src/Queue/Handler/TailorCvJobHandler.php
+++ b/src/Queue/Handler/TailorCvJobHandler.php
@@ -1,0 +1,279 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queue\Handler;
+
+use App\AI\OpenAIProvider;
+use App\Prompts\PromptLibrary;
+use App\Queue\Job;
+use App\Queue\JobHandlerInterface;
+use App\Queue\TransientJobException;
+use DateTimeImmutable;
+use League\CommonMark\CommonMarkConverter;
+use PDO;
+use PDOException;
+use RuntimeException;
+use Throwable;
+
+use const JSON_THROW_ON_ERROR;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function implode;
+use function is_array;
+use function json_encode;
+use function sprintf;
+use function strip_tags;
+use function trim;
+
+final class TailorCvJobHandler implements JobHandlerInterface
+{
+    private CommonMarkConverter $markdownConverter;
+
+    public function __construct(private readonly PDO $pdo)
+    {
+        $this->markdownConverter = new CommonMarkConverter([
+            'html_input' => 'strip',
+            'allow_unsafe_links' => false,
+        ]);
+    }
+
+    public function handle(Job $job): void
+    {
+        $payload = $job->payload();
+        $generationId = $this->extractInt($payload, 'generation_id');
+        $userId = $this->extractInt($payload, 'user_id');
+        $jobDescription = $this->extractString($payload, 'job_description');
+        $cvMarkdown = $this->extractString($payload, 'cv_markdown');
+
+        $this->updateGenerationStatus($generationId, 'processing');
+
+        $provider = new OpenAIProvider($userId, null, $this->pdo);
+
+        $plan = $this->generatePlan($provider, $jobDescription, $cvMarkdown);
+        $constraints = $this->buildConstraints($payload, $cvMarkdown);
+        $draft = $this->generateDraft($provider, $plan, $constraints);
+        $converted = $this->convertDraft($draft);
+
+        $this->persistOutputs($generationId, $plan, $draft, $converted['html'], $converted['text']);
+        $this->updateGenerationStatus($generationId, 'completed');
+    }
+
+    public function onFailure(Job $job, string $error, bool $willRetry): void
+    {
+        $payload = $job->payload();
+        $generationId = isset($payload['generation_id']) ? (int) $payload['generation_id'] : null;
+
+        if ($generationId === null || $generationId <= 0) {
+            return;
+        }
+
+        if ($willRetry) {
+            $this->updateGenerationStatus($generationId, 'processing');
+
+            return;
+        }
+
+        $this->updateGenerationStatus($generationId, 'failed', $error);
+    }
+
+    private function generatePlan(OpenAIProvider $provider, string $jobDescription, string $cvMarkdown): string
+    {
+        try {
+            return $provider->plan($jobDescription, $cvMarkdown);
+        } catch (Throwable $exception) {
+            throw new TransientJobException('Failed to generate tailoring plan: ' . $exception->getMessage(), 0, $exception);
+        }
+    }
+
+    private function generateDraft(OpenAIProvider $provider, string $plan, string $constraints): string
+    {
+        try {
+            return $provider->draft($plan, $constraints);
+        } catch (Throwable $exception) {
+            throw new TransientJobException('Failed to generate tailored draft: ' . $exception->getMessage(), 0, $exception);
+        }
+    }
+
+    private function convertDraft(string $draft): array
+    {
+        try {
+            $html = $this->markdownConverter->convert($draft)->getContent();
+        } catch (Throwable $exception) {
+            throw new RuntimeException('Unable to convert draft markdown into HTML.', 0, $exception);
+        }
+
+        $text = trim(strip_tags($html));
+
+        return [
+            'html' => $html,
+            'text' => $text,
+        ];
+    }
+
+    private function persistOutputs(int $generationId, string $plan, string $draft, string $html, string $plainText): void
+    {
+        try {
+            $this->pdo->beginTransaction();
+
+            $delete = $this->pdo->prepare('DELETE FROM generation_outputs WHERE generation_id = :generation_id');
+            $delete->execute([':generation_id' => $generationId]);
+
+            $insert = $this->pdo->prepare(
+                'INSERT INTO generation_outputs (generation_id, mime_type, content, output_text) '
+                . 'VALUES (:generation_id, :mime_type, :content, :output_text)'
+            );
+
+            $insert->execute([
+                ':generation_id' => $generationId,
+                ':mime_type' => 'application/json',
+                ':content' => null,
+                ':output_text' => $plan,
+            ]);
+
+            $insert->execute([
+                ':generation_id' => $generationId,
+                ':mime_type' => 'text/markdown',
+                ':content' => null,
+                ':output_text' => $draft,
+            ]);
+
+            $insert->execute([
+                ':generation_id' => $generationId,
+                ':mime_type' => 'text/html',
+                ':content' => null,
+                ':output_text' => $html,
+            ]);
+
+            $insert->execute([
+                ':generation_id' => $generationId,
+                ':mime_type' => 'text/plain',
+                ':content' => null,
+                ':output_text' => $plainText,
+            ]);
+
+            $this->pdo->commit();
+        } catch (Throwable $exception) {
+            if ($this->pdo->inTransaction()) {
+                $this->pdo->rollBack();
+            }
+
+            throw new RuntimeException('Failed to persist generation outputs.', 0, $exception);
+        }
+    }
+
+    private function buildConstraints(array $payload, string $cvMarkdown): string
+    {
+        $template = PromptLibrary::tailorPrompt();
+        $jobTitle = $this->optionalString($payload, 'job_title');
+        $company = $this->optionalString($payload, 'company');
+        $competencies = $payload['competencies'] ?? [];
+
+        if (is_array($competencies)) {
+            $cleaned = array_map(
+                static fn($value): string => trim((string) $value),
+                $competencies
+            );
+            $cleaned = array_values(array_filter(
+                $cleaned,
+                static fn(string $value): bool => $value !== ''
+            ));
+            $competencyList = implode(', ', $cleaned);
+        } else {
+            $competencyList = trim((string) $competencies);
+        }
+
+        $cvSections = $this->optionalString($payload, 'cv_sections');
+        $cvSections = $cvSections !== '' ? $cvSections : $cvMarkdown;
+
+        return strtr($template, [
+            '{{title}}' => $jobTitle !== '' ? $jobTitle : 'Not specified',
+            '{{company}}' => $company !== '' ? $company : 'Not specified',
+            '{{competencies}}' => $competencyList !== '' ? $competencyList : 'Not specified',
+            '{{cv_sections}}' => $cvSections,
+        ]);
+    }
+
+    private function updateGenerationStatus(int $generationId, string $status, ?string $error = null): void
+    {
+        try {
+            $statement = $this->pdo->prepare(
+                'UPDATE generations SET status = :status, updated_at = :updated_at WHERE id = :id'
+            );
+
+            $statement->execute([
+                ':status' => $status,
+                ':updated_at' => (new DateTimeImmutable('now'))->format('Y-m-d H:i:s'),
+                ':id' => $generationId,
+            ]);
+
+            if ($error !== null && $status === 'failed') {
+                $this->recordFailure($generationId, $error);
+            }
+        } catch (PDOException $exception) {
+            throw new RuntimeException('Unable to update generation status.', 0, $exception);
+        }
+    }
+
+    private function recordFailure(int $generationId, string $error): void
+    {
+        try {
+            $statement = $this->pdo->prepare(
+                'INSERT INTO audit_logs (user_id, action, details) '
+                . 'SELECT user_id, :action, :details FROM generations WHERE id = :generation_id'
+            );
+
+            $statement->execute([
+                ':action' => 'generation_failed',
+                ':details' => json_encode([
+                    'generation_id' => $generationId,
+                    'error' => $error,
+                ], JSON_THROW_ON_ERROR),
+                ':generation_id' => $generationId,
+            ]);
+        } catch (Throwable) {
+            // Swallow logging errors to avoid masking the original failure.
+        }
+    }
+
+    private function extractInt(array $payload, string $key): int
+    {
+        if (!isset($payload[$key])) {
+            throw new RuntimeException(sprintf('Missing required payload key: %s', $key));
+        }
+
+        $value = (int) $payload[$key];
+
+        if ($value <= 0) {
+            throw new RuntimeException(sprintf('Payload key %s must be a positive integer.', $key));
+        }
+
+        return $value;
+    }
+
+    private function extractString(array $payload, string $key): string
+    {
+        if (!isset($payload[$key])) {
+            throw new RuntimeException(sprintf('Missing required payload key: %s', $key));
+        }
+
+        $value = trim((string) $payload[$key]);
+
+        if ($value === '') {
+            throw new RuntimeException(sprintf('Payload key %s cannot be empty.', $key));
+        }
+
+        return $value;
+    }
+
+    private function optionalString(array $payload, string $key): string
+    {
+        if (!isset($payload[$key])) {
+            return '';
+        }
+
+        return trim((string) $payload[$key]);
+    }
+}

--- a/src/Queue/Job.php
+++ b/src/Queue/Job.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queue;
+
+use DateTimeImmutable;
+use RuntimeException;
+
+final class Job
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $type,
+        private array $payload,
+        private int $attempts,
+        public string $status,
+        public DateTimeImmutable $runAfter,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function payload(): array
+    {
+        return $this->payload;
+    }
+
+    public function attempts(): int
+    {
+        return $this->attempts;
+    }
+
+    public function incrementAttempts(): void
+    {
+        $this->attempts++;
+    }
+
+    public function updateRunAfter(DateTimeImmutable $runAfter): void
+    {
+        $this->runAfter = $runAfter;
+    }
+
+    public function runAfter(): DateTimeImmutable
+    {
+        return $this->runAfter;
+    }
+
+    public function replacePayload(array $payload): void
+    {
+        if ($payload === []) {
+            throw new RuntimeException('Job payload cannot be empty.');
+        }
+
+        $this->payload = $payload;
+    }
+}

--- a/src/Queue/JobHandlerInterface.php
+++ b/src/Queue/JobHandlerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queue;
+
+interface JobHandlerInterface
+{
+    public function handle(Job $job): void;
+
+    public function onFailure(Job $job, string $error, bool $willRetry): void;
+}

--- a/src/Queue/JobRepository.php
+++ b/src/Queue/JobRepository.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queue;
+
+use DateInterval;
+use DateTimeImmutable;
+use PDO;
+use PDOException;
+use RuntimeException;
+use Throwable;
+
+use function json_decode;
+use function mb_substr;
+
+final class JobRepository
+{
+    private const MAX_ERROR_LENGTH = 1000;
+
+    public function __construct(private readonly PDO $pdo)
+    {
+    }
+
+    public function reserveNextPending(): ?Job
+    {
+        try {
+            $this->pdo->beginTransaction();
+
+            $statement = $this->pdo->prepare(
+                'SELECT id, type, payload_json, run_after, attempts, status, created_at '
+                . 'FROM jobs '
+                . 'WHERE status = :status AND run_after <= NOW() '
+                . 'ORDER BY run_after ASC, id ASC '
+                . 'LIMIT 1 FOR UPDATE SKIP LOCKED'
+            );
+
+            $statement->execute([':status' => 'pending']);
+            $row = $statement->fetch(PDO::FETCH_ASSOC);
+
+            if ($row === false) {
+                $this->pdo->commit();
+
+                return null;
+            }
+
+            $update = $this->pdo->prepare(
+                'UPDATE jobs SET status = :status, attempts = attempts + 1, error = NULL '
+                . 'WHERE id = :id'
+            );
+
+            $update->execute([
+                ':status' => 'running',
+                ':id' => $row['id'],
+            ]);
+
+            $this->pdo->commit();
+        } catch (Throwable $exception) {
+            if ($this->pdo->inTransaction()) {
+                $this->pdo->rollBack();
+            }
+
+            throw new RuntimeException('Failed to reserve job: ' . $exception->getMessage(), 0, $exception);
+        }
+
+        $payload = $this->decodePayload((string) $row['payload_json']);
+
+        $job = new Job(
+            (int) $row['id'],
+            (string) $row['type'],
+            $payload,
+            (int) $row['attempts'],
+            (string) $row['status'],
+            new DateTimeImmutable((string) $row['run_after'])
+        );
+
+        $job->incrementAttempts();
+        $job->status = 'running';
+
+        return $job;
+    }
+
+    public function markCompleted(Job $job): void
+    {
+        $this->updateJob($job->id, [
+            'status' => 'completed',
+            'error' => null,
+            'run_after' => (new DateTimeImmutable('now')),
+        ]);
+
+        $job->status = 'completed';
+    }
+
+    public function markFailed(Job $job, string $error): void
+    {
+        $this->updateJob($job->id, [
+            'status' => 'failed',
+            'error' => $this->truncateError($error),
+        ]);
+
+        $job->status = 'failed';
+    }
+
+    public function scheduleRetry(Job $job, int $delaySeconds, string $error): void
+    {
+        $runAfter = (new DateTimeImmutable('now'))->add(new DateInterval('PT' . max(1, $delaySeconds) . 'S'));
+
+        $this->updateJob($job->id, [
+            'status' => 'pending',
+            'error' => $this->truncateError($error),
+            'run_after' => $runAfter,
+        ]);
+
+        $job->status = 'pending';
+        $job->updateRunAfter($runAfter);
+    }
+
+    /**
+     * @param array{status?: string, error?: ?string, run_after?: DateTimeImmutable} $data
+     */
+    private function updateJob(int $id, array $data): void
+    {
+        $fields = [];
+        $parameters = [':id' => $id];
+
+        if (array_key_exists('status', $data)) {
+            $fields[] = 'status = :status';
+            $parameters[':status'] = $data['status'];
+        }
+
+        if (array_key_exists('error', $data)) {
+            $fields[] = 'error = :error';
+            $parameters[':error'] = $data['error'];
+        }
+
+        if (array_key_exists('run_after', $data)) {
+            $fields[] = 'run_after = :run_after';
+            $parameters[':run_after'] = $data['run_after'] instanceof DateTimeImmutable
+                ? $data['run_after']->format('Y-m-d H:i:s')
+                : $data['run_after'];
+        }
+
+        if ($fields === []) {
+            return;
+        }
+
+        $sql = 'UPDATE jobs SET ' . implode(', ', $fields) . ' WHERE id = :id';
+
+        try {
+            $statement = $this->pdo->prepare($sql);
+            $statement->execute($parameters);
+        } catch (PDOException $exception) {
+            throw new RuntimeException('Failed to update job record.', 0, $exception);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodePayload(string $payload): array
+    {
+        try {
+            /** @var array<string, mixed>|null $decoded */
+            $decoded = json_decode($payload, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable $exception) {
+            throw new RuntimeException('Job payload is not valid JSON.', 0, $exception);
+        }
+
+        if (!is_array($decoded)) {
+            throw new RuntimeException('Job payload must decode to an array.');
+        }
+
+        return $decoded;
+    }
+
+    private function truncateError(string $error): string
+    {
+        return mb_substr($error, 0, self::MAX_ERROR_LENGTH);
+    }
+}

--- a/src/Queue/JobWorker.php
+++ b/src/Queue/JobWorker.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queue;
+
+use Throwable;
+
+final class JobWorker
+{
+    private const BASE_BACKOFF_SECONDS = 5;
+    private const MAX_BACKOFF_SECONDS = 300;
+
+    /**
+     * @param array<string, JobHandlerInterface> $handlers
+     */
+    public function __construct(
+        private readonly JobRepository $repository,
+        private readonly array $handlers,
+        private readonly int $maxAttempts = 5
+    ) {
+    }
+
+    public function process(Job $job): void
+    {
+        $handler = $this->handlers[$job->type] ?? null;
+
+        if ($handler === null) {
+            $this->repository->markFailed($job, 'No handler registered for job type: ' . $job->type);
+
+            return;
+        }
+
+        try {
+            $handler->handle($job);
+            $this->repository->markCompleted($job);
+        } catch (TransientJobException $exception) {
+            $willRetry = $job->attempts() < $this->maxAttempts;
+            $handler->onFailure($job, $exception->getMessage(), $willRetry);
+
+            if ($willRetry) {
+                $delay = $this->calculateBackoffSeconds($job->attempts());
+                $this->repository->scheduleRetry($job, $delay, $exception->getMessage());
+            } else {
+                $this->repository->markFailed($job, $exception->getMessage());
+            }
+        } catch (Throwable $exception) {
+            $handler->onFailure($job, $exception->getMessage(), false);
+            $this->repository->markFailed($job, $exception->getMessage());
+        }
+    }
+
+    private function calculateBackoffSeconds(int $attempt): int
+    {
+        $attempt = max(1, $attempt);
+        $delay = self::BASE_BACKOFF_SECONDS * (2 ** ($attempt - 1));
+
+        return (int) min(self::MAX_BACKOFF_SECONDS, $delay);
+    }
+}

--- a/src/Queue/TransientJobException.php
+++ b/src/Queue/TransientJobException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queue;
+
+use RuntimeException;
+
+class TransientJobException extends RuntimeException
+{
+}


### PR DESCRIPTION
## Summary
- overhaul the jobs table to store JSON payloads with scheduling metadata
- add queue domain classes and a CLI worker that reserves jobs with skip locked, exponential backoff, and graceful shutdown
- implement the tailor_cv handler that calls the OpenAI provider, converts outputs, persists generation assets, and updates generation status

## Testing
- composer test
- php -l bin/worker.php
- php -l src/Queue/Handler/TailorCvJobHandler.php
- php -l src/Queue/JobWorker.php
- php -l src/Queue/JobRepository.php
- php -l src/Queue/Job.php
- php -l src/Queue/JobHandlerInterface.php
- php -l src/Queue/TransientJobException.php

------
https://chatgpt.com/codex/tasks/task_e_68d563b77068832e8533b5994ed87e5d