### PR TITLE
Handle missing ZipArchive extension gracefully

### DIFF
--- a/bin/verify.helpers.php
+++ b/bin/verify.helpers.php
@@ -379,6 +379,12 @@ function verify_zip_has_entry(string $binary, string $entry): bool
     $meta = stream_get_meta_data($temp);
     $filename = $meta['uri'];
 
+    if (!class_exists('ZipArchive')) {
+        fclose($temp);
+
+        return false;
+    }
+
     $zip = new ZipArchive();
     $result = $zip->open($filename);
     if ($result !== true) {

--- a/src/Documents/DocumentPreviewer.php
+++ b/src/Documents/DocumentPreviewer.php
@@ -36,6 +36,10 @@ class DocumentPreviewer
 
     private function renderDocx(string $content): string
     {
+        if (!class_exists(ZipArchive::class)) {
+            return '';
+        }
+
         $resource = tmpfile();
 
         if ($resource === false) {

--- a/src/Documents/DocumentValidator.php
+++ b/src/Documents/DocumentValidator.php
@@ -50,6 +50,10 @@ class DocumentValidator
 
     private function validateDocx(string $content, ?string $temporaryPath): string
     {
+        if (!class_exists(ZipArchive::class)) {
+            throw new DocumentValidationException('DOCX validation is unavailable because the PHP zip extension is missing.');
+        }
+
         if (!str_starts_with($content, "PK")) {
             throw new DocumentValidationException('The DOCX archive is malformed.');
         }


### PR DESCRIPTION
## Summary
- guard DOCX validation against missing ZipArchive extension and return a clear validation error
- avoid rendering DOCX previews when ZipArchive is unavailable
- make verification helper resilient when the zip extension is not present

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d69145439c832e8a616828031e202a