### PR TITLE
Restore Tailwind styling on authenticated layout

### DIFF
--- a/resources/views/layout.php
+++ b/resources/views/layout.php
@@ -13,7 +13,59 @@ use App\Security\CspConfig;
     <title><?= htmlspecialchars($title ?? 'job.smeird.com', ENT_QUOTES) ?></title>
     <meta name="application-name" content="job.smeird.com">
     <meta name="apple-mobile-web-app-title" content="job.smeird.com">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+    <script>
+        window.tailwind = window.tailwind || {};
+        window.tailwind.config = {
+            darkMode: 'class',
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['"Inter"', 'system-ui', '-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'sans-serif'],
+                        display: ['"Cal Sans"', '"Inter"', 'system-ui', '-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'sans-serif'],
+                        mono: ['"JetBrains Mono"', 'monospace'],
+                    },
+                    borderRadius: {
+                        xl: '1.25rem',
+                        '2xl': '1.75rem',
+                        '3xl': '2.25rem',
+                    },
+                    boxShadow: {
+                        soft: '0 25px 65px -25px rgba(15, 23, 42, 0.45)',
+                        'soft-xl': '0 40px 120px -45px rgba(15, 23, 42, 0.55)',
+                        inset: 'inset 0 1px 0 rgba(255, 255, 255, 0.35)',
+                    },
+                    colors: {
+                        primary: {
+                            50: '#eef2ff',
+                            100: '#e0e7ff',
+                            200: '#c7d2fe',
+                            300: '#a5b4fc',
+                            400: '#818cf8',
+                            500: '#6366f1',
+                            600: '#4f46e5',
+                            700: '#4338ca',
+                            800: '#3730a3',
+                            900: '#312e81',
+                        },
+                        accent: {
+                            500: '#14b8a6',
+                            600: '#0d9488',
+                            700: '#0f766e',
+                        },
+                        surface: {
+                            light: 'rgba(255, 255, 255, 0.72)',
+                            dark: 'rgba(15, 23, 42, 0.72)',
+                        },
+                    },
+                    transitionDuration: {
+                        350: '350ms',
+                        450: '450ms',
+                    },
+                },
+            },
+        };
+    </script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
     <link rel="stylesheet" href="/assets/css/app.css">
     <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.13.5/dist/cdn.min.js" defer></script>
     <style>[x-cloak]{display:none!important;}</style>


### PR DESCRIPTION
## Summary
- switch the shared layout to initialise Tailwind using the official CDN script
- expose the theme extensions used across the dashboard so utility classes render correctly again

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6808a16e8832e950b0e0b62231eeb