### PR TITLE
Add otpauth provisioning support to QR passcodes

### DIFF
--- a/bin/smoke.php
+++ b/bin/smoke.php
@@ -445,6 +445,9 @@ final class SmokeSchema
             email TEXT NOT NULL,
             action TEXT NOT NULL,
             code_hash TEXT NOT NULL,
+            totp_secret TEXT NULL,
+            period_seconds INTEGER NOT NULL DEFAULT 600,
+            digits INTEGER NOT NULL DEFAULT 6,
             expires_at TEXT NOT NULL,
             created_at TEXT NOT NULL
         )');

--- a/resources/views/auth/qr.php
+++ b/resources/views/auth/qr.php
@@ -8,6 +8,8 @@ use DateTimeInterface;
 /** @var string $buttonLabel */
 /** @var string|null $email */
 /** @var string $code */
+/** @var string $totpSecret */
+/** @var string $qrValue */
 /** @var string $instructions */
 /** @var DateTimeInterface $expiresAt */
 /** @var string $resendUrl */
@@ -15,6 +17,7 @@ use DateTimeInterface;
 /** @var string|null $csrfToken */
 
 $groupedCode = trim(chunk_split($code, 3, ' '));
+$formattedSecret = trim(chunk_split(strtoupper($totpSecret), 4, ' '));
 ?>
 <?php
 $formId = 'form-' . preg_replace('/[^a-z0-9]+/', '-', strtolower(trim((string) $actionUrl, '/')));
@@ -40,7 +43,7 @@ $codeInputId = $formId . '-code';
             role="img"
             aria-live="polite"
             aria-label="QR code containing your one-time 6-digit passcode"
-            data-qr-code="<?= htmlspecialchars($code, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>"
+            data-qr-code="<?= htmlspecialchars($qrValue, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>"
         >
             <span class="text-xs font-medium text-slate-600">Loading QR…</span>
         </div>
@@ -50,12 +53,20 @@ $codeInputId = $formId . '-code';
         <p class="text-xs uppercase tracking-widest text-slate-500">
             Expires at <?= htmlspecialchars($expiresAt->format('H:i T'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
         </p>
-        <p class="text-sm text-slate-200">
-            Can't scan? Enter this code manually:
-            <span class="font-semibold tracking-widest text-indigo-300">
-                <?= htmlspecialchars($groupedCode, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
-            </span>
-        </p>
+        <div class="space-y-2">
+            <p class="text-sm text-slate-200">
+                Can't scan? Enter this 6-digit code before it expires:
+                <span class="font-semibold tracking-widest text-indigo-300">
+                    <?= htmlspecialchars($groupedCode, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
+                </span>
+            </p>
+            <p class="text-xs text-slate-400">
+                Adding it to an authenticator or password manager? Use this setup key:
+                <span class="font-mono tracking-widest text-indigo-200">
+                    <?= htmlspecialchars($formattedSecret, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
+                </span>
+            </p>
+        </div>
     </div>
     <form
         id="<?= htmlspecialchars($formId, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>"

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -61,6 +61,8 @@ class AuthController
                 'Create account',
                 $email,
                 $result['code'],
+                $result['secret'],
+                $result['uri'],
                 $result['expires_at'],
                 '/auth/register?email=' . urlencode($email),
                 'Need a different QR code? Start over.'
@@ -168,6 +170,8 @@ class AuthController
                 'Sign in',
                 $email,
                 $result['code'],
+                $result['secret'],
+                $result['uri'],
                 $result['expires_at'],
                 '/auth/login?email=' . urlencode($email),
                 'Need a new QR code? Request another one.'
@@ -315,6 +319,8 @@ class AuthController
         string $buttonLabel,
         string $email,
         string $code,
+        string $totpSecret,
+        string $qrValue,
         DateTimeInterface $expiresAt,
         string $resendUrl,
         string $resendLabel
@@ -331,6 +337,8 @@ class AuthController
             'buttonLabel' => $buttonLabel,
             'email' => $email,
             'code' => $code,
+            'totpSecret' => $totpSecret,
+            'qrValue' => $qrValue,
             'expiresAt' => $expiresAtUtc,
             'resendUrl' => $resendUrl,
             'resendLabel' => $resendLabel,


### PR DESCRIPTION
## Summary
- generate time-based passcode challenges that include otpauth provisioning URIs and secrets
- render QR codes with setup keys so authenticators and password managers can register the site
- expand pending_passcodes schema for TOTP metadata in both runtime migrations and the smoke harness

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d676b6b210832e9c46b1be7deb4bf6