### PR TITLE
Fix AuditLogger catch syntax for PHP 7

### DIFF
--- a/src/Services/AuditLogger.php
+++ b/src/Services/AuditLogger.php
@@ -34,7 +34,7 @@ class AuditLogger
         if ($details !== []) {
             try {
                 $detailsPayload = json_encode($details, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
-            } catch (JsonException) {
+            } catch (JsonException $exception) {
                 $detailsPayload = null;
             }
         }


### PR DESCRIPTION
## Summary
- ensure AuditLogger catch block declares a variable for PHP 7 compatibility

## Testing
- php -l src/Services/AuditLogger.php

------
https://chatgpt.com/codex/tasks/task_e_68d5802c111c832eb988fb23629cdbb5