### PR TITLE
Fix PHP catch syntax in UsageService

### DIFF
--- a/src/Services/UsageService.php
+++ b/src/Services/UsageService.php
@@ -194,7 +194,7 @@ class UsageService
 
         try {
             return new DateTimeImmutable($value);
-        } catch (\Exception) {
+        } catch (\Exception $exception) {
             return null;
         }
     }


### PR DESCRIPTION
## Summary
- add a variable to the UsageService catch clause so PHP 7 can parse the file again

## Testing
- php -l src/Services/UsageService.php

------
https://chatgpt.com/codex/tasks/task_e_68d6990512b8832eb550bf03ea1b41a9