### PR TITLE
Allow Tailwind CDN in CSP

### DIFF
--- a/src/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Middleware/SecurityHeadersMiddleware.php
@@ -54,6 +54,7 @@ final class SecurityHeadersMiddleware implements MiddlewareInterface
         $scriptSources = [
             "'self'",
             "'unsafe-inline'",
+            'https://cdn.tailwindcss.com',
             'https://cdn.jsdelivr.net',
             'https://code.highcharts.com',
             CspConfig::alpineInitHash(),


### PR DESCRIPTION
## Summary
- permit loading the Tailwind CDN script by adding its origin to the Content Security Policy script-src directive

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d68f749c1c832ebd32d242ca39c2c1