### PR TITLE
Fix duplicate GenerationDownloadService import

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -31,7 +31,6 @@ use Slim\Factory\AppFactory;
 use Slim\Middleware\ErrorMiddleware;
 use App\Generations\GenerationDownloadService;
 use App\Generations\GenerationRepository;
-use App\Generations\GenerationDownloadService;
 use App\Generations\GenerationTokenService;
 
 require_once __DIR__ . '/../autoload.php';


### PR DESCRIPTION
## Summary
- remove the duplicate GenerationDownloadService import from the public bootstrap file

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d694ae1b2c832ea3546ce7a31cac1e