### PR TITLE
Harden security headers, CSRF enforcement, and auditing

### DIFF
--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -1,0 +1,300 @@
+:root {
+    color-scheme: dark;
+    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    line-height: 1.5;
+    background-color: #0f172a;
+    color: #f1f5f9;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: none;
+}
+
+button,
+input {
+    font: inherit;
+}
+
+button {
+    cursor: pointer;
+    border: none;
+    background: none;
+}
+
+.min-h-screen {
+    min-height: 100vh;
+}
+
+.bg-slate-900 {
+    background-color: #0f172a;
+}
+
+.bg-slate-800 {
+    background-color: #1e293b;
+}
+
+.bg-red-900\/40 {
+    background-color: rgba(127, 29, 29, 0.4);
+}
+
+.bg-emerald-900\/40 {
+    background-color: rgba(6, 95, 70, 0.4);
+}
+
+.bg-indigo-600 {
+    background-color: #4f46e5;
+}
+
+.hover\:bg-indigo-500:hover {
+    background-color: #6366f1;
+}
+
+.hover\:bg-slate-700:hover {
+    background-color: #334155;
+}
+
+.flex {
+    display: flex;
+}
+
+.flex-col {
+    flex-direction: column;
+}
+
+.items-center {
+    align-items: center;
+}
+
+.justify-center {
+    justify-content: center;
+}
+
+.p-6 {
+    padding: 1.5rem;
+}
+
+.p-8 {
+    padding: 2rem;
+}
+
+.w-full {
+    width: 100%;
+}
+
+.max-w-md {
+    max-width: 28rem;
+}
+
+.shadow-xl {
+    box-shadow: 0 25px 50px -20px rgba(15, 23, 42, 0.9);
+}
+
+.rounded-lg {
+    border-radius: 0.75rem;
+}
+
+.rounded-md {
+    border-radius: 0.375rem;
+}
+
+.text-center {
+    text-align: center;
+}
+
+.space-y-6 > :not([hidden]) ~ :not([hidden]) {
+    margin-top: 1.5rem;
+}
+
+.space-y-4 > :not([hidden]) ~ :not([hidden]) {
+    margin-top: 1rem;
+}
+
+.space-y-3 > :not([hidden]) ~ :not([hidden]) {
+    margin-top: 0.75rem;
+}
+
+.space-y-2 > :not([hidden]) ~ :not([hidden]) {
+    margin-top: 0.5rem;
+}
+
+.space-y-1 > :not([hidden]) ~ :not([hidden]) {
+    margin-top: 0.25rem;
+}
+
+.mt-1 {
+    margin-top: 0.25rem;
+}
+
+.text-3xl {
+    font-size: 1.875rem;
+    line-height: 2.25rem;
+}
+
+.text-xl {
+    font-size: 1.25rem;
+    line-height: 1.75rem;
+}
+
+.text-lg {
+    font-size: 1.125rem;
+    line-height: 1.75rem;
+}
+
+.text-sm {
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+}
+
+.font-bold {
+    font-weight: 700;
+}
+
+.font-semibold {
+    font-weight: 600;
+}
+
+.font-medium {
+    font-weight: 500;
+}
+
+.tracking-tight {
+    letter-spacing: -0.015em;
+}
+
+.tracking-widest {
+    letter-spacing: 0.2em;
+}
+
+.text-slate-100 {
+    color: #f1f5f9;
+}
+
+.text-slate-200 {
+    color: #e2e8f0;
+}
+
+.text-slate-300 {
+    color: #cbd5f5;
+}
+
+.text-slate-400 {
+    color: #94a3b8;
+}
+
+.text-red-200 {
+    color: #fecaca;
+}
+
+.text-emerald-200 {
+    color: #a7f3d0;
+}
+
+.hover\:text-indigo-300:hover {
+    color: #a5b4fc;
+}
+
+.bg-slate-900 input,
+.bg-slate-900 textarea,
+.bg-slate-900 select {
+    color: #f1f5f9;
+}
+
+.block {
+    display: block;
+}
+
+.border {
+    border-width: 1px;
+    border-style: solid;
+    border-color: #475569;
+}
+
+.border-slate-700 {
+    border-color: #334155;
+}
+
+.border-slate-600 {
+    border-color: #475569;
+}
+
+.border-red-500 {
+    border-color: #ef4444;
+}
+
+.border-emerald-500 {
+    border-color: #10b981;
+}
+
+.px-3 {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+}
+
+.py-2 {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+}
+
+.px-4 {
+    padding-left: 1rem;
+    padding-right: 1rem;
+}
+
+.py-3 {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+}
+
+.focus\:outline-none:focus {
+    outline: none;
+}
+
+.focus\:ring-2:focus {
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.35);
+}
+
+.focus\:ring-indigo-500:focus {
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.55);
+}
+
+.grid {
+    display: grid;
+}
+
+.grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.gap-3 {
+    gap: 0.75rem;
+}
+
+.text-slate-300 code {
+    font-family: "Fira Code", "Source Code Pro", monospace;
+}
+
+button.w-full,
+a.w-full,
+form button.w-full {
+    width: 100%;
+}
+
+button,
+a,
+input {
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}

--- a/public/index.php
+++ b/public/index.php
@@ -7,9 +7,14 @@ use App\Controllers\AuthController;
 use App\Controllers\HomeController;
 use App\Infrastructure\Database\Connection;
 use App\Infrastructure\Database\Migrator;
+use App\Middleware\CsrfMiddleware;
+use App\Middleware\InputValidationMiddleware;
+use App\Middleware\PathThrottleMiddleware;
+use App\Middleware\SecurityHeadersMiddleware;
 use App\Middleware\SessionMiddleware;
 use App\Routes;
 use App\Services\AuthService;
+use App\Services\AuditLogger;
 use App\Services\LogMailer;
 use App\Services\MailerInterface;
 use App\Services\RateLimiter;
@@ -69,12 +74,24 @@ $container->set(MailerInterface::class, static function () use ($rootPath): Mail
     return new LogMailer($logPath);
 });
 
+$container->set(AuditLogger::class, static function (Container $c): AuditLogger {
+    return new AuditLogger($c->get(\PDO::class));
+});
+
 $container->set('rateLimiter.request', static function (Container $c): RateLimiter {
-    return new RateLimiter($c->get(\PDO::class), 5, new \DateInterval('PT10M'));
+    return new RateLimiter($c->get(\PDO::class), $c->get(AuditLogger::class), 5, new \DateInterval('PT10M'));
 });
 
 $container->set('rateLimiter.verify', static function (Container $c): RateLimiter {
-    return new RateLimiter($c->get(\PDO::class), 10, new \DateInterval('PT10M'));
+    return new RateLimiter($c->get(\PDO::class), $c->get(AuditLogger::class), 10, new \DateInterval('PT10M'));
+});
+
+$container->set('rateLimiter.route.auth', static function (Container $c): RateLimiter {
+    return new RateLimiter($c->get(\PDO::class), $c->get(AuditLogger::class), 20, new \DateInterval('PT5M'));
+});
+
+$container->set('rateLimiter.route.upload', static function (Container $c): RateLimiter {
+    return new RateLimiter($c->get(\PDO::class), $c->get(AuditLogger::class), 10, new \DateInterval('PT10M'));
 });
 
 $container->set(AuthService::class, static function (Container $c): AuthService {
@@ -82,7 +99,8 @@ $container->set(AuthService::class, static function (Container $c): AuthService 
         $c->get(\PDO::class),
         $c->get(MailerInterface::class),
         $c->get('rateLimiter.request'),
-        $c->get('rateLimiter.verify')
+        $c->get('rateLimiter.verify'),
+        $c->get(AuditLogger::class)
     );
 });
 
@@ -104,10 +122,24 @@ $app = AppFactory::create();
 $migrator = new Migrator($container->get(\PDO::class));
 $migrator->migrate();
 
-Bootstrap::init($app, $rootPath);
+$appUrl = Bootstrap::init($app, $rootPath);
 
-$app->addBodyParsingMiddleware();
+$securityHeadersMiddleware = new SecurityHeadersMiddleware($appUrl);
+$csrfMiddleware = new CsrfMiddleware($app->getResponseFactory(), $container->get(AuditLogger::class));
+$inputValidationMiddleware = new InputValidationMiddleware($app->getResponseFactory(), $container->get(AuditLogger::class));
+$pathThrottleMiddleware = new PathThrottleMiddleware(
+    $container->get('rateLimiter.route.auth'),
+    $container->get('rateLimiter.route.upload'),
+    $app->getResponseFactory(),
+    $container->get(AuditLogger::class)
+);
+
 $app->addRoutingMiddleware();
+$app->add($securityHeadersMiddleware);
+$app->add($csrfMiddleware);
+$app->add($pathThrottleMiddleware);
+$app->add($inputValidationMiddleware);
+$app->addBodyParsingMiddleware();
 $app->add($container->get(SessionMiddleware::class));
 
 $displayErrorDetails = filter_var($_ENV['APP_DEBUG'] ?? false, FILTER_VALIDATE_BOOL);

--- a/resources/views/auth/backup-codes-request.php
+++ b/resources/views/auth/backup-codes-request.php
@@ -8,10 +8,11 @@
     <p class="text-slate-300 text-sm">Generate new backup codes to access your account if email is unavailable.</p>
     <?php if (!empty($error)) : ?>
         <div class="rounded-md bg-red-900/40 border border-red-500 px-3 py-2 text-sm text-red-200">
-            <?= htmlspecialchars($error, ENT_QUOTES) ?>
+            <?= htmlspecialchars($error, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
         </div>
     <?php endif; ?>
     <form method="post" action="/auth/backup-codes" class="space-y-4">
+        <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
         <button type="submit" class="w-full rounded-md bg-indigo-600 hover:bg-indigo-500 px-4 py-2 text-center font-semibold">Generate backup codes</button>
     </form>
     <a href="/" class="block w-full rounded-md border border-slate-600 hover:bg-slate-700 px-4 py-2 text-center font-semibold">Return to dashboard</a>

--- a/resources/views/auth/backup-codes.php
+++ b/resources/views/auth/backup-codes.php
@@ -11,7 +11,7 @@
     </div>
     <div class="grid grid-cols-2 gap-3">
         <?php foreach ($codes as $code): ?>
-            <div class="rounded-md bg-slate-900 border border-slate-700 px-3 py-2 text-center text-lg font-semibold tracking-widest"><?= htmlspecialchars($code, ENT_QUOTES) ?></div>
+            <div class="rounded-md bg-slate-900 border border-slate-700 px-3 py-2 text-center text-lg font-semibold tracking-widest"><?= htmlspecialchars($code, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></div>
         <?php endforeach; ?>
     </div>
     <a href="/" class="block w-full rounded-md bg-indigo-600 hover:bg-indigo-500 px-4 py-2 text-center font-semibold">Return to dashboard</a>

--- a/resources/views/auth/request.php
+++ b/resources/views/auth/request.php
@@ -9,27 +9,28 @@
 /** @var array $links */
 ?>
 <?php ob_start(); ?>
-<form method="post" action="<?= htmlspecialchars($actionUrl, ENT_QUOTES) ?>" class="space-y-4">
+<form method="post" action="<?= htmlspecialchars($actionUrl, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>" class="space-y-4">
+    <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
     <div>
         <label for="email" class="block text-sm font-medium text-slate-200">Email</label>
-        <input id="email" name="email" type="email" required value="<?= htmlspecialchars($email ?? '', ENT_QUOTES) ?>" class="mt-1 block w-full rounded-md bg-slate-900 border border-slate-700 px-3 py-2 text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+        <input id="email" name="email" type="email" maxlength="255" required value="<?= htmlspecialchars($email ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>" class="mt-1 block w-full rounded-md bg-slate-900 border border-slate-700 px-3 py-2 text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500">
     </div>
     <?php if (!empty($error)) : ?>
         <div class="rounded-md bg-red-900/40 border border-red-500 px-3 py-2 text-sm text-red-200">
-            <?= htmlspecialchars($error, ENT_QUOTES) ?>
+            <?= htmlspecialchars($error, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
         </div>
     <?php endif; ?>
     <?php if (!empty($status)) : ?>
         <div class="rounded-md bg-emerald-900/40 border border-emerald-500 px-3 py-2 text-sm text-emerald-200">
-            <?= htmlspecialchars($status, ENT_QUOTES) ?>
+            <?= htmlspecialchars($status, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
         </div>
     <?php endif; ?>
-    <button type="submit" class="w-full rounded-md bg-indigo-600 hover:bg-indigo-500 px-4 py-2 text-center font-semibold"><?= htmlspecialchars($buttonLabel, ENT_QUOTES) ?></button>
+    <button type="submit" class="w-full rounded-md bg-indigo-600 hover:bg-indigo-500 px-4 py-2 text-center font-semibold"><?= htmlspecialchars($buttonLabel, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></button>
 </form>
 <?php if (!empty($links)) : ?>
     <div class="text-center text-sm text-slate-400 space-y-1">
         <?php foreach ($links as $link): ?>
-            <p><a href="<?= htmlspecialchars($link['href'], ENT_QUOTES) ?>" class="hover:text-indigo-300"><?= htmlspecialchars($link['label'], ENT_QUOTES) ?></a></p>
+            <p><a href="<?= htmlspecialchars($link['href'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>" class="hover:text-indigo-300"><?= htmlspecialchars($link['label'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></a></p>
         <?php endforeach; ?>
     </div>
 <?php endif; ?>

--- a/resources/views/auth/verify.php
+++ b/resources/views/auth/verify.php
@@ -8,23 +8,24 @@
 /** @var string|null $email */
 ?>
 <?php ob_start(); ?>
-<form method="post" action="<?= htmlspecialchars($actionUrl, ENT_QUOTES) ?>" class="space-y-4">
-    <input type="hidden" name="email" value="<?= htmlspecialchars($email ?? '', ENT_QUOTES) ?>">
+<form method="post" action="<?= htmlspecialchars($actionUrl, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>" class="space-y-4">
+    <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
+    <input type="hidden" name="email" value="<?= htmlspecialchars($email ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
     <div>
         <label for="code" class="block text-sm font-medium text-slate-200">6-digit code</label>
         <input id="code" name="code" inputmode="numeric" minlength="6" maxlength="6" pattern="[0-9]{6}" required class="mt-1 block w-full rounded-md bg-slate-900 border border-slate-700 px-3 py-2 text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500">
     </div>
     <?php if (!empty($error)) : ?>
         <div class="rounded-md bg-red-900/40 border border-red-500 px-3 py-2 text-sm text-red-200">
-            <?= htmlspecialchars($error, ENT_QUOTES) ?>
+            <?= htmlspecialchars($error, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
         </div>
     <?php endif; ?>
     <?php if (!empty($status)) : ?>
         <div class="rounded-md bg-emerald-900/40 border border-emerald-500 px-3 py-2 text-sm text-emerald-200">
-            <?= htmlspecialchars($status, ENT_QUOTES) ?>
+            <?= htmlspecialchars($status, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
         </div>
     <?php endif; ?>
-    <button type="submit" class="w-full rounded-md bg-indigo-600 hover:bg-indigo-500 px-4 py-2 text-center font-semibold"><?= htmlspecialchars($buttonLabel, ENT_QUOTES) ?></button>
+    <button type="submit" class="w-full rounded-md bg-indigo-600 hover:bg-indigo-500 px-4 py-2 text-center font-semibold"><?= htmlspecialchars($buttonLabel, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></button>
 </form>
 <div class="text-center text-sm text-slate-400">
     <a href="/auth/login" class="hover:text-indigo-300">Request a new code</a>

--- a/resources/views/dashboard.php
+++ b/resources/views/dashboard.php
@@ -6,12 +6,13 @@
 <?php ob_start(); ?>
 <div class="space-y-6">
     <div class="space-y-2">
-        <h2 class="text-xl font-semibold">Welcome back, <?= htmlspecialchars($email, ENT_QUOTES) ?></h2>
+        <h2 class="text-xl font-semibold">Welcome back, <?= htmlspecialchars($email, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></h2>
         <p class="text-slate-300">You're signed in to job.smeird.com. Use the quick links below to manage your security.</p>
     </div>
     <div class="space-y-3">
         <a href="/auth/backup-codes" class="block w-full rounded-md bg-indigo-600 hover:bg-indigo-500 px-4 py-3 text-center font-semibold">Generate backup codes</a>
         <form method="post" action="/auth/logout">
+            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
             <button type="submit" class="w-full rounded-md border border-slate-600 hover:bg-slate-700 px-4 py-2 text-center font-semibold">Sign out</button>
         </form>
     </div>

--- a/resources/views/layout.php
+++ b/resources/views/layout.php
@@ -1,14 +1,16 @@
 <?php
 /** @var string $title */
 /** @var string $body */
+
+use App\Security\CspConfig;
 ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title><?= htmlspecialchars($title ?? 'job.smeird.com', ENT_QUOTES) ?></title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+    <title><?= htmlspecialchars($title ?? 'job.smeird.com', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></title>
+    <link rel="stylesheet" href="/assets/css/app.css">
 </head>
 <body class="min-h-screen bg-slate-900 text-slate-100">
 <div class="min-h-screen flex flex-col items-center justify-center p-6">
@@ -16,11 +18,12 @@
         <div class="text-center space-y-2">
             <h1 class="text-3xl font-bold tracking-tight">job.smeird.com</h1>
             <?php if (!empty($subtitle)) : ?>
-                <p class="text-slate-300"><?= htmlspecialchars($subtitle, ENT_QUOTES) ?></p>
+                <p class="text-slate-300"><?= htmlspecialchars($subtitle, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></p>
             <?php endif; ?>
         </div>
         <?= $body ?>
     </div>
 </div>
+<script><?= CspConfig::ALPINE_INIT_SCRIPT ?></script>
 </body>
 </html>

--- a/src/Middleware/CsrfMiddleware.php
+++ b/src/Middleware/CsrfMiddleware.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Middleware;
+
+use App\Services\AuditLogger;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class CsrfMiddleware implements MiddlewareInterface
+{
+    private const TOKEN_SESSION_KEY = 'csrf_token';
+
+    public function __construct(
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly AuditLogger $auditLogger
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $token = $this->ensureToken();
+        $request = $request->withAttribute(self::TOKEN_SESSION_KEY, $token);
+
+        if (!$this->requiresValidation($request->getMethod())) {
+            return $handler->handle($request);
+        }
+
+        $provided = $this->extractToken($request);
+
+        if (!is_string($provided) || !hash_equals($token, $provided)) {
+            $ip = $this->getClientIp($request);
+            $userAgent = $request->getHeaderLine('User-Agent') ?: null;
+
+            $this->auditLogger->log('security.csrf.blocked', [
+                'path' => $request->getUri()->getPath(),
+                'method' => $request->getMethod(),
+            ], null, null, $ip, $userAgent);
+
+            $response = $this->responseFactory->createResponse(403);
+            $response->getBody()->write('CSRF token mismatch.');
+
+            return $response->withHeader('Content-Type', 'text/plain; charset=utf-8');
+        }
+
+        return $handler->handle($request);
+    }
+
+    private function ensureToken(): string
+    {
+        $token = $_SESSION[self::TOKEN_SESSION_KEY] ?? null;
+
+        if (!is_string($token) || $token === '') {
+            $token = bin2hex(random_bytes(32));
+            $_SESSION[self::TOKEN_SESSION_KEY] = $token;
+        }
+
+        return $token;
+    }
+
+    private function requiresValidation(string $method): bool
+    {
+        return in_array(strtoupper($method), ['POST', 'PUT', 'PATCH', 'DELETE'], true);
+    }
+
+    private function extractToken(ServerRequestInterface $request): ?string
+    {
+        $parsed = $request->getParsedBody();
+
+        if (is_array($parsed) && isset($parsed['_token'])) {
+            return is_string($parsed['_token']) ? $parsed['_token'] : null;
+        }
+
+        $header = $request->getHeaderLine('X-CSRF-Token');
+
+        return $header !== '' ? $header : null;
+    }
+
+    private function getClientIp(ServerRequestInterface $request): ?string
+    {
+        $forwarded = $request->getHeaderLine('X-Forwarded-For');
+
+        if ($forwarded !== '') {
+            $parts = explode(',', $forwarded);
+            $candidate = trim($parts[0]);
+
+            if ($candidate !== '') {
+                return $candidate;
+            }
+        }
+
+        $serverParams = $request->getServerParams();
+
+        return isset($serverParams['REMOTE_ADDR']) ? (string) $serverParams['REMOTE_ADDR'] : null;
+    }
+}

--- a/src/Middleware/InputValidationMiddleware.php
+++ b/src/Middleware/InputValidationMiddleware.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Middleware;
+
+use App\Services\AuditLogger;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class InputValidationMiddleware implements MiddlewareInterface
+{
+    private const DEFAULT_MAX_BODY_BYTES = 1048576; // 1 MiB
+    private const DEFAULT_MAX_FIELD_LENGTH = 10000;
+
+    public function __construct(
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly AuditLogger $auditLogger,
+        private readonly int $maxBodyBytes = self::DEFAULT_MAX_BODY_BYTES,
+        private readonly int $maxFieldLength = self::DEFAULT_MAX_FIELD_LENGTH
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if (!$this->requiresValidation($request->getMethod())) {
+            return $handler->handle($request);
+        }
+
+        $contentLength = $this->parseContentLength($request);
+
+        if ($contentLength !== null && $contentLength > $this->maxBodyBytes) {
+            return $this->reject($request, 413, 'Request payload too large.');
+        }
+
+        $parsed = $request->getParsedBody();
+
+        if (is_array($parsed) && $this->containsOversizedField($parsed)) {
+            return $this->reject($request, 400, 'One or more fields exceed allowed length.');
+        }
+
+        return $handler->handle($request);
+    }
+
+    private function requiresValidation(string $method): bool
+    {
+        return in_array(strtoupper($method), ['POST', 'PUT', 'PATCH', 'DELETE'], true);
+    }
+
+    private function parseContentLength(ServerRequestInterface $request): ?int
+    {
+        $header = $request->getHeaderLine('Content-Length');
+
+        if ($header === '') {
+            return null;
+        }
+
+        $value = filter_var($header, FILTER_VALIDATE_INT);
+
+        return $value === false ? null : $value;
+    }
+
+    private function containsOversizedField(array $payload): bool
+    {
+        foreach ($payload as $value) {
+            if (is_array($value)) {
+                if ($this->containsOversizedField($value)) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            if (is_string($value) && mb_strlen($value) > $this->maxFieldLength) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function reject(ServerRequestInterface $request, int $status, string $message): ResponseInterface
+    {
+        $ip = $this->getClientIp($request);
+        $userAgent = $request->getHeaderLine('User-Agent') ?: null;
+
+        $this->auditLogger->log('security.input.rejected', [
+            'path' => $request->getUri()->getPath(),
+            'status' => $status,
+            'reason' => $message,
+        ], null, null, $ip, $userAgent);
+
+        $response = $this->responseFactory->createResponse($status);
+        $response->getBody()->write($message);
+
+        return $response->withHeader('Content-Type', 'text/plain; charset=utf-8');
+    }
+
+    private function getClientIp(ServerRequestInterface $request): ?string
+    {
+        $forwarded = $request->getHeaderLine('X-Forwarded-For');
+
+        if ($forwarded !== '') {
+            $parts = explode(',', $forwarded);
+            $candidate = trim($parts[0]);
+
+            if ($candidate !== '') {
+                return $candidate;
+            }
+        }
+
+        $serverParams = $request->getServerParams();
+
+        return isset($serverParams['REMOTE_ADDR']) ? (string) $serverParams['REMOTE_ADDR'] : null;
+    }
+}

--- a/src/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Middleware/SecurityHeadersMiddleware.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Middleware;
+
+use App\Security\CspConfig;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class SecurityHeadersMiddleware implements MiddlewareInterface
+{
+    public function __construct(private readonly string $appUrl)
+    {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $response = $handler->handle($request);
+
+        $csp = $this->buildContentSecurityPolicy();
+
+        $headers = [
+            'Content-Security-Policy' => $csp,
+            'Referrer-Policy' => 'strict-origin-when-cross-origin',
+            'Permissions-Policy' => 'camera=(), geolocation=(), microphone=()',
+            'X-Content-Type-Options' => 'nosniff',
+        ];
+
+        foreach ($headers as $name => $value) {
+            if (!$response->hasHeader($name)) {
+                $response = $response->withHeader($name, $value);
+            }
+        }
+
+        return $response;
+    }
+
+    private function buildContentSecurityPolicy(): string
+    {
+        $formActionOrigin = trim($this->appUrl);
+        $formActionDirective = "form-action 'self'";
+
+        if ($formActionOrigin !== '') {
+            $formActionDirective .= ' ' . rtrim($formActionOrigin, '/');
+        }
+
+        $directives = [
+            "default-src 'self'",
+            "base-uri 'self'",
+            "connect-src 'self'",
+            "font-src 'self'",
+            $formActionDirective,
+            "frame-ancestors 'none'",
+            "img-src 'self' data:",
+            "object-src 'none'",
+            "script-src 'self' " . CspConfig::alpineInitHash(),
+            "style-src 'self'",
+        ];
+
+        return implode('; ', $directives);
+    }
+}

--- a/src/Security/CspConfig.php
+++ b/src/Security/CspConfig.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+final class CspConfig
+{
+    public const ALPINE_INIT_SCRIPT = "document.addEventListener('alpine:init',function(){document.documentElement.dataset.alpineReady='true';});";
+
+    public static function alpineInitHash(): string
+    {
+        return 'sha256-' . base64_encode(hash('sha256', self::ALPINE_INIT_SCRIPT, true));
+    }
+}

--- a/src/Services/AuditLogger.php
+++ b/src/Services/AuditLogger.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use DateTimeImmutable;
+use JsonException;
+use PDO;
+
+class AuditLogger
+{
+    public function __construct(private readonly PDO $pdo)
+    {
+    }
+
+    public function log(
+        string $action,
+        array $details = [],
+        ?int $userId = null,
+        ?string $email = null,
+        ?string $ipAddress = null,
+        ?string $userAgent = null
+    ): void {
+        $statement = $this->pdo->prepare(
+            'INSERT INTO audit_logs (user_id, email, action, ip_address, user_agent, details, created_at) VALUES (:user_id, :email, :action, :ip_address, :user_agent, :details, :created_at)'
+        );
+
+        $detailsPayload = null;
+
+        if ($details !== []) {
+            try {
+                $detailsPayload = json_encode($details, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+            } catch (JsonException) {
+                $detailsPayload = null;
+            }
+        }
+
+        $statement->execute([
+            'user_id' => $userId,
+            'email' => $email,
+            'action' => $action,
+            'ip_address' => $ipAddress,
+            'user_agent' => $userAgent,
+            'details' => $detailsPayload,
+            'created_at' => (new DateTimeImmutable())->format('Y-m-d H:i:s'),
+        ]);
+    }
+}

--- a/src/Services/RateLimiter.php
+++ b/src/Services/RateLimiter.php
@@ -10,18 +10,22 @@ use PDO;
 
 class RateLimiter
 {
-    public function __construct(private readonly PDO $pdo, private readonly int $limit, private readonly DateInterval $interval)
-    {
+    public function __construct(
+        private readonly PDO $pdo,
+        private readonly AuditLogger $auditLogger,
+        private readonly int $limit,
+        private readonly DateInterval $interval
+    ) {
     }
 
-    public function tooManyAttempts(string $ipAddress, string $email, string $action): bool
+    public function tooManyAttempts(string $ipAddress, string $identifier, string $action): bool
     {
         $windowStart = (new DateTimeImmutable())->sub($this->interval)->format('Y-m-d H:i:s');
 
         $statement = $this->pdo->prepare('SELECT COUNT(*) FROM audit_logs WHERE ip_address = :ip AND email = :email AND action = :action AND created_at >= :start');
         $statement->execute([
             'ip' => $ipAddress,
-            'email' => $email,
+            'email' => $identifier,
             'action' => $action,
             'start' => $windowStart,
         ]);
@@ -31,14 +35,15 @@ class RateLimiter
         return $count >= $this->limit;
     }
 
-    public function hit(string $ipAddress, string $email, string $action): void
+    public function hit(string $ipAddress, string $identifier, string $action, ?string $userAgent = null, array $details = []): void
     {
-        $statement = $this->pdo->prepare('INSERT INTO audit_logs (ip_address, email, action, created_at) VALUES (:ip, :email, :action, :created_at)');
-        $statement->execute([
-            'ip' => $ipAddress,
-            'email' => $email,
-            'action' => $action,
-            'created_at' => (new DateTimeImmutable())->format('Y-m-d H:i:s'),
-        ]);
+        $this->auditLogger->log($action, $details, null, $identifier, $ipAddress, $userAgent);
+    }
+
+    public function getIntervalSeconds(): int
+    {
+        $reference = new DateTimeImmutable('@0');
+
+        return (int) $reference->add($this->interval)->format('U');
     }
 }

--- a/src/Views/Renderer.php
+++ b/src/Views/Renderer.php
@@ -21,6 +21,10 @@ class Renderer
             throw new RuntimeException(sprintf('Template "%s" not found.', $template));
         }
 
+        if (!array_key_exists('csrfToken', $data)) {
+            $data['csrfToken'] = $_SESSION['csrf_token'] ?? null;
+        }
+
         extract($data);
 
         ob_start();


### PR DESCRIPTION
## Summary
- add middleware for CSP/permissions headers, CSRF enforcement, input length validation, and /auth|/documents throttling
- introduce an audit logger with schema updates and wire auth flows to structured logging and throttled rate limiting
- embed CSRF tokens in rendered forms and serve local styles to satisfy the stricter CSP

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d564236348832ea7c407779a756cd6