### PR TITLE
Remove trailing commas incompatible with PHP 7

### DIFF
--- a/src/Documents/DocumentRepository.php
+++ b/src/Documents/DocumentRepository.php
@@ -166,7 +166,7 @@ class DocumentRepository
             (int) $row['size_bytes'],
             $row['sha256'],
             is_resource($row['content']) ? stream_get_contents($row['content']) ?: '' : (string) $row['content'],
-            new DateTimeImmutable($row['created_at']),
+            new DateTimeImmutable($row['created_at'])
         );
     }
 }

--- a/src/Documents/DocumentService.php
+++ b/src/Documents/DocumentService.php
@@ -18,7 +18,7 @@ class DocumentService
 
     public function __construct(
         DocumentRepository $repository,
-        DocumentValidator $validator,
+        DocumentValidator $validator
     ) {
         $this->repository = $repository;
         $this->validator = $validator;
@@ -76,7 +76,7 @@ class DocumentService
                 $validation['size'],
                 $sha256,
                 $buffer,
-                new DateTimeImmutable(),
+                new DateTimeImmutable()
             );
 
             return $this->repository->save($document);

--- a/src/Generations/GenerationStreamRepository.php
+++ b/src/Generations/GenerationStreamRepository.php
@@ -58,7 +58,7 @@ class GenerationStreamRepository
             $totalTokens,
             $errorMessage !== null ? (string) $errorMessage : null,
             $updatedAt,
-            $latestOutputAt,
+            $latestOutputAt
         );
     }
 }

--- a/src/Queue/Job.php
+++ b/src/Queue/Job.php
@@ -33,7 +33,7 @@ final class Job
         array $payload,
         int $attempts,
         string $status,
-        DateTimeImmutable $runAfter,
+        DateTimeImmutable $runAfter
     ) {
         $this->id = $id;
         $this->type = $type;


### PR DESCRIPTION
## Summary
- remove trailing commas from Job constructor parameters and related object creation calls so they parse under PHP 7
- ensure GenerationStreamSnapshot and Document hydrations no longer use trailing commas in argument lists

## Testing
- find src -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68d68f3c2a84832e9b6fd3a1c1724396