### PR TITLE
Fix PDOException catch syntax

### DIFF
--- a/src/Infrastructure/Database/Migrator.php
+++ b/src/Infrastructure/Database/Migrator.php
@@ -171,7 +171,7 @@ class Migrator
             }
 
             $this->pdo->exec(sprintf('ALTER TABLE %s %s', $table, $alterStatement));
-        } catch (PDOException) {
+        } catch (PDOException $exception) {
             // Ignore inability to inspect or alter the table; migration may be running on a database without SHOW COLUMNS support.
         }
     }
@@ -185,7 +185,7 @@ class Migrator
             if ($column !== false && isset($column['Null']) && $column['Null'] === 'NO') {
                 $this->pdo->exec('ALTER TABLE audit_logs MODIFY email VARCHAR(255) NULL');
             }
-        } catch (PDOException) {
+        } catch (PDOException $exception) {
             // Ignore if the column cannot be inspected.
         }
     }


### PR DESCRIPTION
## Summary
- assign variables to PDOException catch blocks to satisfy PHP's catch syntax requirements

## Testing
- composer check (fails: No lockfile found)

------
https://chatgpt.com/codex/tasks/task_e_68d57c5695fc832ebd69b50dc9878734