### PR TITLE
Fix syntax error in DocumentService constructor

### DIFF
--- a/src/Documents/DocumentService.php
+++ b/src/Documents/DocumentService.php
@@ -18,7 +18,7 @@ class DocumentService
 
     public function __construct(
         DocumentRepository $repository,
-        DocumentValidator $validator,
+        DocumentValidator $validator
     ) {
         $this->repository = $repository;
         $this->validator = $validator;


### PR DESCRIPTION
## Summary
- remove the trailing comma from the DocumentService constructor parameter list to satisfy PHP 7 syntax rules and prevent runtime parse errors

## Testing
- php -l src/Documents/DocumentService.php

------
https://chatgpt.com/codex/tasks/task_e_68d68f3c2a84832e9b6fd3a1c1724396