### PR TITLE
Persist TOTP secrets for returning logins

### DIFF
--- a/bin/smoke.php
+++ b/bin/smoke.php
@@ -446,6 +446,9 @@ final class SmokeSchema
         $this->pdo->exec('CREATE TABLE IF NOT EXISTS users (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             email TEXT NOT NULL UNIQUE,
+            totp_secret TEXT NULL,
+            totp_period_seconds INTEGER NULL,
+            totp_digits INTEGER NULL,
             name TEXT NULL,
             status TEXT NOT NULL DEFAULT "active",
             last_login_at TEXT NULL,


### PR DESCRIPTION
## Summary
- store each user's TOTP configuration after registration so future verifications reuse the same secret
- reuse the stored TOTP secret when generating login challenges and update database setup scripts to support the new columns

## Testing
- composer test
- php -l src/Services/AuthService.php

------
https://chatgpt.com/codex/tasks/task_e_68d68b8465ac832ea490ad1915468f93