### PR TITLE
Expose document uploads and surface hidden routes

### DIFF
--- a/resources/views/dashboard.php
+++ b/resources/views/dashboard.php
@@ -46,6 +46,39 @@ $wizardJson = htmlspecialchars(
         </form>
     </div>
 
+    <div class="grid gap-3 sm:grid-cols-3">
+        <a href="/documents" class="group flex items-center justify-between gap-3 rounded-xl border border-slate-800/80 bg-slate-900/60 px-4 py-3 text-sm font-medium text-slate-200 transition hover:border-indigo-400/60 hover:bg-indigo-500/10 hover:text-indigo-100">
+            <span class="inline-flex items-center gap-2">
+                <span class="rounded-full bg-indigo-500/20 px-2 py-1 text-xs uppercase tracking-wide text-indigo-200">Upload</span>
+                <span>Manage documents</span>
+            </span>
+            <svg aria-hidden="true" class="h-4 w-4 transition group-hover:translate-x-1" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                <path d="M5 12h14" stroke-linecap="round" stroke-linejoin="round"></path>
+                <path d="M13 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+        </a>
+        <a href="/usage" class="group flex items-center justify-between gap-3 rounded-xl border border-slate-800/80 bg-slate-900/60 px-4 py-3 text-sm font-medium text-slate-200 transition hover:border-indigo-400/60 hover:bg-indigo-500/10 hover:text-indigo-100">
+            <span class="inline-flex items-center gap-2">
+                <span class="rounded-full bg-emerald-500/20 px-2 py-1 text-xs uppercase tracking-wide text-emerald-200">Insights</span>
+                <span>Usage analytics</span>
+            </span>
+            <svg aria-hidden="true" class="h-4 w-4 transition group-hover:translate-x-1" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                <path d="M5 12h14" stroke-linecap="round" stroke-linejoin="round"></path>
+                <path d="M13 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+        </a>
+        <a href="/retention" class="group flex items-center justify-between gap-3 rounded-xl border border-slate-800/80 bg-slate-900/60 px-4 py-3 text-sm font-medium text-slate-200 transition hover:border-indigo-400/60 hover:bg-indigo-500/10 hover:text-indigo-100">
+            <span class="inline-flex items-center gap-2">
+                <span class="rounded-full bg-sky-500/20 px-2 py-1 text-xs uppercase tracking-wide text-sky-200">Policy</span>
+                <span>Retention settings</span>
+            </span>
+            <svg aria-hidden="true" class="h-4 w-4 transition group-hover:translate-x-1" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                <path d="M5 12h14" stroke-linecap="round" stroke-linejoin="round"></path>
+                <path d="M13 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+        </a>
+    </div>
+
     <div class="grid gap-6 lg:grid-cols-[320px,1fr]">
         <nav class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6">
             <ol class="space-y-4">

--- a/resources/views/documents.php
+++ b/resources/views/documents.php
@@ -1,0 +1,143 @@
+<?php
+/** @var string $title */
+/** @var string $subtitle */
+/** @var array<int, array{href: string, label: string, current: bool}> $navLinks */
+/** @var array<int, array{filename: string, created_at: string, size: string}> $jobDocuments */
+/** @var array<int, array{filename: string, created_at: string, size: string}> $cvDocuments */
+/** @var array<int, string> $errors */
+/** @var string|null $status */
+/** @var string|null $csrfToken */
+?>
+<?php ob_start(); ?>
+<div class="space-y-8">
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+            <p class="text-sm uppercase tracking-[0.3em] text-indigo-400">Workspace documents</p>
+            <h2 class="mt-2 text-3xl font-semibold text-white">Manage uploads</h2>
+            <p class="mt-2 max-w-2xl text-sm text-slate-400">
+                Keep your latest job descriptions and CVs ready for tailoring. Upload new files below and they will appear
+                instantly inside the generation wizard.
+            </p>
+        </div>
+        <a href="/" class="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:bg-slate-800/60">
+            ← Back to dashboard
+        </a>
+    </div>
+
+    <?php if (!empty($status)) : ?>
+        <div class="rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100">
+            <?= htmlspecialchars($status, ENT_QUOTES) ?>
+        </div>
+    <?php endif; ?>
+
+    <?php if (!empty($errors)) : ?>
+        <div class="space-y-2">
+            <?php foreach ($errors as $error) : ?>
+                <div class="rounded-xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+                    <?= htmlspecialchars($error, ENT_QUOTES) ?>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <section class="grid gap-6 lg:grid-cols-[420px,1fr]">
+        <form
+            method="post"
+            action="/documents/upload"
+            enctype="multipart/form-data"
+            class="space-y-5 rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl"
+        >
+            <div class="space-y-2">
+                <h3 class="text-lg font-semibold text-white">Upload a document</h3>
+                <p class="text-sm text-slate-400">Accepted formats: PDF, DOCX, Markdown, and plain text. Maximum size 1&nbsp;MiB.</p>
+            </div>
+            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+
+            <fieldset class="space-y-3">
+                <legend class="text-sm font-medium text-slate-200">Document type</legend>
+                <p class="text-xs text-slate-400">Choose how the file should be stored so the wizard can find it.</p>
+                <label class="flex items-center gap-3 text-sm text-slate-200">
+                    <input type="radio" name="document_type" value="job_description" class="h-4 w-4 border-slate-600 bg-slate-800 text-indigo-500 focus:ring-indigo-400" required>
+                    <span>Job description</span>
+                </label>
+                <label class="flex items-center gap-3 text-sm text-slate-200">
+                    <input type="radio" name="document_type" value="cv" class="h-4 w-4 border-slate-600 bg-slate-800 text-indigo-500 focus:ring-indigo-400">
+                    <span>CV</span>
+                </label>
+            </fieldset>
+
+            <div class="space-y-2">
+                <label for="document" class="text-sm font-medium text-slate-200">Select file</label>
+                <input
+                    type="file"
+                    id="document"
+                    name="document"
+                    accept=".pdf,.docx,.md,.txt,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,text/markdown,text/plain"
+                    class="block w-full cursor-pointer rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-200 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                    required
+                >
+                <p class="text-xs text-slate-500">Uploads are scanned for macros and binary content before being stored.</p>
+            </div>
+
+            <button type="submit" class="w-full rounded-lg bg-indigo-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400">
+                Upload document
+            </button>
+        </form>
+
+        <div class="space-y-6">
+            <section class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl">
+                <header class="flex items-center justify-between">
+                    <div>
+                        <h3 class="text-lg font-semibold text-white">Job descriptions</h3>
+                        <p class="text-sm text-slate-400">Latest first. Pick any of these inside the dashboard wizard.</p>
+                    </div>
+                    <span class="rounded-full border border-indigo-400/40 bg-indigo-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-200">
+                        <?= count($jobDocuments) ?> stored
+                    </span>
+                </header>
+                <div class="mt-4 divide-y divide-slate-800/60 text-sm text-slate-200">
+                    <?php if (empty($jobDocuments)) : ?>
+                        <p class="py-4 text-slate-400">No job descriptions uploaded yet.</p>
+                    <?php else : ?>
+                        <?php foreach ($jobDocuments as $document) : ?>
+                            <article class="flex flex-col gap-1 py-3 sm:flex-row sm:items-center sm:justify-between">
+                                <div>
+                                    <p class="font-medium text-white"><?= htmlspecialchars($document['filename'], ENT_QUOTES) ?></p>
+                                    <p class="text-xs text-slate-400">Added <?= htmlspecialchars($document['created_at'], ENT_QUOTES) ?> · <?= htmlspecialchars($document['size'], ENT_QUOTES) ?></p>
+                                </div>
+                            </article>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </div>
+            </section>
+
+            <section class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl">
+                <header class="flex items-center justify-between">
+                    <div>
+                        <h3 class="text-lg font-semibold text-white">CV library</h3>
+                        <p class="text-sm text-slate-400">Keep your strongest CV variants available for pairing.</p>
+                    </div>
+                    <span class="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-200">
+                        <?= count($cvDocuments) ?> stored
+                    </span>
+                </header>
+                <div class="mt-4 divide-y divide-slate-800/60 text-sm text-slate-200">
+                    <?php if (empty($cvDocuments)) : ?>
+                        <p class="py-4 text-slate-400">No CVs uploaded yet.</p>
+                    <?php else : ?>
+                        <?php foreach ($cvDocuments as $document) : ?>
+                            <article class="flex flex-col gap-1 py-3 sm:flex-row sm:items-center sm:justify-between">
+                                <div>
+                                    <p class="font-medium text-white"><?= htmlspecialchars($document['filename'], ENT_QUOTES) ?></p>
+                                    <p class="text-xs text-slate-400">Added <?= htmlspecialchars($document['created_at'], ENT_QUOTES) ?> · <?= htmlspecialchars($document['size'], ENT_QUOTES) ?></p>
+                                </div>
+                            </article>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </div>
+            </section>
+        </div>
+    </section>
+</div>
+<?php $body = ob_get_clean(); ?>
+<?php include __DIR__ . '/layout.php'; ?>

--- a/resources/views/layout.php
+++ b/resources/views/layout.php
@@ -70,16 +70,36 @@ use App\Security\CspConfig;
     <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.13.5/dist/cdn.min.js" defer></script>
     <style>[x-cloak]{display:none!important;}</style>
 </head>
-<?php $fullWidth = $fullWidth ?? false; ?>
+<?php
+$fullWidth = $fullWidth ?? false;
+$navLinks = $navLinks ?? [];
+?>
 <body id="site-job-smeird-com" data-site-id="job.smeird.com" class="min-h-screen bg-slate-950 text-slate-100">
 <?php if ($fullWidth) : ?>
     <div class="min-h-screen flex flex-col">
         <header class="border-b border-slate-800/60 bg-slate-900/80 backdrop-blur">
-            <div class="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-5">
-                <div>
-                    <h1 class="text-2xl font-semibold">job.smeird.com</h1>
-                    <?php if (!empty($subtitle)) : ?>
-                        <p class="text-sm text-slate-400 mt-1"><?= htmlspecialchars($subtitle, ENT_QUOTES) ?></p>
+            <div class="mx-auto w-full max-w-6xl px-6 py-5">
+                <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <h1 class="text-2xl font-semibold">job.smeird.com</h1>
+                        <?php if (!empty($subtitle)) : ?>
+                            <p class="mt-1 text-sm text-slate-400"><?= htmlspecialchars($subtitle, ENT_QUOTES) ?></p>
+                        <?php endif; ?>
+                    </div>
+                    <?php if (!empty($navLinks)) : ?>
+                        <nav class="flex flex-wrap gap-2 text-sm font-medium text-slate-300">
+                            <?php foreach ($navLinks as $link) : ?>
+                                <?php
+                                $isCurrent = !empty($link['current']);
+                                $classes = $isCurrent
+                                    ? 'inline-flex items-center gap-2 rounded-full border border-indigo-400/40 bg-indigo-500/20 px-4 py-2 text-indigo-100'
+                                    : 'inline-flex items-center gap-2 rounded-full border border-slate-700 px-4 py-2 text-slate-300 transition hover:border-slate-500 hover:bg-slate-800/60 hover:text-slate-100';
+                                ?>
+                                <a href="<?= htmlspecialchars($link['href'], ENT_QUOTES) ?>" class="<?= $classes ?>">
+                                    <?= htmlspecialchars($link['label'], ENT_QUOTES) ?>
+                                </a>
+                            <?php endforeach; ?>
+                        </nav>
                     <?php endif; ?>
                 </div>
             </div>
@@ -92,6 +112,21 @@ use App\Security\CspConfig;
     </div>
 <?php else : ?>
     <div class="min-h-screen flex flex-col items-center justify-center p-6">
+        <?php if (!empty($navLinks)) : ?>
+            <nav class="mb-6 flex flex-wrap justify-center gap-2 text-sm font-medium text-slate-300">
+                <?php foreach ($navLinks as $link) : ?>
+                    <?php
+                    $isCurrent = !empty($link['current']);
+                    $classes = $isCurrent
+                        ? 'inline-flex items-center gap-2 rounded-full border border-indigo-400/40 bg-indigo-500/20 px-4 py-2 text-indigo-100'
+                        : 'inline-flex items-center gap-2 rounded-full border border-slate-700 px-4 py-2 text-slate-300 transition hover:border-slate-500 hover:bg-slate-800/60 hover:text-slate-100';
+                    ?>
+                    <a href="<?= htmlspecialchars($link['href'], ENT_QUOTES) ?>" class="<?= $classes ?>">
+                        <?= htmlspecialchars($link['label'], ENT_QUOTES) ?>
+                    </a>
+                <?php endforeach; ?>
+            </nav>
+        <?php endif; ?>
         <div class="w-full max-w-md bg-slate-900/70 shadow-xl rounded-lg p-8 space-y-6 border border-slate-800/70">
             <div class="text-center space-y-2">
                 <h1 class="text-3xl font-bold tracking-tight">job.smeird.com</h1>

--- a/resources/views/usage.php
+++ b/resources/views/usage.php
@@ -15,6 +15,24 @@
 </head>
 <body class="min-h-full bg-slate-950 text-slate-100">
 <div class="mx-auto flex min-h-full w-full max-w-6xl flex-col gap-10 px-6 py-12 lg:px-10">
+    <nav class="flex flex-wrap gap-2 text-sm font-medium text-slate-300">
+        <?php
+        $navLinks = [
+            ['href' => '/', 'label' => 'Dashboard', 'current' => false],
+            ['href' => '/documents', 'label' => 'Documents', 'current' => false],
+            ['href' => '/usage', 'label' => 'Usage', 'current' => true],
+            ['href' => '/retention', 'label' => 'Retention', 'current' => false],
+        ];
+        foreach ($navLinks as $link) {
+            $isCurrent = $link['current'];
+            $classes = $isCurrent
+                ? 'inline-flex items-center gap-2 rounded-full border border-indigo-400/40 bg-indigo-500/20 px-4 py-2 text-indigo-100'
+                : 'inline-flex items-center gap-2 rounded-full border border-slate-700 px-4 py-2 text-slate-300 transition hover:border-slate-500 hover:bg-slate-800/60 hover:text-slate-100';
+            echo '<a href="' . htmlspecialchars($link['href'], ENT_QUOTES) . '" class="' . $classes . '">'
+                . htmlspecialchars($link['label'], ENT_QUOTES) . '</a>';
+        }
+        ?>
+    </nav>
     <header class="space-y-4">
         <p class="text-sm uppercase tracking-[0.2em] text-indigo-400">Insights</p>
         <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">

--- a/src/Controllers/DocumentController.php
+++ b/src/Controllers/DocumentController.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controllers;
+
+use App\Documents\DocumentRepository;
+use App\Documents\DocumentService;
+use App\Documents\DocumentValidationException;
+use App\Views\Renderer;
+use PDOException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UploadedFileInterface;
+use RuntimeException;
+
+final class DocumentController
+{
+    /** @var Renderer */
+    private $renderer;
+
+    /** @var DocumentRepository */
+    private $documentRepository;
+
+    /** @var DocumentService */
+    private $documentService;
+
+    public function __construct(
+        Renderer $renderer,
+        DocumentRepository $documentRepository,
+        DocumentService $documentService
+    ) {
+        $this->renderer = $renderer;
+        $this->documentRepository = $documentRepository;
+        $this->documentService = $documentService;
+    }
+
+    public function index(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $user = $request->getAttribute('user');
+
+        if (!is_array($user) || !isset($user['user_id'])) {
+            return $response->withHeader('Location', '/auth/login')->withStatus(302);
+        }
+
+        $userId = (int) $user['user_id'];
+        $status = $request->getQueryParams()['status'] ?? null;
+
+        return $this->renderer->render($response, 'documents', [
+            'title' => 'Documents',
+            'subtitle' => 'Upload CVs and job descriptions for tailoring.',
+            'fullWidth' => true,
+            'navLinks' => $this->navLinks('documents'),
+            'jobDocuments' => $this->mapDocuments($this->documentRepository->listForUserAndType($userId, 'job_description')),
+            'cvDocuments' => $this->mapDocuments($this->documentRepository->listForUserAndType($userId, 'cv')),
+            'errors' => [],
+            'status' => $status,
+        ]);
+    }
+
+    public function upload(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $user = $request->getAttribute('user');
+
+        if (!is_array($user) || !isset($user['user_id'])) {
+            return $response->withHeader('Location', '/auth/login')->withStatus(302);
+        }
+
+        $userId = (int) $user['user_id'];
+        $data = $request->getParsedBody();
+        $errors = [];
+        $documentType = '';
+
+        if (is_array($data)) {
+            $documentType = isset($data['document_type']) ? trim((string) $data['document_type']) : '';
+        }
+
+        if (!in_array($documentType, ['job_description', 'cv'], true)) {
+            $errors[] = 'Choose whether the file is a job description or a CV.';
+        }
+
+        $files = $request->getUploadedFiles();
+        $uploadedFile = $files['document'] ?? null;
+
+        if (!$uploadedFile instanceof UploadedFileInterface || $uploadedFile->getError() === UPLOAD_ERR_NO_FILE) {
+            $errors[] = 'Select a file to upload.';
+        }
+
+        if ($errors === []) {
+            try {
+                $document = $this->documentService->storeUploadedDocument($uploadedFile, $userId, $documentType);
+
+                $label = $documentType === 'cv' ? 'CV' : 'job description';
+                $message = sprintf('Uploaded "%s" as your %s.', $document->filename(), $label);
+
+                return $response
+                    ->withHeader('Location', '/documents?status=' . rawurlencode($message))
+                    ->withStatus(302);
+            } catch (DocumentValidationException $exception) {
+                $errors[] = $exception->getMessage();
+            } catch (PDOException $exception) {
+                $errors[] = 'We could not store the document. Please try a different file.';
+            } catch (RuntimeException $exception) {
+                $errors[] = $exception->getMessage();
+            }
+        }
+
+        return $this->renderer->render($response->withStatus(422), 'documents', [
+            'title' => 'Documents',
+            'subtitle' => 'Upload CVs and job descriptions for tailoring.',
+            'fullWidth' => true,
+            'navLinks' => $this->navLinks('documents'),
+            'jobDocuments' => $this->mapDocuments($this->documentRepository->listForUserAndType($userId, 'job_description')),
+            'cvDocuments' => $this->mapDocuments($this->documentRepository->listForUserAndType($userId, 'cv')),
+            'errors' => $errors,
+            'status' => null,
+        ]);
+    }
+
+    /**
+     * @param array<int, \App\Documents\Document> $documents
+     * @return array<int, array{filename: string, created_at: string, size: string}>
+     */
+    private function mapDocuments(array $documents): array
+    {
+        return array_map(function ($document) {
+            return [
+                'filename' => $document->filename(),
+                'created_at' => $document->createdAt()->format('Y-m-d H:i'),
+                'size' => $this->formatBytes($document->sizeBytes()),
+            ];
+        }, $documents);
+    }
+
+    private function formatBytes(int $bytes): string
+    {
+        if ($bytes < 1024) {
+            return $bytes . ' B';
+        }
+
+        $units = ['KiB', 'MiB'];
+        $value = $bytes / 1024;
+        $unitIndex = 0;
+
+        while ($value >= 1024 && $unitIndex < count($units) - 1) {
+            $value /= 1024;
+            $unitIndex++;
+        }
+
+        return sprintf('%.1f %s', $value, $units[$unitIndex]);
+    }
+
+    /**
+     * @return array<int, array{href: string, label: string, current: bool}>
+     */
+    private function navLinks(string $current): array
+    {
+        $links = [
+            'dashboard' => ['href' => '/', 'label' => 'Dashboard'],
+            'documents' => ['href' => '/documents', 'label' => 'Documents'],
+            'usage' => ['href' => '/usage', 'label' => 'Usage'],
+            'retention' => ['href' => '/retention', 'label' => 'Retention'],
+        ];
+
+        return array_map(function ($key, $link) use ($current) {
+            return [
+                'href' => $link['href'],
+                'label' => $link['label'],
+                'current' => $key === $current,
+            ];
+        }, array_keys($links), $links);
+    }
+}

--- a/src/Controllers/RetentionController.php
+++ b/src/Controllers/RetentionController.php
@@ -41,6 +41,8 @@ class RetentionController
         return $this->renderer->render($response, 'retention', [
             'title' => 'Data retention',
             'subtitle' => 'Control how long sensitive records are kept before purge.',
+            'fullWidth' => true,
+            'navLinks' => $this->navLinks('retention'),
             'policy' => $policy,
             'allowedResources' => $this->retentionPolicyService->getAllowedResources(),
             'resourceLabels' => $this->resourceLabels(),
@@ -88,6 +90,8 @@ class RetentionController
             return $this->renderer->render($response, 'retention', [
                 'title' => 'Data retention',
                 'subtitle' => 'Control how long sensitive records are kept before purge.',
+                'fullWidth' => true,
+                'navLinks' => $this->navLinks('retention'),
                 'policy' => $policy,
                 'allowedResources' => $this->retentionPolicyService->getAllowedResources(),
                 'resourceLabels' => $this->resourceLabels(),
@@ -110,5 +114,26 @@ class RetentionController
             'api_usage' => 'API usage metrics',
             'audit_logs' => 'Audit logs',
         ];
+    }
+
+    /**
+     * @return array<int, array{href: string, label: string, current: bool}>
+     */
+    private function navLinks(string $current): array
+    {
+        $links = [
+            'dashboard' => ['href' => '/', 'label' => 'Dashboard'],
+            'documents' => ['href' => '/documents', 'label' => 'Documents'],
+            'usage' => ['href' => '/usage', 'label' => 'Usage'],
+            'retention' => ['href' => '/retention', 'label' => 'Retention'],
+        ];
+
+        return array_map(function ($key, $link) use ($current) {
+            return [
+                'href' => $link['href'],
+                'label' => $link['label'],
+                'current' => $key === $current,
+            ];
+        }, array_keys($links), $links);
     }
 }

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace App;
 
 use App\Controllers\AuthController;
+use App\Controllers\DocumentController;
 use App\Controllers\GenerationController;
+use App\Controllers\GenerationDownloadController;
 use App\Controllers\HomeController;
+use App\Controllers\RetentionController;
 use App\Controllers\UsageController;
 use App\Prompts\PromptLibrary;
 use App\Validation\DraftValidator;
@@ -29,6 +32,14 @@ class Routes
 
         $app->get('/', function (Request $request, Response $response) use ($container) {
             return $container->get(HomeController::class)->index($request, $response);
+        });
+
+        $app->get('/documents', function (Request $request, Response $response) use ($container) {
+            return $container->get(DocumentController::class)->index($request, $response);
+        });
+
+        $app->post('/documents/upload', function (Request $request, Response $response) use ($container) {
+            return $container->get(DocumentController::class)->upload($request, $response);
         });
 
 
@@ -89,6 +100,10 @@ class Routes
             return $container->get(GenerationController::class)->show($request, $response, $args);
         });
 
+        $app->get('/generations/{id}/download', function (Request $request, Response $response, array $args) use ($container) {
+            return $container->get(GenerationDownloadController::class)->download($request, $response, $args);
+        });
+
         $app->get('/healthz', function (Request $request, Response $response): Response {
             $response->getBody()->write('ok');
 
@@ -146,6 +161,14 @@ class Routes
 
         $app->get('/usage', UsageController::class . ':index');
         $app->get('/usage/data', UsageController::class . ':data');
+
+        $app->get('/retention', function (Request $request, Response $response) use ($container) {
+            return $container->get(RetentionController::class)->show($request, $response);
+        });
+
+        $app->post('/retention', function (Request $request, Response $response) use ($container) {
+            return $container->get(RetentionController::class)->update($request, $response);
+        });
 
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated document upload controller and page so job descriptions and CVs can be added from the app
- register missing services and routes (documents, retention, generation downloads) and surface quick links in the dashboard layout
- extend shared navigation elements, including the usage view, so every major capability stays reachable

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d68c1c6c94832e889657569b06f176