### PR TITLE
Handle JsonException in retention policy service

### DIFF
--- a/src/Services/RetentionPolicyService.php
+++ b/src/Services/RetentionPolicyService.php
@@ -55,7 +55,7 @@ class RetentionPolicyService
 
         try {
             $applyTo = json_decode((string) $row['apply_to'], true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
+        } catch (JsonException $exception) {
             $applyTo = [];
         }
 


### PR DESCRIPTION
## Summary
- add a variable to the JsonException catch block in RetentionPolicyService so the code parses under PHP 7

## Testing
- php -l src/Services/RetentionPolicyService.php

------
https://chatgpt.com/codex/tasks/task_e_68d69548e2b0832e8ccdb523db601003