### PR TITLE
Handle missing Composer autoloader gracefully

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+$autoloadPath = __DIR__ . '/vendor/autoload.php';
+
+if (!file_exists($autoloadPath)) {
+    $message = 'Application dependencies are missing. Please run "composer install" from the project root.';
+
+    if (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') {
+        fwrite(STDERR, $message . PHP_EOL);
+    } else {
+        if (!headers_sent()) {
+            http_response_code(500);
+            header('Content-Type: text/html; charset=utf-8');
+        }
+
+        echo '<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Application Error</title>';
+        echo '<style>body{font-family:system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;margin:2rem;color:#1f2937;background:#f9fafb;}';
+        echo '.card{max-width:32rem;margin:0 auto;background:#fff;padding:2.5rem 2rem;border-radius:1rem;box-shadow:0 10px 30px rgba(15,23,42,0.1);}';
+        echo 'h1{font-size:1.5rem;margin-bottom:1rem;color:#111827;}p{margin-bottom:0.75rem;line-height:1.6;}</style></head><body>';
+        echo '<div class="card"><h1>Application dependencies missing</h1>';
+        echo '<p>The application could not be started because the Composer autoloader was not found.</p>';
+        echo '<p>Please install the project dependencies by running <code>composer install</code> from the project root directory.</p>';
+        echo '<p>Once the dependencies have been installed the site will load normally.</p></div></body></html>';
+    }
+
+    exit(1);
+}
+
+return require $autoloadPath;

--- a/bin/migrate.php
+++ b/bin/migrate.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
 use App\DB;
 use Dotenv\Dotenv;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../autoload.php';
 
 $rootPath = dirname(__DIR__);
 

--- a/bin/purge.php
+++ b/bin/purge.php
@@ -7,7 +7,7 @@ use App\DB;
 use App\Services\RetentionPolicyService;
 use Dotenv\Dotenv;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../autoload.php';
 
 $rootPath = dirname(__DIR__);
 

--- a/bin/rollback.php
+++ b/bin/rollback.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
 use App\DB;
 use Dotenv\Dotenv;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../autoload.php';
 
 $rootPath = dirname(__DIR__);
 

--- a/bin/verify.php
+++ b/bin/verify.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../autoload.php';
 require __DIR__ . '/verify.helpers.php';
 
 use GuzzleHttp\Client;

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -8,7 +8,7 @@ use App\Queue\Handler\TailorCvJobHandler;
 use App\Queue\JobRepository;
 use App\Queue\JobWorker;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../autoload.php';
 
 if (!extension_loaded('pcntl')) {
     fwrite(STDERR, "The pcntl extension is required to run the worker." . PHP_EOL);

--- a/public/index.php
+++ b/public/index.php
@@ -30,7 +30,7 @@ use Slim\Middleware\ErrorMiddleware;
 use App\Controllers\GenerationController;
 use App\Generations\GenerationRepository;
 
-require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../autoload.php';
 
 $rootPath = dirname(__DIR__);
 


### PR DESCRIPTION
## Summary
- add a shared autoload bootstrap that surfaces a friendly error when the Composer autoloader is missing
- update the web and CLI entry points to require the new bootstrap instead of the vendor autoloader directly

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d57859a788832ebc2f1144918fd437