### PR TITLE
Ensure PHP 7 compatibility

### DIFF
--- a/bin/smoke.php
+++ b/bin/smoke.php
@@ -25,7 +25,8 @@ namespace Dotenv {
 namespace Ramsey\Uuid {
     final class Uuid
     {
-        private string $value;
+        /** @var string */
+        private $value;
 
         private function __construct(string $value)
         {
@@ -47,7 +48,8 @@ namespace Ramsey\Uuid {
 namespace League\CommonMark {
     final class RenderedContent
     {
-        private string $content;
+        /** @var string */
+        private $content;
 
         public function __construct(string $content)
         {
@@ -326,10 +328,17 @@ final class SmokeStream implements StreamInterface
 
 final class SmokeUploadedFile implements UploadedFileInterface
 {
-    private SmokeStream $stream;
-    private ?string $clientFilename;
-    private ?string $clientMediaType;
-    private int $error;
+    /** @var SmokeStream */
+    private $stream;
+
+    /** @var string|null */
+    private $clientFilename;
+
+    /** @var string|null */
+    private $clientMediaType;
+
+    /** @var int */
+    private $error;
 
     public function __construct(SmokeStream $stream, ?string $clientFilename, ?string $clientMediaType, int $error = UPLOAD_ERR_OK)
     {
@@ -386,8 +395,11 @@ final class SmokeUploadedFile implements UploadedFileInterface
 
 final class SmokeEnvironment
 {
-    private string $databasePath;
-    private string $rootPath;
+    /** @var string */
+    private $databasePath;
+
+    /** @var string */
+    private $rootPath;
 
     public function __construct(string $rootPath)
     {
@@ -418,7 +430,8 @@ final class SmokeEnvironment
 
 final class SmokeSchema
 {
-    private GlobalPDO $pdo;
+    /** @var GlobalPDO */
+    private $pdo;
 
     public function __construct(GlobalPDO $pdo)
     {
@@ -555,9 +568,11 @@ final class SmokeSchema
 
 final class SmokeAuth
 {
-    private AuthService $service;
+    /** @var AuthService */
+    private $service;
 
-    private GlobalPDO $pdo;
+    /** @var GlobalPDO */
+    private $pdo;
 
     public function __construct(GlobalPDO $pdo)
     {
@@ -594,7 +609,8 @@ final class SmokeAuth
 
 final class SmokeDocuments
 {
-    private GlobalPDO $pdo;
+    /** @var GlobalPDO */
+    private $pdo;
 
     public function __construct(GlobalPDO $pdo)
     {
@@ -636,9 +652,11 @@ final class SmokeDocuments
 
 final class SmokeFakeOpenAIProvider
 {
-    private GlobalPDO $pdo;
+    /** @var GlobalPDO */
+    private $pdo;
 
-    private int $userId;
+    /** @var int */
+    private $userId;
 
     public function __construct(int $userId, ?object $client = null, ?GlobalPDO $pdo = null)
     {
@@ -696,7 +714,8 @@ MARKDOWN;
 
 final class SmokeGeneration
 {
-    private GlobalPDO $pdo;
+    /** @var GlobalPDO */
+    private $pdo;
 
     public function __construct(GlobalPDO $pdo)
     {
@@ -819,7 +838,8 @@ final class SmokeGeneration
 
 final class SmokePurge
 {
-    private GlobalPDO $pdo;
+    /** @var GlobalPDO */
+    private $pdo;
 
     public function __construct(GlobalPDO $pdo)
     {

--- a/bin/verify.helpers.php
+++ b/bin/verify.helpers.php
@@ -34,9 +34,13 @@ function verify_load_env(string $projectRoot): array
     ];
 }
 
-function verify_env(array $config, string $key, mixed $default = null): mixed
+/**
+ * @param mixed $default
+ * @return mixed
+ */
+function verify_env(array $config, string $key, $default = null)
 {
-    return $config[$key] ?? $default;
+    return array_key_exists($key, $config) ? $config[$key] : $default;
 }
 
 function verify_color(string $text, string $color): string
@@ -65,7 +69,10 @@ function verify_status_emoji(bool $pass, bool $critical = true): string
     return $critical ? '❌' : '⚠️';
 }
 
-function verify_pretty_json(mixed $data): string
+/**
+ * @param mixed $data
+ */
+function verify_pretty_json($data): string
 {
     if (is_string($data)) {
         $decoded = json_decode($data, true);

--- a/src/AI/OpenAIProvider.php
+++ b/src/AI/OpenAIProvider.php
@@ -33,21 +33,36 @@ final class OpenAIProvider
     private const ENDPOINT_CHAT_COMPLETIONS = '/chat/completions';
     private const MAX_ATTEMPTS = 5;
     private const INITIAL_BACKOFF_MS = 200;
-    private const MAX_BACKOFF_MS = 4_000;
+    private const MAX_BACKOFF_MS = 4000;
 
-    private ClientInterface $client;
-    private PDO $pdo;
-    private string $apiKey;
-    private string $baseUrl;
-    private string $modelPlan;
-    private string $modelDraft;
-    private int $maxTokens;
-    private int $userId;
+    /** @var ClientInterface */
+    private $client;
+
+    /** @var PDO */
+    private $pdo;
+
+    /** @var string */
+    private $apiKey;
+
+    /** @var string */
+    private $baseUrl;
+
+    /** @var string */
+    private $modelPlan;
+
+    /** @var string */
+    private $modelDraft;
+
+    /** @var int */
+    private $maxTokens;
+
+    /** @var int */
+    private $userId;
 
     /**
      * @var array<string, array{prompt: float, completion: float}>
      */
-    private array $tariffs;
+    private $tariffs;
 
     public function __construct(
         int $userId,

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -14,8 +14,11 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class AuthController
 {
-    private AuthService $authService;
-    private Renderer $renderer;
+    /** @var AuthService */
+    private $authService;
+
+    /** @var Renderer */
+    private $renderer;
 
     public function __construct(AuthService $authService, Renderer $renderer)
     {

--- a/src/Controllers/GenerationController.php
+++ b/src/Controllers/GenerationController.php
@@ -19,8 +19,11 @@ final class GenerationController
         ['value' => 'claude-3-5-sonnet', 'label' => 'Claude 3.5 Sonnet · Balanced reasoning'],
     ];
 
-    private GenerationRepository $generationRepository;
-    private DocumentRepository $documentRepository;
+    /** @var GenerationRepository */
+    private $generationRepository;
+
+    /** @var DocumentRepository */
+    private $documentRepository;
 
     public function __construct(
         GenerationRepository $generationRepository,

--- a/src/Controllers/GenerationDownloadController.php
+++ b/src/Controllers/GenerationDownloadController.php
@@ -30,8 +30,11 @@ final class GenerationDownloadController
 {
     private const SUPPORTED_FORMATS = ['md', 'docx', 'pdf'];
 
-    private GenerationDownloadService $downloadService;
-    private GenerationTokenService $tokenService;
+    /** @var GenerationDownloadService */
+    private $downloadService;
+
+    /** @var GenerationTokenService */
+    private $tokenService;
 
     public function __construct(
         GenerationDownloadService $downloadService,

--- a/src/Controllers/HomeController.php
+++ b/src/Controllers/HomeController.php
@@ -12,9 +12,14 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class HomeController
 {
-    private Renderer $renderer;
-    private DocumentRepository $documentRepository;
-    private GenerationRepository $generationRepository;
+    /** @var Renderer */
+    private $renderer;
+
+    /** @var DocumentRepository */
+    private $documentRepository;
+
+    /** @var GenerationRepository */
+    private $generationRepository;
 
     public function __construct(
         Renderer $renderer,
@@ -38,19 +43,23 @@ class HomeController
                 'subtitle' => 'Keep growing your career with confidence.',
                 'email' => $user['email'],
                 'jobDocuments' => array_map(
-                    static fn($document) => [
-                        'id' => $document->id(),
-                        'filename' => $document->filename(),
-                        'created_at' => $document->createdAt()->format('Y-m-d H:i'),
-                    ],
+                    static function ($document) {
+                        return [
+                            'id' => $document->id(),
+                            'filename' => $document->filename(),
+                            'created_at' => $document->createdAt()->format('Y-m-d H:i'),
+                        ];
+                    },
                     $this->documentRepository->listForUserAndType($userId, 'job_description')
                 ),
                 'cvDocuments' => array_map(
-                    static fn($document) => [
-                        'id' => $document->id(),
-                        'filename' => $document->filename(),
-                        'created_at' => $document->createdAt()->format('Y-m-d H:i'),
-                    ],
+                    static function ($document) {
+                        return [
+                            'id' => $document->id(),
+                            'filename' => $document->filename(),
+                            'created_at' => $document->createdAt()->format('Y-m-d H:i'),
+                        ];
+                    },
                     $this->documentRepository->listForUserAndType($userId, 'cv')
                 ),
                 'generations' => $this->generationRepository->listForUser($userId),

--- a/src/Controllers/RetentionController.php
+++ b/src/Controllers/RetentionController.php
@@ -13,8 +13,11 @@ use RuntimeException;
 
 class RetentionController
 {
-    private Renderer $renderer;
-    private RetentionPolicyService $retentionPolicyService;
+    /** @var Renderer */
+    private $renderer;
+
+    /** @var RetentionPolicyService */
+    private $retentionPolicyService;
 
     public function __construct(
         Renderer $renderer,

--- a/src/Controllers/UsageController.php
+++ b/src/Controllers/UsageController.php
@@ -12,8 +12,11 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class UsageController
 {
-    private UsageService $usageService;
-    private Renderer $renderer;
+    /** @var UsageService */
+    private $usageService;
+
+    /** @var Renderer */
+    private $renderer;
 
     public function __construct(UsageService $usageService, Renderer $renderer)
     {

--- a/src/Conversion/Converter.php
+++ b/src/Conversion/Converter.php
@@ -19,7 +19,8 @@ use Throwable;
 
 class Converter
 {
-    private ConverterInterface $markdownConverter;
+    /** @var ConverterInterface */
+    private $markdownConverter;
 
     public function __construct(?ConverterInterface $markdownConverter = null)
     {

--- a/src/Documents/Document.php
+++ b/src/Documents/Document.php
@@ -8,15 +8,32 @@ use DateTimeImmutable;
 
 class Document
 {
-    private ?int $id;
-    private int $userId;
-    private string $documentType;
-    private string $filename;
-    private string $mimeType;
-    private int $sizeBytes;
-    private string $sha256;
-    private string $content;
-    private DateTimeImmutable $createdAt;
+    /** @var int|null */
+    private $id;
+
+    /** @var int */
+    private $userId;
+
+    /** @var string */
+    private $documentType;
+
+    /** @var string */
+    private $filename;
+
+    /** @var string */
+    private $mimeType;
+
+    /** @var int */
+    private $sizeBytes;
+
+    /** @var string */
+    private $sha256;
+
+    /** @var string */
+    private $content;
+
+    /** @var DateTimeImmutable */
+    private $createdAt;
 
     public function __construct(
         ?int $id,
@@ -27,7 +44,7 @@ class Document
         int $sizeBytes,
         string $sha256,
         string $content,
-        DateTimeImmutable $createdAt,
+        DateTimeImmutable $createdAt
     ) {
         $this->id = $id;
         $this->userId = $userId;
@@ -56,7 +73,7 @@ class Document
             $this->sizeBytes,
             $this->sha256,
             $this->content,
-            $this->createdAt,
+            $this->createdAt
         );
     }
 

--- a/src/Documents/DocumentPreviewer.php
+++ b/src/Documents/DocumentPreviewer.php
@@ -9,7 +9,8 @@ use ZipArchive;
 
 class DocumentPreviewer
 {
-    private Parser $pdfParser;
+    /** @var Parser */
+    private $pdfParser;
 
     public function __construct(?Parser $parser = null)
     {

--- a/src/Documents/DocumentRepository.php
+++ b/src/Documents/DocumentRepository.php
@@ -9,7 +9,8 @@ use PDO;
 
 class DocumentRepository
 {
-    private PDO $pdo;
+    /** @var PDO */
+    private $pdo;
 
     public function __construct(PDO $pdo)
     {

--- a/src/Documents/DocumentService.php
+++ b/src/Documents/DocumentService.php
@@ -10,8 +10,11 @@ use RuntimeException;
 
 class DocumentService
 {
-    private DocumentRepository $repository;
-    private DocumentValidator $validator;
+    /** @var DocumentRepository */
+    private $repository;
+
+    /** @var DocumentValidator */
+    private $validator;
 
     public function __construct(
         DocumentRepository $repository,

--- a/src/Documents/DocumentValidationException.php
+++ b/src/Documents/DocumentValidationException.php
@@ -8,7 +8,8 @@ use RuntimeException;
 
 class DocumentValidationException extends RuntimeException
 {
-    private int $statusCode;
+    /** @var int */
+    private $statusCode;
 
     public function __construct(string $message, int $statusCode = 400)
     {

--- a/src/Extraction/Extractor.php
+++ b/src/Extraction/Extractor.php
@@ -16,8 +16,11 @@ use Throwable;
 class Extractor
 {
     /** @var ReaderInterface[] */
-    private array $readers = [];
-    private PDO $connection;
+    /** @var array */
+    private $readers = [];
+
+    /** @var PDO */
+    private $connection;
 
     public function __construct(PDO $connection, iterable $readers = [])
     {
@@ -268,7 +271,8 @@ final class PdfReader implements ReaderInterface
 final class TextReader implements ReaderInterface
 {
     /** @var string[] */
-    private array $extensions;
+    /** @var array */
+    private $extensions;
 
     /**
      * @param string[] $extensions

--- a/src/Generations/Generation.php
+++ b/src/Generations/Generation.php
@@ -8,14 +8,29 @@ use DateTimeImmutable;
 
 final class Generation
 {
-    private int $id;
-    private int $userId;
-    private int $jobDocumentId;
-    private int $cvDocumentId;
-    private string $model;
-    private float $temperature;
-    private string $status;
-    private DateTimeImmutable $createdAt;
+    /** @var int */
+    private $id;
+
+    /** @var int */
+    private $userId;
+
+    /** @var int */
+    private $jobDocumentId;
+
+    /** @var int */
+    private $cvDocumentId;
+
+    /** @var string */
+    private $model;
+
+    /** @var float */
+    private $temperature;
+
+    /** @var string */
+    private $status;
+
+    /** @var DateTimeImmutable */
+    private $createdAt;
 
     public function __construct(
         int $id,
@@ -25,7 +40,7 @@ final class Generation
         string $model,
         float $temperature,
         string $status,
-        DateTimeImmutable $createdAt,
+        DateTimeImmutable $createdAt
     ) {
         $this->id = $id;
         $this->userId = $userId;

--- a/src/Generations/GenerationDownloadService.php
+++ b/src/Generations/GenerationDownloadService.php
@@ -18,7 +18,8 @@ final class GenerationDownloadService
     private const FORMAT_DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
     private const FORMAT_PDF_MIME = 'application/pdf';
 
-    private PDO $pdo;
+    /** @var PDO */
+    private $pdo;
 
     public function __construct(PDO $pdo)
     {

--- a/src/Generations/GenerationRepository.php
+++ b/src/Generations/GenerationRepository.php
@@ -9,7 +9,8 @@ use PDO;
 
 final class GenerationRepository
 {
-    private PDO $pdo;
+    /** @var PDO */
+    private $pdo;
 
     public function __construct(PDO $pdo)
     {

--- a/src/Generations/GenerationStreamPoller.php
+++ b/src/Generations/GenerationStreamPoller.php
@@ -10,21 +10,50 @@ class GenerationStreamPoller
 {
     private const TERMINAL_STATUSES = ['completed', 'succeeded', 'success', 'failed', 'cancelled', 'canceled'];
 
-    private GenerationStreamRepository $repository;
-    private int $generationId;
-    private int $pollIntervalSeconds;
-    private int $heartbeatIntervalSeconds;
-    private int $timeoutSeconds;
-    private ?string $lastStatus = null;
-    private ?int $lastProgress = null;
-    private ?int $lastTokens = null;
-    private ?int $lastCost = null;
-    private ?string $lastError = null;
-    private bool $initialised = false;
-    private bool $terminated = false;
-    private float $lastHeartbeat;
-    private float $startedAt;
-    private ?GenerationStreamSnapshot $primedSnapshot;
+    /** @var GenerationStreamRepository */
+    private $repository;
+
+    /** @var int */
+    private $generationId;
+
+    /** @var int */
+    private $pollIntervalSeconds;
+
+    /** @var int */
+    private $heartbeatIntervalSeconds;
+
+    /** @var int */
+    private $timeoutSeconds;
+
+    /** @var string|null */
+    private $lastStatus = null;
+
+    /** @var int|null */
+    private $lastProgress = null;
+
+    /** @var int|null */
+    private $lastTokens = null;
+
+    /** @var int|null */
+    private $lastCost = null;
+
+    /** @var string|null */
+    private $lastError = null;
+
+    /** @var bool */
+    private $initialised = false;
+
+    /** @var bool */
+    private $terminated = false;
+
+    /** @var float */
+    private $lastHeartbeat;
+
+    /** @var float */
+    private $startedAt;
+
+    /** @var GenerationStreamSnapshot|null */
+    private $primedSnapshot;
 
     public function __construct(
         GenerationStreamRepository $repository,
@@ -32,7 +61,7 @@ class GenerationStreamPoller
         int $pollIntervalSeconds = 1,
         int $heartbeatIntervalSeconds = 15,
         int $timeoutSeconds = 300,
-        ?GenerationStreamSnapshot $initialSnapshot = null,
+        ?GenerationStreamSnapshot $initialSnapshot = null
     ) {
         $this->repository = $repository;
         $this->generationId = $generationId;
@@ -90,7 +119,7 @@ class GenerationStreamPoller
                 return $this->formatEvent('error', ['message' => 'Stream timeout.']);
             }
 
-            usleep($this->pollIntervalSeconds * 1_000_000);
+            usleep($this->pollIntervalSeconds * 1000000);
         }
     }
 

--- a/src/Generations/GenerationStreamRepository.php
+++ b/src/Generations/GenerationStreamRepository.php
@@ -10,7 +10,8 @@ use PDO;
 
 class GenerationStreamRepository
 {
-    private PDO $connection;
+    /** @var PDO */
+    private $connection;
 
     public function __construct(?PDO $connection = null)
     {

--- a/src/Generations/GenerationStreamSnapshot.php
+++ b/src/Generations/GenerationStreamSnapshot.php
@@ -8,14 +8,29 @@ use DateTimeImmutable;
 
 class GenerationStreamSnapshot
 {
-    public int $id;
-    public string $status;
-    public int $progressPercent;
-    public int $costPence;
-    public int $totalTokens;
-    public ?string $errorMessage;
-    public DateTimeImmutable $updatedAt;
-    public ?DateTimeImmutable $latestOutputAt;
+    /** @var int */
+    public $id;
+
+    /** @var string */
+    public $status;
+
+    /** @var int */
+    public $progressPercent;
+
+    /** @var int */
+    public $costPence;
+
+    /** @var int */
+    public $totalTokens;
+
+    /** @var string|null */
+    public $errorMessage;
+
+    /** @var DateTimeImmutable */
+    public $updatedAt;
+
+    /** @var DateTimeImmutable|null */
+    public $latestOutputAt;
 
     public function __construct(
         int $id,
@@ -25,7 +40,7 @@ class GenerationStreamSnapshot
         int $totalTokens,
         ?string $errorMessage,
         DateTimeImmutable $updatedAt,
-        ?DateTimeImmutable $latestOutputAt,
+        ?DateTimeImmutable $latestOutputAt
     ) {
         $this->id = $id;
         $this->status = $status;

--- a/src/Generations/GenerationTokenService.php
+++ b/src/Generations/GenerationTokenService.php
@@ -26,8 +26,11 @@ use function trim;
 
 final class GenerationTokenService
 {
-    private string $secret;
-    private int $ttlSeconds;
+    /** @var string */
+    private $secret;
+
+    /** @var int */
+    private $ttlSeconds;
 
     public function __construct(string $secret, int $ttlSeconds = 300)
     {
@@ -50,7 +53,9 @@ final class GenerationTokenService
 
     public function createToken(int $userId, int $generationId, string $format, ?DateTimeImmutable $now = null): string
     {
-        $now ??= new DateTimeImmutable();
+        if ($now === null) {
+            $now = new DateTimeImmutable();
+        }
         $expiresAt = $now->add(new DateInterval(sprintf('PT%dS', $this->ttlSeconds)))->getTimestamp();
 
         $normalizedFormat = strtolower(trim($format));

--- a/src/Infrastructure/Database/Connection.php
+++ b/src/Infrastructure/Database/Connection.php
@@ -10,7 +10,8 @@ use RuntimeException;
 
 class Connection
 {
-    private PDO $pdo;
+    /** @var PDO */
+    private $pdo;
 
     public function __construct()
     {

--- a/src/Infrastructure/Database/Migrator.php
+++ b/src/Infrastructure/Database/Migrator.php
@@ -9,7 +9,8 @@ use PDOException;
 
 class Migrator
 {
-    private PDO $pdo;
+    /** @var PDO */
+    private $pdo;
 
     public function __construct(PDO $pdo)
     {

--- a/src/Middleware/CsrfMiddleware.php
+++ b/src/Middleware/CsrfMiddleware.php
@@ -15,8 +15,11 @@ final class CsrfMiddleware implements MiddlewareInterface
 {
     private const TOKEN_SESSION_KEY = 'csrf_token';
 
-    private ResponseFactoryInterface $responseFactory;
-    private AuditLogger $auditLogger;
+    /** @var ResponseFactoryInterface */
+    private $responseFactory;
+
+    /** @var AuditLogger */
+    private $auditLogger;
 
     public function __construct(
         ResponseFactoryInterface $responseFactory,

--- a/src/Middleware/InputValidationMiddleware.php
+++ b/src/Middleware/InputValidationMiddleware.php
@@ -16,10 +16,17 @@ final class InputValidationMiddleware implements MiddlewareInterface
     private const DEFAULT_MAX_BODY_BYTES = 1048576; // 1 MiB
     private const DEFAULT_MAX_FIELD_LENGTH = 10000;
 
-    private ResponseFactoryInterface $responseFactory;
-    private AuditLogger $auditLogger;
-    private int $maxBodyBytes;
-    private int $maxFieldLength;
+    /** @var ResponseFactoryInterface */
+    private $responseFactory;
+
+    /** @var AuditLogger */
+    private $auditLogger;
+
+    /** @var int */
+    private $maxBodyBytes;
+
+    /** @var int */
+    private $maxFieldLength;
 
     public function __construct(
         ResponseFactoryInterface $responseFactory,

--- a/src/Middleware/PathThrottleMiddleware.php
+++ b/src/Middleware/PathThrottleMiddleware.php
@@ -14,10 +14,17 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 final class PathThrottleMiddleware implements MiddlewareInterface
 {
-    private RateLimiter $authLimiter;
-    private RateLimiter $uploadLimiter;
-    private ResponseFactoryInterface $responseFactory;
-    private AuditLogger $auditLogger;
+    /** @var RateLimiter */
+    private $authLimiter;
+
+    /** @var RateLimiter */
+    private $uploadLimiter;
+
+    /** @var ResponseFactoryInterface */
+    private $responseFactory;
+
+    /** @var AuditLogger */
+    private $auditLogger;
 
     public function __construct(
         RateLimiter $authLimiter,

--- a/src/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Middleware/SecurityHeadersMiddleware.php
@@ -12,7 +12,8 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 final class SecurityHeadersMiddleware implements MiddlewareInterface
 {
-    private string $appUrl;
+    /** @var string */
+    private $appUrl;
 
     public function __construct(string $appUrl)
     {

--- a/src/Middleware/SessionMiddleware.php
+++ b/src/Middleware/SessionMiddleware.php
@@ -12,7 +12,8 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class SessionMiddleware implements MiddlewareInterface
 {
-    private AuthService $authService;
+    /** @var AuthService */
+    private $authService;
 
     public function __construct(AuthService $authService)
     {

--- a/src/Queue/Handler/TailorCvJobHandler.php
+++ b/src/Queue/Handler/TailorCvJobHandler.php
@@ -30,8 +30,11 @@ use function trim;
 
 final class TailorCvJobHandler implements JobHandlerInterface
 {
-    private CommonMarkConverter $markdownConverter;
-    private PDO $pdo;
+    /** @var CommonMarkConverter */
+    private $markdownConverter;
+
+    /** @var PDO */
+    private $pdo;
 
     public function __construct(PDO $pdo)
     {
@@ -183,12 +186,16 @@ final class TailorCvJobHandler implements JobHandlerInterface
 
         if (is_array($competencies)) {
             $cleaned = array_map(
-                static fn($value): string => trim((string) $value),
+                static function ($value): string {
+                    return trim((string) $value);
+                },
                 $competencies
             );
             $cleaned = array_values(array_filter(
                 $cleaned,
-                static fn(string $value): bool => $value !== ''
+                static function (string $value): bool {
+                    return $value !== '';
+                }
             ));
             $competencyList = implode(', ', $cleaned);
         } else {

--- a/src/Queue/Job.php
+++ b/src/Queue/Job.php
@@ -9,12 +9,23 @@ use RuntimeException;
 
 final class Job
 {
-    public int $id;
-    public string $type;
-    private array $payload;
-    private int $attempts;
-    public string $status;
-    public DateTimeImmutable $runAfter;
+    /** @var int */
+    public $id;
+
+    /** @var string */
+    public $type;
+
+    /** @var array */
+    private $payload;
+
+    /** @var int */
+    private $attempts;
+
+    /** @var string */
+    public $status;
+
+    /** @var DateTimeImmutable */
+    public $runAfter;
 
     public function __construct(
         int $id,

--- a/src/Queue/JobRepository.php
+++ b/src/Queue/JobRepository.php
@@ -18,7 +18,8 @@ final class JobRepository
 {
     private const MAX_ERROR_LENGTH = 1000;
 
-    private PDO $pdo;
+    /** @var PDO */
+    private $pdo;
 
     public function __construct(PDO $pdo)
     {

--- a/src/Queue/JobWorker.php
+++ b/src/Queue/JobWorker.php
@@ -11,17 +11,16 @@ final class JobWorker
     private const BASE_BACKOFF_SECONDS = 5;
     private const MAX_BACKOFF_SECONDS = 300;
 
-    /**
-     * @param array<string, JobHandlerInterface> $handlers
-     */
-    private JobRepository $repository;
+    /** @var JobRepository */
+    private $repository;
 
     /**
      * @var array<string, JobHandlerInterface>
      */
-    private array $handlers;
+    private $handlers;
 
-    private int $maxAttempts;
+    /** @var int */
+    private $maxAttempts;
 
     /**
      * @param array<string, JobHandlerInterface> $handlers

--- a/src/Services/AuditLogger.php
+++ b/src/Services/AuditLogger.php
@@ -10,7 +10,8 @@ use PDO;
 
 class AuditLogger
 {
-    private PDO $pdo;
+    /** @var PDO */
+    private $pdo;
 
     public function __construct(PDO $pdo)
     {

--- a/src/Services/AuthService.php
+++ b/src/Services/AuthService.php
@@ -22,10 +22,17 @@ class AuthService
     private const OTP_ALGORITHM = 'sha1';
     private const OTP_ISSUER = 'job.smeird.com';
 
-    private PDO $pdo;
-    private RateLimiter $requestLimiter;
-    private RateLimiter $verifyLimiter;
-    private AuditLogger $auditLogger;
+    /** @var PDO */
+    private $pdo;
+
+    /** @var RateLimiter */
+    private $requestLimiter;
+
+    /** @var RateLimiter */
+    private $verifyLimiter;
+
+    /** @var AuditLogger */
+    private $auditLogger;
 
     public function __construct(
         PDO $pdo,

--- a/src/Services/LogMailer.php
+++ b/src/Services/LogMailer.php
@@ -6,7 +6,8 @@ namespace App\Services;
 
 class LogMailer implements MailerInterface
 {
-    private string $logPath;
+    /** @var string */
+    private $logPath;
 
     public function __construct(string $logPath)
     {

--- a/src/Services/RateLimiter.php
+++ b/src/Services/RateLimiter.php
@@ -10,10 +10,17 @@ use PDO;
 
 class RateLimiter
 {
-    private PDO $pdo;
-    private AuditLogger $auditLogger;
-    private int $limit;
-    private DateInterval $interval;
+    /** @var PDO */
+    private $pdo;
+
+    /** @var AuditLogger */
+    private $auditLogger;
+
+    /** @var int */
+    private $limit;
+
+    /** @var DateInterval */
+    private $interval;
 
     public function __construct(
         PDO $pdo,

--- a/src/Services/RetentionPolicyService.php
+++ b/src/Services/RetentionPolicyService.php
@@ -14,7 +14,8 @@ class RetentionPolicyService
 {
     private const TABLE_NAME = 'retention_settings';
 
-    private PDO $pdo;
+    /** @var PDO */
+    private $pdo;
 
     /**
      * @var array<int, string>

--- a/src/Services/SmtpMailer.php
+++ b/src/Services/SmtpMailer.php
@@ -8,12 +8,23 @@ use RuntimeException;
 
 class SmtpMailer implements MailerInterface
 {
-    private string $host;
-    private int $port;
-    private string $from;
-    private ?string $username;
-    private ?string $password;
-    private bool $useTls;
+    /** @var string */
+    private $host;
+
+    /** @var int */
+    private $port;
+
+    /** @var string */
+    private $from;
+
+    /** @var string|null */
+    private $username;
+
+    /** @var string|null */
+    private $password;
+
+    /** @var bool */
+    private $useTls;
 
     public function __construct(string $host, int $port, string $from, ?string $username = null, ?string $password = null, bool $useTls = false)
     {

--- a/src/Services/UsageService.php
+++ b/src/Services/UsageService.php
@@ -10,7 +10,8 @@ use PDO;
 
 class UsageService
 {
-    private PDO $pdo;
+    /** @var PDO */
+    private $pdo;
 
     public function __construct(PDO $pdo)
     {

--- a/src/Views/Renderer.php
+++ b/src/Views/Renderer.php
@@ -9,7 +9,8 @@ use RuntimeException;
 
 class Renderer
 {
-    private string $basePath;
+    /** @var string */
+    private $basePath;
 
     public function __construct(string $basePath)
     {


### PR DESCRIPTION
## Summary
- replace typed properties and other PHP 8-only syntax with PHPDoc annotations across controllers, services, and supporting classes
- convert arrow functions and null-coalescing assignment to constructs accepted by PHP 7 and adjust helper utilities accordingly
- update smoke and verification tooling to avoid PHP 8-specific type declarations while preserving behaviour

## Testing
- find . -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68d6802e1d3c832ea6130c3b83ca48ba