### PR TITLE
Fix GenerationController constructor syntax for PHP 7

### DIFF
--- a/src/Controllers/GenerationController.php
+++ b/src/Controllers/GenerationController.php
@@ -24,7 +24,7 @@ final class GenerationController
 
     public function __construct(
         GenerationRepository $generationRepository,
-        DocumentRepository $documentRepository,
+        DocumentRepository $documentRepository
     ) {
         $this->generationRepository = $generationRepository;
         $this->documentRepository = $documentRepository;


### PR DESCRIPTION
## Summary
- remove the trailing comma from GenerationController's constructor parameter list to satisfy PHP 7's parser

## Testing
- php -l src/Controllers/GenerationController.php

------
https://chatgpt.com/codex/tasks/task_e_68d67fac4954832ea59f2de9aa9be107