### PR TITLE
Fix CSRF token mismatch on logout

### DIFF
--- a/resources/views/dashboard.php
+++ b/resources/views/dashboard.php
@@ -38,6 +38,7 @@ $wizardJson = htmlspecialchars(
             </p>
         </div>
         <form method="post" action="/auth/logout" class="md:self-end">
+            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
             <button type="submit" class="inline-flex items-center justify-center rounded-lg border border-slate-700 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:bg-slate-800">
                 Sign out
             </button>


### PR DESCRIPTION
## Summary
- add the CSRF hidden field to the dashboard logout form so the middleware validates the request

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d680d16698832eb54180bb37452b83