### PR TITLE
Add protected generation download endpoint

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 use App\Bootstrap;
 use App\Controllers\AuthController;
+use App\Controllers\GenerationDownloadController;
 use App\Controllers\HomeController;
+use App\Generations\GenerationDownloadService;
+use App\Generations\GenerationTokenService;
 use App\Infrastructure\Database\Connection;
 use App\Infrastructure\Database\Migrator;
 use App\Middleware\SessionMiddleware;
@@ -96,6 +99,33 @@ $container->set(HomeController::class, static function (Container $c): HomeContr
 
 $container->set(SessionMiddleware::class, static function (Container $c): SessionMiddleware {
     return new SessionMiddleware($c->get(AuthService::class));
+});
+
+$container->set(GenerationDownloadService::class, static function (Container $c): GenerationDownloadService {
+    return new GenerationDownloadService($c->get(\PDO::class));
+});
+
+$container->set(GenerationTokenService::class, static function (): GenerationTokenService {
+    $secret = getenv('DOWNLOAD_TOKEN_SECRET') ?: getenv('APP_KEY') ?: '';
+
+    if ($secret === '') {
+        throw new RuntimeException('DOWNLOAD_TOKEN_SECRET or APP_KEY must be configured.');
+    }
+
+    $ttl = (int) (getenv('DOWNLOAD_TOKEN_TTL') ?: 300);
+
+    if ($ttl <= 0) {
+        $ttl = 300;
+    }
+
+    return new GenerationTokenService($secret, $ttl);
+});
+
+$container->set(GenerationDownloadController::class, static function (Container $c): GenerationDownloadController {
+    return new GenerationDownloadController(
+        $c->get(GenerationDownloadService::class),
+        $c->get(GenerationTokenService::class)
+    );
 });
 
 AppFactory::setContainer($container);

--- a/src/Controllers/GenerationDownloadController.php
+++ b/src/Controllers/GenerationDownloadController.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controllers;
+
+use App\Generations\GenerationAccessDeniedException;
+use App\Generations\GenerationDownloadService;
+use App\Generations\GenerationNotFoundException;
+use App\Generations\GenerationOutputUnavailableException;
+use App\Generations\GenerationTokenService;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Slim\Psr7\Stream;
+
+use function fopen;
+use function fwrite;
+use function in_array;
+use function is_array;
+use function json_encode;
+use function sprintf;
+use function strlen;
+use function str_replace;
+use function time;
+use function strtolower;
+use function trim;
+use function rewind;
+
+final class GenerationDownloadController
+{
+    private const SUPPORTED_FORMATS = ['md', 'docx', 'pdf'];
+
+    public function __construct(
+        private readonly GenerationDownloadService $downloadService,
+        private readonly GenerationTokenService $tokenService
+    ) {
+    }
+
+    /**
+     * @param array<string, string> $args
+     */
+    public function download(ServerRequestInterface $request, ResponseInterface $response, array $args): ResponseInterface
+    {
+        $format = strtolower(trim((string) ($request->getQueryParams()['format'] ?? '')));
+
+        if ($format === '' || !in_array($format, self::SUPPORTED_FORMATS, true)) {
+            return $this->error($response, 400, 'Invalid or missing format parameter.');
+        }
+
+        $token = trim((string) ($request->getQueryParams()['token'] ?? ''));
+
+        if ($token === '') {
+            return $this->error($response, 401, 'Download token is required.');
+        }
+
+        $payload = $this->tokenService->validateToken($token);
+
+        if ($payload === null || $payload['format'] !== $format) {
+            return $this->error($response, 403, 'Invalid download token.');
+        }
+
+        $generationId = (int) ($args['id'] ?? 0);
+
+        if ($generationId <= 0 || $payload['generation_id'] !== $generationId) {
+            return $this->error($response, 403, 'Download token does not match the requested generation.');
+        }
+
+        $now = time();
+
+        if ($payload['expires_at'] < $now) {
+            return $this->error($response, 403, 'Download link has expired.');
+        }
+
+        $user = $request->getAttribute('user');
+
+        if (is_array($user) && isset($user['user_id']) && (int) $user['user_id'] !== $payload['user_id']) {
+            return $this->error($response, 403, 'Authenticated user does not match download token.');
+        }
+
+        try {
+            $download = $this->downloadService->fetch($generationId, $payload['user_id'], $format);
+        } catch (GenerationNotFoundException) {
+            return $this->error($response, 404, 'Generation not found.');
+        } catch (GenerationAccessDeniedException) {
+            return $this->error($response, 403, 'You do not have access to this generation.');
+        } catch (GenerationOutputUnavailableException $exception) {
+            return $this->error($response, 409, $exception->getMessage());
+        }
+
+        $resource = fopen('php://temp', 'wb+');
+
+        if ($resource === false) {
+            return $this->error($response, 500, 'Unable to prepare download stream.');
+        }
+
+        fwrite($resource, $download['content']);
+        rewind($resource);
+
+        $stream = new Stream($resource);
+
+        $disposition = sprintf('attachment; filename="%s"', $this->sanitizeFilename($download['filename']));
+
+        $response = $response->withBody($stream)
+            ->withHeader('Content-Type', $download['mime_type'])
+            ->withHeader('Content-Disposition', $disposition)
+            ->withHeader('Cache-Control', 'no-store');
+
+        $length = strlen($download['content']);
+        $response = $response->withHeader('Content-Length', (string) $length);
+
+        return $response;
+    }
+
+    private function sanitizeFilename(string $filename): string
+    {
+        return str_replace(['"', '\\', "\r", "\n"], '', $filename);
+    }
+
+    private function error(ResponseInterface $response, int $status, string $message): ResponseInterface
+    {
+        $payload = ['error' => $message];
+        $resource = fopen('php://temp', 'wb+');
+
+        if ($resource !== false) {
+            fwrite($resource, json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+            rewind($resource);
+            $stream = new Stream($resource);
+            $response = $response->withBody($stream);
+        }
+
+        return $response->withStatus($status)->withHeader('Content-Type', 'application/json; charset=utf-8');
+    }
+}

--- a/src/Generations/GenerationAccessDeniedException.php
+++ b/src/Generations/GenerationAccessDeniedException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Generations;
+
+use RuntimeException;
+
+final class GenerationAccessDeniedException extends RuntimeException
+{
+}

--- a/src/Generations/GenerationDownloadService.php
+++ b/src/Generations/GenerationDownloadService.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Generations;
+
+use PDO;
+use PDOException;
+use RuntimeException;
+
+use function is_resource;
+use function sprintf;
+use function stream_get_contents;
+use function trim;
+
+final class GenerationDownloadService
+{
+    private const FORMAT_DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+    private const FORMAT_PDF_MIME = 'application/pdf';
+
+    public function __construct(private readonly PDO $pdo)
+    {
+    }
+
+    /**
+     * @return array{filename: string, mime_type: string, content: string}
+     */
+    public function fetch(int $generationId, int $userId, string $format): array
+    {
+        $generation = $this->findGeneration($generationId);
+
+        if ($generation === null) {
+            throw new GenerationNotFoundException('Generation not found.');
+        }
+
+        if ((int) $generation['user_id'] !== $userId) {
+            throw new GenerationAccessDeniedException('You do not have access to this generation.');
+        }
+
+        return match ($format) {
+            'md' => $this->fetchMarkdown($generationId),
+            'docx' => $this->fetchBinary($generationId, 'docx', self::FORMAT_DOCX_MIME),
+            'pdf' => $this->fetchBinary($generationId, 'pdf', self::FORMAT_PDF_MIME),
+            default => throw new RuntimeException('Unsupported format requested.'),
+        };
+    }
+
+    /**
+     * @return array{filename: string, mime_type: string, content: string}
+     */
+    private function fetchMarkdown(int $generationId): array
+    {
+        $statement = $this->pdo->prepare(
+            'SELECT output_text FROM generation_outputs WHERE generation_id = :generation_id '
+            . 'AND output_text IS NOT NULL ORDER BY created_at DESC, id DESC LIMIT 1'
+        );
+        $statement->bindValue(':generation_id', $generationId, PDO::PARAM_INT);
+        $statement->execute();
+
+        $row = $statement->fetch();
+
+        if ($row === false) {
+            throw new GenerationOutputUnavailableException('Markdown output is not available for this generation.');
+        }
+
+        $markdown = trim((string) $row['output_text']);
+
+        if ($markdown === '') {
+            throw new GenerationOutputUnavailableException('Markdown output is empty for this generation.');
+        }
+
+        return [
+            'filename' => sprintf('generation-%d.md', $generationId),
+            'mime_type' => 'text/markdown; charset=utf-8',
+            'content' => $markdown,
+        ];
+    }
+
+    /**
+     * @return array{filename: string, mime_type: string, content: string}
+     */
+    private function fetchBinary(int $generationId, string $extension, string $expectedMime): array
+    {
+        $statement = $this->pdo->prepare(
+            'SELECT mime_type, content FROM generation_outputs WHERE generation_id = :generation_id '
+            . 'AND mime_type = :mime_type AND content IS NOT NULL ORDER BY created_at DESC, id DESC LIMIT 1'
+        );
+        $statement->bindValue(':generation_id', $generationId, PDO::PARAM_INT);
+        $statement->bindValue(':mime_type', $expectedMime);
+        $statement->execute();
+
+        $row = $statement->fetch();
+
+        if ($row === false) {
+            throw new GenerationOutputUnavailableException('Requested format is not available for this generation.');
+        }
+
+        $rawContent = $row['content'];
+
+        if (is_resource($rawContent)) {
+            $content = stream_get_contents($rawContent);
+        } else {
+            $content = (string) $rawContent;
+        }
+
+        if ($content === '' || $content === false) {
+            throw new GenerationOutputUnavailableException('Stored file content is empty.');
+        }
+
+        return [
+            'filename' => sprintf('generation-%d.%s', $generationId, $extension),
+            'mime_type' => $row['mime_type'] ?? $expectedMime,
+            'content' => (string) $content,
+        ];
+    }
+
+    /**
+     * @return array{id: int, user_id: int}|null
+     */
+    private function findGeneration(int $generationId): ?array
+    {
+        try {
+            $statement = $this->pdo->prepare('SELECT id, user_id FROM generations WHERE id = :id LIMIT 1');
+            $statement->bindValue(':id', $generationId, PDO::PARAM_INT);
+            $statement->execute();
+        } catch (PDOException $exception) {
+            throw new RuntimeException('Failed to query generation.', 0, $exception);
+        }
+
+        $row = $statement->fetch();
+
+        if ($row === false) {
+            return null;
+        }
+
+        return [
+            'id' => (int) $row['id'],
+            'user_id' => (int) $row['user_id'],
+        ];
+    }
+}

--- a/src/Generations/GenerationNotFoundException.php
+++ b/src/Generations/GenerationNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Generations;
+
+use RuntimeException;
+
+final class GenerationNotFoundException extends RuntimeException
+{
+}

--- a/src/Generations/GenerationOutputUnavailableException.php
+++ b/src/Generations/GenerationOutputUnavailableException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Generations;
+
+use RuntimeException;
+
+final class GenerationOutputUnavailableException extends RuntimeException
+{
+}

--- a/src/Generations/GenerationTokenService.php
+++ b/src/Generations/GenerationTokenService.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Generations;
+
+use DateInterval;
+use DateTimeImmutable;
+use RuntimeException;
+
+use function base64_decode;
+use function base64_encode;
+use function ctype_digit;
+use function explode;
+use function hash_equals;
+use function hash_hmac;
+use function implode;
+use function is_string;
+use function rtrim;
+use function sprintf;
+use function str_repeat;
+use function strtr;
+use function strlen;
+use function strtolower;
+use function trim;
+
+final class GenerationTokenService
+{
+    public function __construct(private readonly string $secret, private readonly int $ttlSeconds = 300)
+    {
+        if ($secret === '') {
+            throw new RuntimeException('Download token secret must be configured.');
+        }
+
+        if ($ttlSeconds <= 0) {
+            throw new RuntimeException('Token TTL must be positive.');
+        }
+    }
+
+    public function getTtl(): int
+    {
+        return $this->ttlSeconds;
+    }
+
+    public function createToken(int $userId, int $generationId, string $format, ?DateTimeImmutable $now = null): string
+    {
+        $now ??= new DateTimeImmutable();
+        $expiresAt = $now->add(new DateInterval(sprintf('PT%dS', $this->ttlSeconds)))->getTimestamp();
+
+        $normalizedFormat = strtolower(trim($format));
+
+        $data = implode(':', [
+            (string) $userId,
+            (string) $generationId,
+            $normalizedFormat,
+            (string) $expiresAt,
+        ]);
+
+        $signature = hash_hmac('sha256', $data, $this->secret, true);
+
+        return $this->encode($data) . '.' . $this->encode($signature);
+    }
+
+    /**
+     * @return array{user_id: int, generation_id: int, format: string, expires_at: int}|null
+     */
+    public function validateToken(string $token): ?array
+    {
+        $parts = explode('.', $token);
+
+        if (count($parts) !== 2) {
+            return null;
+        }
+
+        [$encodedData, $encodedSignature] = $parts;
+        $data = $this->decode($encodedData);
+        $signature = $this->decode($encodedSignature);
+
+        if ($data === null || $signature === null) {
+            return null;
+        }
+
+        $expectedSignature = hash_hmac('sha256', $data, $this->secret, true);
+
+        if (!hash_equals($expectedSignature, $signature)) {
+            return null;
+        }
+
+        $segments = explode(':', $data);
+
+        if (count($segments) !== 4) {
+            return null;
+        }
+
+        [$userId, $generationId, $format, $expiresAt] = $segments;
+
+        if (!ctype_digit($userId) || !ctype_digit($generationId) || !ctype_digit($expiresAt)) {
+            return null;
+        }
+
+        return [
+            'user_id' => (int) $userId,
+            'generation_id' => (int) $generationId,
+            'format' => strtolower(trim($format)),
+            'expires_at' => (int) $expiresAt,
+        ];
+    }
+
+    private function encode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+
+    private function decode(string $value): ?string
+    {
+        $remainder = strlen($value) % 4;
+
+        if ($remainder > 0) {
+            $value .= str_repeat('=', 4 - $remainder);
+        }
+
+        $decoded = base64_decode(strtr($value, '-_', '+/'), true);
+
+        return is_string($decoded) ? $decoded : null;
+    }
+}

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace App;
 
 use App\Controllers\AuthController;
+use App\Controllers\GenerationDownloadController;
 use App\Controllers\HomeController;
 
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\App;
 use Slim\Exception\HttpBadRequestException;
+use RuntimeException;
 
 class Routes
 {
@@ -90,6 +92,19 @@ class Routes
 
             return $response->withHeader('Content-Type', 'application/json');
 
+        });
+
+        $app->get('/generations/{id}/download', function (Request $request, Response $response, array $args) use ($app): Response {
+            $container = $app->getContainer();
+
+            if ($container === null) {
+                throw new RuntimeException('Application container is not available.');
+            }
+
+            /** @var GenerationDownloadController $controller */
+            $controller = $container->get(GenerationDownloadController::class);
+
+            return $controller->download($request, $response, $args);
         });
     }
 }


### PR DESCRIPTION
## Summary
- add services and controller to serve generation downloads via short-lived signed tokens
- register container bindings and route for the new download endpoint
- ensure generation content streaming validates ownership and requested format

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d563d46d74832ebcfa8a85160a5842