### PR TITLE
Normalize passcode input before verification

### DIFF
--- a/src/Services/AuthService.php
+++ b/src/Services/AuthService.php
@@ -332,6 +332,8 @@ class AuthService
 
     private function assertPasscodeValid(string $email, string $action, string $code): void
     {
+        $code = $this->normalizeCode($code);
+
         $this->pdo->prepare('DELETE FROM pending_passcodes WHERE expires_at < :now')->execute([
             'now' => (new DateTimeImmutable())->format('Y-m-d H:i:s'),
         ]);
@@ -369,6 +371,17 @@ class AuthService
 
         $delete = $this->pdo->prepare('DELETE FROM pending_passcodes WHERE id = :id');
         $delete->execute(['id' => $row['id']]);
+    }
+
+    private function normalizeCode(string $code): string
+    {
+        $normalized = preg_replace('/\D+/', '', $code);
+
+        if ($normalized === null) {
+            return '';
+        }
+
+        return $normalized;
     }
 
     private function verifyTotpCode(string $secret, string $code, int $period, int $digits): bool


### PR DESCRIPTION
## Summary
- strip non-digit characters from submitted passcodes before validation
- ensure TOTP and hashed passcode checks run against the normalized value

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d67a85127c832e9e4abbc624bdd9cf