### PR TITLE
Fix HomeController constructor syntax for PHP 7

### DIFF
--- a/src/Controllers/HomeController.php
+++ b/src/Controllers/HomeController.php
@@ -19,7 +19,7 @@ class HomeController
     public function __construct(
         Renderer $renderer,
         DocumentRepository $documentRepository,
-        GenerationRepository $generationRepository,
+        GenerationRepository $generationRepository
     ) {
         $this->renderer = $renderer;
         $this->documentRepository = $documentRepository;


### PR DESCRIPTION
## Summary
- remove the trailing comma from HomeController's constructor parameter list to satisfy PHP 7's syntax rules

## Testing
- php -l src/Controllers/HomeController.php

------
https://chatgpt.com/codex/tasks/task_e_68d5863fcf58832e8067736e89e9e729