### PR TITLE
Fix usage controller catch syntax

### DIFF
--- a/src/Controllers/UsageController.php
+++ b/src/Controllers/UsageController.php
@@ -51,7 +51,7 @@ class UsageController
         try {
             $dataset = $this->usageService->getUsageForUser((int) $user['user_id']);
             $payload = json_encode($dataset, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
-        } catch (JsonException) {
+        } catch (JsonException $exception) {
             $response->getBody()->write((string) json_encode(
                 ['error' => 'Unable to encode response.'],
                 JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE


### PR DESCRIPTION
## Summary
- add a variable to the JsonException catch block in UsageController to satisfy PHP 7 syntax requirements

## Testing
- php -l src/Controllers/UsageController.php

------
https://chatgpt.com/codex/tasks/task_e_68d690b200e4832eaf92dcaacb0e4474