### PR TITLE
Add job application tracker with free-text descriptions

### DIFF
--- a/database/migrations/20240801000000_create_job_applications.php
+++ b/database/migrations/20240801000000_create_job_applications.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'id' => '20240801000000_create_job_applications',
+    'up' => [
+        "CREATE TABLE IF NOT EXISTS job_applications (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            user_id BIGINT UNSIGNED NOT NULL,
+            title VARCHAR(255) NOT NULL DEFAULT '',
+            source_url TEXT NULL,
+            description LONGTEXT NOT NULL,
+            status VARCHAR(32) NOT NULL DEFAULT 'outstanding',
+            applied_at DATETIME NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            CONSTRAINT fk_job_applications_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+            INDEX idx_job_applications_user_status (user_id, status),
+            INDEX idx_job_applications_user_created (user_id, created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+    ],
+    'down' => [
+        'DROP TABLE IF EXISTS job_applications',
+    ],
+];

--- a/public/index.php
+++ b/public/index.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 use App\Bootstrap;
 use App\Controllers\AuthController;
+use App\Applications\JobApplicationRepository;
+use App\Applications\JobApplicationService;
 use App\Controllers\DocumentController;
+use App\Controllers\JobApplicationController;
 use App\Controllers\GenerationController;
 use App\Controllers\GenerationDownloadController;
 use App\Controllers\HomeController;
@@ -85,6 +88,22 @@ $container->set(DocumentController::class, static function (Container $c): Docum
     );
 });
 
+$container->set(JobApplicationRepository::class, static function (Container $c): JobApplicationRepository {
+    return new JobApplicationRepository($c->get(\PDO::class));
+});
+
+$container->set(JobApplicationService::class, static function (Container $c): JobApplicationService {
+    return new JobApplicationService($c->get(JobApplicationRepository::class));
+});
+
+$container->set(JobApplicationController::class, static function (Container $c): JobApplicationController {
+    return new JobApplicationController(
+        $c->get(Renderer::class),
+        $c->get(JobApplicationRepository::class),
+        $c->get(JobApplicationService::class)
+    );
+});
+
 $container->set(GenerationRepository::class, static function (Container $c): GenerationRepository {
     return new GenerationRepository($c->get(\PDO::class));
 });
@@ -126,7 +145,8 @@ $container->set(HomeController::class, static function (Container $c): HomeContr
     return new HomeController(
         $c->get(Renderer::class),
         $c->get(DocumentRepository::class),
-        $c->get(GenerationRepository::class)
+        $c->get(GenerationRepository::class),
+        $c->get(JobApplicationRepository::class)
     );
 });
 

--- a/resources/views/applications.php
+++ b/resources/views/applications.php
@@ -1,0 +1,203 @@
+<?php
+/** @var string $title */
+/** @var string $subtitle */
+/** @var array<int, array{href: string, label: string, current: bool}> $navLinks */
+/** @var array<int, array<string, mixed>> $outstanding */
+/** @var array<int, array<string, mixed>> $applied */
+/** @var array<int, string> $errors */
+/** @var string|null $status */
+/** @var array<string, string> $form */
+/** @var string|null $csrfToken */
+?>
+<?php ob_start(); ?>
+<div class="space-y-8">
+    <header class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div class="space-y-3">
+            <p class="text-sm uppercase tracking-[0.35em] text-indigo-400">Job application tracker</p>
+            <h2 class="text-3xl font-semibold text-white">Paste postings and plan your follow-up</h2>
+            <p class="max-w-2xl text-sm text-slate-400">
+                Capture descriptions directly from job boards, keep the source URL handy, and mark each opportunity once you have
+                submitted an application.
+            </p>
+        </div>
+        <a href="/" class="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:bg-slate-800/60">
+            ← Back to dashboard
+        </a>
+    </header>
+
+    <?php if (!empty($status)) : ?>
+        <div class="rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100">
+            <?= htmlspecialchars($status, ENT_QUOTES) ?>
+        </div>
+    <?php endif; ?>
+
+    <?php if (!empty($errors)) : ?>
+        <div class="space-y-2">
+            <?php foreach ($errors as $error) : ?>
+                <div class="rounded-xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+                    <?= htmlspecialchars($error, ENT_QUOTES) ?>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <section class="grid gap-6 xl:grid-cols-[420px,1fr]">
+        <form method="post" action="/applications" class="space-y-5 rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl">
+            <div class="space-y-2">
+                <h3 class="text-lg font-semibold text-white">Add a posting</h3>
+                <p class="text-sm text-slate-400">
+                    Paste the full job description text and the URL where you found it. This keeps everything searchable alongside your CVs.
+                </p>
+            </div>
+            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+
+            <div class="space-y-2">
+                <label for="title" class="text-sm font-medium text-slate-200">Role title</label>
+                <input
+                    type="text"
+                    id="title"
+                    name="title"
+                    value="<?= htmlspecialchars($form['title'] ?? '', ENT_QUOTES) ?>"
+                    placeholder="e.g. Senior Automation Engineer"
+                    class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                >
+            </div>
+
+            <div class="space-y-2">
+                <label for="source_url" class="text-sm font-medium text-slate-200">Source URL</label>
+                <input
+                    type="url"
+                    id="source_url"
+                    name="source_url"
+                    value="<?= htmlspecialchars($form['source_url'] ?? '', ENT_QUOTES) ?>"
+                    placeholder="https://"
+                    class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                >
+                <p class="text-xs text-slate-500">Storing the URL lets you return to the original listing quickly.</p>
+            </div>
+
+            <div class="space-y-2">
+                <label for="description" class="text-sm font-medium text-slate-200">Job description</label>
+                <textarea
+                    id="description"
+                    name="description"
+                    rows="10"
+                    class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                    placeholder="Paste the role summary, responsibilities, and requirements here"
+                    required
+                ><?= htmlspecialchars($form['description'] ?? '', ENT_QUOTES) ?></textarea>
+                <p class="text-xs text-slate-500">The full text remains editable later through copy and paste.</p>
+            </div>
+
+            <button type="submit" class="w-full rounded-lg bg-indigo-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400">
+                Save posting
+            </button>
+        </form>
+
+        <div class="space-y-6">
+            <section class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl">
+                <header class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <h3 class="text-lg font-semibold text-white">Outstanding opportunities</h3>
+                        <p class="text-sm text-slate-400">Everything you still plan to apply for appears here.</p>
+                    </div>
+                    <span class="rounded-full border border-amber-400/40 bg-amber-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-200">
+                        <?= count($outstanding) ?> queued
+                    </span>
+                </header>
+                <div class="mt-4 space-y-4">
+                    <?php if (empty($outstanding)) : ?>
+                        <p class="rounded-xl border border-slate-800 bg-slate-900/70 px-4 py-6 text-sm text-slate-400">
+                            Nothing queued yet. Paste the next role you are targeting to get started.
+                        </p>
+                    <?php else : ?>
+                        <?php foreach ($outstanding as $item) : ?>
+                            <article class="rounded-xl border border-slate-800 bg-slate-950/80 p-4 text-sm text-slate-200 shadow-inner">
+                                <header class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                                    <div>
+                                        <h4 class="text-base font-semibold text-white">
+                                            <?= htmlspecialchars($item['title'] ?? 'Untitled application', ENT_QUOTES) ?>
+                                        </h4>
+                                        <p class="text-xs text-slate-500">Added <?= htmlspecialchars($item['created_at'], ENT_QUOTES) ?></p>
+                                    </div>
+                                    <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="self-start">
+                                        <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                                        <input type="hidden" name="status" value="applied">
+                                        <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-200 transition hover:border-emerald-300 hover:text-emerald-100">
+                                            Mark applied
+                                        </button>
+                                    </form>
+                                </header>
+                                <?php if (!empty($item['source_url'])) : ?>
+                                    <a href="<?= htmlspecialchars($item['source_url'], ENT_QUOTES) ?>" target="_blank" rel="noopener" class="mt-2 inline-flex items-center gap-2 text-xs text-indigo-300 hover:text-indigo-200">
+                                        View listing
+                                        <svg aria-hidden="true" class="h-3 w-3" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                                            <path d="M7 17L17 7M7 7h10v10" stroke-linecap="round" stroke-linejoin="round"></path>
+                                        </svg>
+                                    </a>
+                                <?php endif; ?>
+                                <p class="mt-3 text-sm text-slate-300">
+                                    <?= nl2br(htmlspecialchars($item['description_preview'], ENT_QUOTES)) ?>
+                                </p>
+                            </article>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </div>
+            </section>
+
+            <section class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl">
+                <header class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <h3 class="text-lg font-semibold text-white">Submitted applications</h3>
+                        <p class="text-sm text-slate-400">Keep a record of where you have already applied.</p>
+                    </div>
+                    <span class="rounded-full border border-indigo-400/40 bg-indigo-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-200">
+                        <?= count($applied) ?> sent
+                    </span>
+                </header>
+                <div class="mt-4 space-y-4">
+                    <?php if (empty($applied)) : ?>
+                        <p class="rounded-xl border border-slate-800 bg-slate-900/70 px-4 py-6 text-sm text-slate-400">
+                            Once you submit an application it will be archived here for quick reference.
+                        </p>
+                    <?php else : ?>
+                        <?php foreach ($applied as $item) : ?>
+                            <article class="rounded-xl border border-slate-800 bg-slate-950/80 p-4 text-sm text-slate-200 shadow-inner">
+                                <header class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                                    <div>
+                                        <h4 class="text-base font-semibold text-white">
+                                            <?= htmlspecialchars($item['title'] ?? 'Untitled application', ENT_QUOTES) ?>
+                                        </h4>
+                                        <p class="text-xs text-slate-500">
+                                            Applied <?= htmlspecialchars($item['applied_at'] ?? $item['created_at'], ENT_QUOTES) ?>
+                                        </p>
+                                    </div>
+                                    <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="self-start">
+                                        <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                                        <input type="hidden" name="status" value="outstanding">
+                                        <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-300 transition hover:border-slate-500 hover:text-slate-100">
+                                            Move back to queue
+                                        </button>
+                                    </form>
+                                </header>
+                                <?php if (!empty($item['source_url'])) : ?>
+                                    <a href="<?= htmlspecialchars($item['source_url'], ENT_QUOTES) ?>" target="_blank" rel="noopener" class="mt-2 inline-flex items-center gap-2 text-xs text-indigo-300 hover:text-indigo-200">
+                                        View listing
+                                        <svg aria-hidden="true" class="h-3 w-3" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                                            <path d="M7 17L17 7M7 7h10v10" stroke-linecap="round" stroke-linejoin="round"></path>
+                                        </svg>
+                                    </a>
+                                <?php endif; ?>
+                                <p class="mt-3 text-sm text-slate-300">
+                                    <?= nl2br(htmlspecialchars($item['description_preview'], ENT_QUOTES)) ?>
+                                </p>
+                            </article>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </div>
+            </section>
+        </div>
+    </section>
+</div>
+<?php $body = ob_get_clean(); ?>
+<?php include __DIR__ . '/layout.php'; ?>

--- a/resources/views/dashboard.php
+++ b/resources/views/dashboard.php
@@ -6,6 +6,8 @@
 /** @var array<int, array<string, mixed>> $cvDocuments */
 /** @var array<int, array<string, mixed>> $generations */
 /** @var array<int, array<string, mixed>> $modelOptions */
+/** @var array<int, array<string, mixed>> $outstandingApplications */
+/** @var int $outstandingApplicationsCount */
 
 $fullWidth = true;
 
@@ -46,7 +48,7 @@ $wizardJson = htmlspecialchars(
         </form>
     </div>
 
-    <div class="grid gap-3 sm:grid-cols-3">
+    <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <a href="/documents" class="group flex items-center justify-between gap-3 rounded-xl border border-slate-800/80 bg-slate-900/60 px-4 py-3 text-sm font-medium text-slate-200 transition hover:border-indigo-400/60 hover:bg-indigo-500/10 hover:text-indigo-100">
             <span class="inline-flex items-center gap-2">
                 <span class="rounded-full bg-indigo-500/20 px-2 py-1 text-xs uppercase tracking-wide text-indigo-200">Upload</span>
@@ -56,6 +58,15 @@ $wizardJson = htmlspecialchars(
                 <path d="M5 12h14" stroke-linecap="round" stroke-linejoin="round"></path>
                 <path d="M13 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round"></path>
             </svg>
+        </a>
+        <a href="/applications" class="group flex items-center justify-between gap-3 rounded-xl border border-slate-800/80 bg-slate-900/60 px-4 py-3 text-sm font-medium text-slate-200 transition hover:border-indigo-400/60 hover:bg-indigo-500/10 hover:text-indigo-100">
+            <span class="inline-flex items-center gap-2">
+                <span class="rounded-full bg-amber-500/20 px-2 py-1 text-xs uppercase tracking-wide text-amber-200">Track</span>
+                <span>Job tracker</span>
+            </span>
+            <span class="text-xs font-semibold uppercase tracking-wide text-amber-200">
+                <?= (int) $outstandingApplicationsCount ?> outstanding
+            </span>
         </a>
         <a href="/usage" class="group flex items-center justify-between gap-3 rounded-xl border border-slate-800/80 bg-slate-900/60 px-4 py-3 text-sm font-medium text-slate-200 transition hover:border-indigo-400/60 hover:bg-indigo-500/10 hover:text-indigo-100">
             <span class="inline-flex items-center gap-2">
@@ -78,6 +89,42 @@ $wizardJson = htmlspecialchars(
             </svg>
         </a>
     </div>
+
+    <section class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl">
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+                <h3 class="text-lg font-semibold text-white">Next up</h3>
+                <p class="text-sm text-slate-400">A snapshot of the roles you still plan to apply for.</p>
+            </div>
+            <a href="/applications" class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-300 transition hover:border-slate-500 hover:text-slate-100">
+                Open tracker
+            </a>
+        </div>
+        <div class="mt-4 space-y-4">
+            <?php if (empty($outstandingApplications)) : ?>
+                <p class="rounded-xl border border-slate-800 bg-slate-950/70 px-4 py-6 text-sm text-slate-400">
+                    You have no outstanding postings right now. Capture the next role you find to keep everything organised.
+                </p>
+            <?php else : ?>
+                <?php foreach ($outstandingApplications as $application) : ?>
+                    <article class="flex flex-col gap-2 rounded-xl border border-slate-800 bg-slate-950/80 px-4 py-3 text-sm text-slate-200">
+                        <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                            <p class="font-medium text-white"><?= htmlspecialchars($application['title'] ?? 'Untitled application', ENT_QUOTES) ?></p>
+                            <p class="text-xs text-slate-500">Added <?= htmlspecialchars($application['created_at'], ENT_QUOTES) ?></p>
+                        </div>
+                        <?php if (!empty($application['source_url'])) : ?>
+                            <a href="<?= htmlspecialchars($application['source_url'], ENT_QUOTES) ?>" target="_blank" rel="noopener" class="inline-flex items-center gap-2 text-xs text-indigo-300 hover:text-indigo-200">
+                                View listing
+                                <svg aria-hidden="true" class="h-3 w-3" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                                    <path d="M7 17L17 7M7 7h10v10" stroke-linecap="round" stroke-linejoin="round"></path>
+                                </svg>
+                            </a>
+                        <?php endif; ?>
+                    </article>
+                <?php endforeach; ?>
+            <?php endif; ?>
+        </div>
+    </section>
 
     <div class="grid gap-6 lg:grid-cols-[320px,1fr]">
         <nav class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6">

--- a/resources/views/usage.php
+++ b/resources/views/usage.php
@@ -6,6 +6,7 @@ $subtitle = 'Spend and token insight';
 $navLinks = [
     ['href' => '/', 'label' => 'Dashboard', 'current' => false],
     ['href' => '/documents', 'label' => 'Documents', 'current' => false],
+    ['href' => '/applications', 'label' => 'Applications', 'current' => false],
     ['href' => '/usage', 'label' => 'Usage', 'current' => true],
     ['href' => '/retention', 'label' => 'Retention', 'current' => false],
 ];

--- a/src/Applications/JobApplication.php
+++ b/src/Applications/JobApplication.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Applications;
+
+use DateTimeImmutable;
+
+class JobApplication
+{
+    /** @var int|null */
+    private $id;
+
+    /** @var int */
+    private $userId;
+
+    /** @var string */
+    private $title;
+
+    /** @var string|null */
+    private $sourceUrl;
+
+    /** @var string */
+    private $description;
+
+    /** @var string */
+    private $status;
+
+    /** @var DateTimeImmutable|null */
+    private $appliedAt;
+
+    /** @var DateTimeImmutable */
+    private $createdAt;
+
+    /** @var DateTimeImmutable */
+    private $updatedAt;
+
+    /**
+     * Construct the object with its required dependencies.
+     *
+     * This ensures collaborating services are available for subsequent method calls.
+     */
+    public function __construct(
+        ?int $id,
+        int $userId,
+        string $title,
+        ?string $sourceUrl,
+        string $description,
+        string $status,
+        ?DateTimeImmutable $appliedAt,
+        DateTimeImmutable $createdAt,
+        DateTimeImmutable $updatedAt
+    ) {
+        $this->id = $id;
+        $this->userId = $userId;
+        $this->title = $title;
+        $this->sourceUrl = $sourceUrl;
+        $this->description = $description;
+        $this->status = $status;
+        $this->appliedAt = $appliedAt;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $updatedAt;
+    }
+
+    /**
+     * Handle the id operation.
+     *
+     * Documenting this helper clarifies its role within the wider workflow.
+     */
+    public function id(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * Handle the user id operation.
+     *
+     * Documenting this helper clarifies its role within the wider workflow.
+     */
+    public function userId(): int
+    {
+        return $this->userId;
+    }
+
+    /**
+     * Handle the title operation.
+     *
+     * Documenting this helper clarifies its role within the wider workflow.
+     */
+    public function title(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * Handle the source url operation.
+     *
+     * Documenting this helper clarifies its role within the wider workflow.
+     */
+    public function sourceUrl(): ?string
+    {
+        return $this->sourceUrl;
+    }
+
+    /**
+     * Handle the description operation.
+     *
+     * Documenting this helper clarifies its role within the wider workflow.
+     */
+    public function description(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * Handle the status operation.
+     *
+     * Documenting this helper clarifies its role within the wider workflow.
+     */
+    public function status(): string
+    {
+        return $this->status;
+    }
+
+    /**
+     * Handle the applied at operation.
+     *
+     * Documenting this helper clarifies its role within the wider workflow.
+     */
+    public function appliedAt(): ?DateTimeImmutable
+    {
+        return $this->appliedAt;
+    }
+
+    /**
+     * Handle the created at operation.
+     *
+     * Documenting this helper clarifies its role within the wider workflow.
+     */
+    public function createdAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * Handle the updated at operation.
+     *
+     * Documenting this helper clarifies its role within the wider workflow.
+     */
+    public function updatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    /**
+     * Handle the with status operation.
+     *
+     * This helper keeps the immutable update workflow neat and predictable.
+     */
+    public function withStatus(string $status, ?DateTimeImmutable $appliedAt, DateTimeImmutable $updatedAt): self
+    {
+        return new self(
+            $this->id,
+            $this->userId,
+            $this->title,
+            $this->sourceUrl,
+            $this->description,
+            $status,
+            $appliedAt,
+            $this->createdAt,
+            $updatedAt
+        );
+    }
+}

--- a/src/Applications/JobApplicationRepository.php
+++ b/src/Applications/JobApplicationRepository.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Applications;
+
+use DateTimeImmutable;
+use PDO;
+use RuntimeException;
+
+class JobApplicationRepository
+{
+    /** @var PDO */
+    private $pdo;
+
+    /**
+     * Construct the object with its required dependencies.
+     *
+     * This ensures collaborating services are available for subsequent method calls.
+     */
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+        $this->ensureSchema();
+    }
+
+    /**
+     * Handle the create operation.
+     *
+     * Documenting this helper clarifies its role within the wider workflow.
+     */
+    public function create(int $userId, string $title, ?string $sourceUrl, string $description): JobApplication
+    {
+        $now = new DateTimeImmutable('now');
+        $createdAt = $now->format('Y-m-d H:i:s');
+
+        $statement = $this->pdo->prepare(
+            'INSERT INTO job_applications (user_id, title, source_url, description, status, applied_at, created_at, updated_at)
+             VALUES (:user_id, :title, :source_url, :description, :status, :applied_at, :created_at, :updated_at)'
+        );
+
+        $statement->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        $statement->bindValue(':title', $title);
+
+        if ($sourceUrl === null) {
+            $statement->bindValue(':source_url', null, PDO::PARAM_NULL);
+        } else {
+            $statement->bindValue(':source_url', $sourceUrl);
+        }
+
+        $statement->bindValue(':description', $description);
+        $statement->bindValue(':status', 'outstanding');
+        $statement->bindValue(':applied_at', null, PDO::PARAM_NULL);
+        $statement->bindValue(':created_at', $createdAt);
+        $statement->bindValue(':updated_at', $createdAt);
+
+        $statement->execute();
+
+        $id = (int) $this->pdo->lastInsertId();
+
+        return new JobApplication(
+            $id,
+            $userId,
+            $title,
+            $sourceUrl,
+            $description,
+            'outstanding',
+            null,
+            new DateTimeImmutable($createdAt),
+            new DateTimeImmutable($createdAt)
+        );
+    }
+
+    /**
+     * Handle the list for user and status workflow.
+     *
+     * This helper keeps the list operation centralised for clarity and reuse.
+     * @return JobApplication[]
+     */
+    public function listForUserAndStatus(int $userId, string $status, ?int $limit = null): array
+    {
+        $sql = 'SELECT * FROM job_applications WHERE user_id = :user_id AND status = :status ORDER BY created_at DESC';
+
+        if ($limit !== null) {
+            $sql .= ' LIMIT :limit';
+        }
+
+        $statement = $this->pdo->prepare($sql);
+        $statement->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        $statement->bindValue(':status', $status);
+
+        if ($limit !== null) {
+            $statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+        }
+
+        $statement->execute();
+
+        $items = [];
+
+        while ($row = $statement->fetch()) {
+            $items[] = $this->hydrate($row);
+        }
+
+        return $items;
+    }
+
+    /**
+     * Handle the count for user and status workflow.
+     *
+     * The helper keeps counting logic in one place to avoid duplication.
+     */
+    public function countForUserAndStatus(int $userId, string $status): int
+    {
+        $statement = $this->pdo->prepare('SELECT COUNT(*) FROM job_applications WHERE user_id = :user_id AND status = :status');
+        $statement->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        $statement->bindValue(':status', $status);
+        $statement->execute();
+
+        return (int) $statement->fetchColumn();
+    }
+
+    /**
+     * Handle the find for user operation.
+     *
+     * Documenting this helper clarifies its role within the wider workflow.
+     */
+    public function findForUser(int $userId, int $applicationId): ?JobApplication
+    {
+        $statement = $this->pdo->prepare('SELECT * FROM job_applications WHERE id = :id AND user_id = :user_id LIMIT 1');
+        $statement->bindValue(':id', $applicationId, PDO::PARAM_INT);
+        $statement->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        $statement->execute();
+
+        $row = $statement->fetch();
+
+        if ($row === false) {
+            return null;
+        }
+
+        return $this->hydrate($row);
+    }
+
+    /**
+     * Handle the update status operation.
+     *
+     * The helper keeps state transitions consistent across the service layer.
+     */
+    public function updateStatus(JobApplication $application, string $status): JobApplication
+    {
+        $now = new DateTimeImmutable('now');
+        $appliedAt = $status === 'applied' ? $now : null;
+
+        $statement = $this->pdo->prepare(
+            'UPDATE job_applications
+             SET status = :status, applied_at = :applied_at, updated_at = :updated_at
+             WHERE id = :id AND user_id = :user_id'
+        );
+
+        $statement->bindValue(':status', $status);
+        if ($appliedAt !== null) {
+            $statement->bindValue(':applied_at', $appliedAt->format('Y-m-d H:i:s'));
+        } else {
+            $statement->bindValue(':applied_at', null, PDO::PARAM_NULL);
+        }
+        $statement->bindValue(':updated_at', $now->format('Y-m-d H:i:s'));
+        $statement->bindValue(':id', (int) $application->id(), PDO::PARAM_INT);
+        $statement->bindValue(':user_id', $application->userId(), PDO::PARAM_INT);
+
+        $statement->execute();
+
+        if ($statement->rowCount() === 0) {
+            throw new RuntimeException('No job application was updated.');
+        }
+
+        return $application->withStatus($status, $appliedAt, $now);
+    }
+
+    /**
+     * Handle the ensure schema operation.
+     *
+     * This helper keeps schema bootstrapping predictable across environments.
+     */
+    private function ensureSchema(): void
+    {
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'mysql') {
+            $sql = <<<SQL
+            CREATE TABLE IF NOT EXISTS job_applications (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                user_id BIGINT UNSIGNED NOT NULL,
+                title VARCHAR(255) NOT NULL DEFAULT '',
+                source_url TEXT NULL,
+                description LONGTEXT NOT NULL,
+                status VARCHAR(32) NOT NULL DEFAULT 'outstanding',
+                applied_at DATETIME NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                CONSTRAINT fk_job_applications_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+                INDEX idx_job_applications_user_status (user_id, status),
+                INDEX idx_job_applications_user_created (user_id, created_at)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+            SQL;
+
+            $this->pdo->exec($sql);
+
+            return;
+        }
+
+        $sql = <<<SQL
+        CREATE TABLE IF NOT EXISTS job_applications (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            title TEXT NOT NULL DEFAULT '',
+            source_url TEXT NULL,
+            description TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'outstanding',
+            applied_at TEXT NULL,
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        SQL;
+
+        $this->pdo->exec($sql);
+
+        $this->pdo->exec('CREATE INDEX IF NOT EXISTS idx_job_applications_user_status ON job_applications (user_id, status)');
+        $this->pdo->exec('CREATE INDEX IF NOT EXISTS idx_job_applications_user_created ON job_applications (user_id, created_at)');
+    }
+
+    /**
+     * Handle the hydrate workflow.
+     *
+     * This helper keeps model hydration logic consistent for reuse.
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(array $row): JobApplication
+    {
+        $appliedAt = null;
+
+        if (!empty($row['applied_at'])) {
+            $appliedAt = new DateTimeImmutable((string) $row['applied_at']);
+        }
+
+        return new JobApplication(
+            isset($row['id']) ? (int) $row['id'] : null,
+            (int) $row['user_id'],
+            (string) ($row['title'] ?? ''),
+            array_key_exists('source_url', $row) && $row['source_url'] !== null ? (string) $row['source_url'] : null,
+            (string) $row['description'],
+            (string) $row['status'],
+            $appliedAt,
+            new DateTimeImmutable((string) $row['created_at']),
+            new DateTimeImmutable((string) $row['updated_at'])
+        );
+    }
+}

--- a/src/Applications/JobApplicationService.php
+++ b/src/Applications/JobApplicationService.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Applications;
+
+use RuntimeException;
+
+class JobApplicationService
+{
+    /** @var JobApplicationRepository */
+    private $repository;
+
+    /**
+     * Construct the object with its required dependencies.
+     *
+     * This ensures collaborating services are available for subsequent method calls.
+     */
+    public function __construct(JobApplicationRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * Handle the create from submission workflow.
+     *
+     * This helper centralises validation and persistence for new applications.
+     * @param array<string, mixed>|null $input
+     * @return array{application: ?JobApplication, errors: array<int, string>}
+     */
+    public function createFromSubmission(int $userId, ?array $input): array
+    {
+        $title = '';
+        $sourceUrl = '';
+        $description = '';
+        $errors = [];
+
+        if (is_array($input)) {
+            $title = isset($input['title']) ? trim((string) $input['title']) : '';
+            $sourceUrl = isset($input['source_url']) ? trim((string) $input['source_url']) : '';
+            $description = isset($input['description']) ? trim((string) $input['description']) : '';
+        }
+
+        if ($description === '') {
+            $errors[] = 'Paste the job description text before saving the record.';
+        }
+
+        if ($sourceUrl !== '' && filter_var($sourceUrl, FILTER_VALIDATE_URL) === false) {
+            $errors[] = 'Provide a valid URL so the job posting can be revisited later.';
+        }
+
+        if ($errors !== []) {
+            return [
+                'application' => null,
+                'errors' => $errors,
+            ];
+        }
+
+        $title = $title === '' ? 'Untitled application' : $title;
+        $storedUrl = $sourceUrl === '' ? null : $sourceUrl;
+
+        $application = $this->repository->create($userId, $title, $storedUrl, $description);
+
+        return [
+            'application' => $application,
+            'errors' => [],
+        ];
+    }
+
+    /**
+     * Handle the status transition workflow.
+     *
+     * This helper keeps status updates predictable and access-controlled.
+     */
+    public function transitionStatus(int $userId, int $applicationId, string $status): JobApplication
+    {
+        $normalisedStatus = in_array($status, ['applied', 'outstanding'], true) ? $status : 'outstanding';
+        $application = $this->repository->findForUser($userId, $applicationId);
+
+        if ($application === null) {
+            throw new RuntimeException('The requested job application could not be found.');
+        }
+
+        return $this->repository->updateStatus($application, $normalisedStatus);
+    }
+}

--- a/src/Controllers/DocumentController.php
+++ b/src/Controllers/DocumentController.php
@@ -183,6 +183,7 @@ final class DocumentController
         $links = [
             'dashboard' => ['href' => '/', 'label' => 'Dashboard'],
             'documents' => ['href' => '/documents', 'label' => 'Documents'],
+            'applications' => ['href' => '/applications', 'label' => 'Applications'],
             'usage' => ['href' => '/usage', 'label' => 'Usage'],
             'retention' => ['href' => '/retention', 'label' => 'Retention'],
         ];

--- a/src/Controllers/JobApplicationController.php
+++ b/src/Controllers/JobApplicationController.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controllers;
+
+use App\Applications\JobApplicationRepository;
+use App\Applications\JobApplicationService;
+use App\Views\Renderer;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
+
+final class JobApplicationController
+{
+    /** @var Renderer */
+    private $renderer;
+
+    /** @var JobApplicationRepository */
+    private $repository;
+
+    /** @var JobApplicationService */
+    private $service;
+
+    /**
+     * Construct the object with its required dependencies.
+     *
+     * This ensures collaborating services are available for subsequent method calls.
+     */
+    public function __construct(
+        Renderer $renderer,
+        JobApplicationRepository $repository,
+        JobApplicationService $service
+    ) {
+        $this->renderer = $renderer;
+        $this->repository = $repository;
+        $this->service = $service;
+    }
+
+    /**
+     * Display the job application tracker overview.
+     *
+     * Keeping listing concerns together ensures consistent rendering of overview screens.
+     */
+    public function index(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $user = $request->getAttribute('user');
+
+        if ($user === null) {
+            return $response->withHeader('Location', '/auth/login')->withStatus(302);
+        }
+
+        $userId = (int) $user['user_id'];
+        $statusMessage = $request->getQueryParams()['status'] ?? null;
+
+        return $this->renderer->render($response, 'applications', [
+            'title' => 'Job tracker',
+            'subtitle' => 'Capture postings, track applications, and mark outcomes.',
+            'fullWidth' => true,
+            'navLinks' => $this->navLinks('applications'),
+            'outstanding' => $this->mapApplications($this->repository->listForUserAndStatus($userId, 'outstanding')),
+            'applied' => $this->mapApplications($this->repository->listForUserAndStatus($userId, 'applied')),
+            'errors' => [],
+            'status' => $statusMessage,
+            'form' => [
+                'title' => '',
+                'source_url' => '',
+                'description' => '',
+            ],
+        ]);
+    }
+
+    /**
+     * Handle the store workflow for text-based job descriptions.
+     *
+     * Centralising validation and persistence keeps the workflow predictable.
+     */
+    public function store(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $user = $request->getAttribute('user');
+
+        if ($user === null) {
+            return $response->withHeader('Location', '/auth/login')->withStatus(302);
+        }
+
+        $userId = (int) $user['user_id'];
+        $data = $request->getParsedBody();
+        $formInput = is_array($data) ? $data : [];
+
+        $result = $this->service->createFromSubmission($userId, $formInput);
+
+        if ($result['errors'] === []) {
+            return $response
+                ->withHeader('Location', '/applications?status=Job+application+saved')
+                ->withStatus(302);
+        }
+
+        return $this->renderer->render($response->withStatus(422), 'applications', [
+            'title' => 'Job tracker',
+            'subtitle' => 'Capture postings, track applications, and mark outcomes.',
+            'fullWidth' => true,
+            'navLinks' => $this->navLinks('applications'),
+            'outstanding' => $this->mapApplications($this->repository->listForUserAndStatus($userId, 'outstanding')),
+            'applied' => $this->mapApplications($this->repository->listForUserAndStatus($userId, 'applied')),
+            'errors' => $result['errors'],
+            'status' => null,
+            'form' => [
+                'title' => isset($formInput['title']) ? (string) $formInput['title'] : '',
+                'source_url' => isset($formInput['source_url']) ? (string) $formInput['source_url'] : '',
+                'description' => isset($formInput['description']) ? (string) $formInput['description'] : '',
+            ],
+        ]);
+    }
+
+    /**
+     * Handle status transitions for saved applications.
+     *
+     * This ensures the tracker reflects the latest actions taken by the user.
+     * @param array<string, string> $args
+     */
+    public function updateStatus(ServerRequestInterface $request, ResponseInterface $response, array $args): ResponseInterface
+    {
+        $user = $request->getAttribute('user');
+
+        if ($user === null) {
+            return $response->withHeader('Location', '/auth/login')->withStatus(302);
+        }
+
+        $userId = (int) $user['user_id'];
+        $applicationId = isset($args['id']) ? (int) $args['id'] : 0;
+        $data = $request->getParsedBody();
+        $desiredStatus = 'applied';
+
+        if (is_array($data) && isset($data['status'])) {
+            $desiredStatus = (string) $data['status'];
+        }
+
+        try {
+            $updated = $this->service->transitionStatus($userId, $applicationId, $desiredStatus);
+        } catch (RuntimeException $exception) {
+            return $response
+                ->withHeader('Location', '/applications?status=' . rawurlencode($exception->getMessage()))
+                ->withStatus(302);
+        }
+
+        $message = $updated->status() === 'applied'
+            ? 'Marked application as submitted.'
+            : 'Marked application as outstanding.';
+
+        return $response
+            ->withHeader('Location', '/applications?status=' . rawurlencode($message))
+            ->withStatus(302);
+    }
+
+    /**
+     * Handle the mapping workflow.
+     *
+     * This helper keeps response shaping consistent across controller actions.
+     * @param array<int, \App\Applications\JobApplication> $applications
+     * @return array<int, array<string, mixed>>
+     */
+    private function mapApplications(array $applications): array
+    {
+        return array_map(static function ($application) {
+            $preview = mb_substr($application->description(), 0, 220);
+
+            if (mb_strlen($application->description()) > 220) {
+                $preview .= '…';
+            }
+
+            return [
+                'id' => $application->id(),
+                'title' => $application->title(),
+                'source_url' => $application->sourceUrl(),
+                'status' => $application->status(),
+                'applied_at' => $application->appliedAt() ? $application->appliedAt()->format('Y-m-d H:i') : null,
+                'created_at' => $application->createdAt()->format('Y-m-d H:i'),
+                'description_preview' => $preview,
+            ];
+        }, $applications);
+    }
+
+    /**
+     * Handle the nav links workflow.
+     *
+     * This helper keeps navigation data aligned across authenticated screens.
+     * @return array<int, array{href: string, label: string, current: bool}>
+     */
+    private function navLinks(string $current): array
+    {
+        $links = [
+            'dashboard' => ['href' => '/', 'label' => 'Dashboard'],
+            'documents' => ['href' => '/documents', 'label' => 'Documents'],
+            'applications' => ['href' => '/applications', 'label' => 'Applications'],
+            'usage' => ['href' => '/usage', 'label' => 'Usage'],
+            'retention' => ['href' => '/retention', 'label' => 'Retention'],
+        ];
+
+        return array_map(static function ($key, $link) use ($current) {
+            return [
+                'href' => $link['href'],
+                'label' => $link['label'],
+                'current' => $key === $current,
+            ];
+        }, array_keys($links), $links);
+    }
+}

--- a/src/Controllers/RetentionController.php
+++ b/src/Controllers/RetentionController.php
@@ -145,6 +145,7 @@ class RetentionController
         $links = [
             'dashboard' => ['href' => '/', 'label' => 'Dashboard'],
             'documents' => ['href' => '/documents', 'label' => 'Documents'],
+            'applications' => ['href' => '/applications', 'label' => 'Applications'],
             'usage' => ['href' => '/usage', 'label' => 'Usage'],
             'retention' => ['href' => '/retention', 'label' => 'Retention'],
         ];

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -9,6 +9,7 @@ use App\Controllers\DocumentController;
 use App\Controllers\GenerationController;
 use App\Controllers\GenerationDownloadController;
 use App\Controllers\HomeController;
+use App\Controllers\JobApplicationController;
 use App\Controllers\RetentionController;
 use App\Controllers\UsageController;
 use App\Prompts\PromptLibrary;
@@ -45,6 +46,18 @@ class Routes
 
         $app->post('/documents/upload', function (Request $request, Response $response) use ($container) {
             return $container->get(DocumentController::class)->upload($request, $response);
+        });
+
+        $app->get('/applications', function (Request $request, Response $response) use ($container) {
+            return $container->get(JobApplicationController::class)->index($request, $response);
+        });
+
+        $app->post('/applications', function (Request $request, Response $response) use ($container) {
+            return $container->get(JobApplicationController::class)->store($request, $response);
+        });
+
+        $app->post('/applications/{id}/status', function (Request $request, Response $response, array $args) use ($container) {
+            return $container->get(JobApplicationController::class)->updateStatus($request, $response, $args);
         });
 
 


### PR DESCRIPTION
## Summary
- add a job_applications table with repository and service support for free-text postings
- introduce a job tracker UI to capture descriptions, URLs, and mark applications applied or outstanding
- surface outstanding application counts on the dashboard and update navigation to link to the tracker

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d69f76a358832eab6a052c3e1cebc3