### PR TITLE
Add redirect for legacy /auth route

### DIFF
--- a/src/Routes.php
+++ b/src/Routes.php
@@ -31,6 +31,12 @@ class Routes
             return $container->get(HomeController::class)->index($request, $response);
         });
 
+        $app->get('/auth', function (Request $request, Response $response): Response {
+            return $response
+                ->withHeader('Location', '/auth/login')
+                ->withStatus(302);
+        });
+
         $app->get('/auth/register', function (Request $request, Response $response) use ($container) {
             return $container->get(AuthController::class)->showRegister($request, $response);
         });


### PR DESCRIPTION
## Summary
- add a handler for GET /auth that redirects visitors to /auth/login

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d64a1eb12c832ebe7c2ca3134610f6