### PR TITLE
Fix UsageService JsonException catch syntax error

### DIFF
--- a/src/Services/UsageService.php
+++ b/src/Services/UsageService.php
@@ -173,7 +173,7 @@ class UsageService
 
         try {
             $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
+        } catch (JsonException $exception) {
             return [];
         }
 


### PR DESCRIPTION
## Summary
- fix the UsageService metadata decoder to include a variable in the JsonException catch clause

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6983223e8832e9f9ab402e1097d91