### PR TITLE
Replace temperature controls with thinking time slider

### DIFF
--- a/database/migrations/20240326000000_initial.php
+++ b/database/migrations/20240326000000_initial.php
@@ -56,7 +56,7 @@ return [
             job_document_id BIGINT UNSIGNED NOT NULL,
             cv_document_id BIGINT UNSIGNED NOT NULL,
             model VARCHAR(128) NOT NULL,
-            temperature DECIMAL(4,2) NOT NULL DEFAULT 0.20,
+            thinking_time TINYINT UNSIGNED NOT NULL DEFAULT 30,
             status VARCHAR(32) NOT NULL DEFAULT 'queued',
             progress_percent TINYINT UNSIGNED NOT NULL DEFAULT 0,
             cost_pence BIGINT UNSIGNED NOT NULL DEFAULT 0,

--- a/resources/views/dashboard.php
+++ b/resources/views/dashboard.php
@@ -177,11 +177,11 @@ $wizardJson = htmlspecialchars(
                     </div>
                     <div class="space-y-2">
                         <div class="flex items-center justify-between text-sm text-slate-200">
-                            <span>Creativity (temperature)</span>
-                            <span class="font-semibold text-indigo-200" x-text="form.temperature.toFixed(1)"></span>
+                            <span>Thinking time (seconds)</span>
+                            <span class="font-semibold text-indigo-200" x-text="form.thinking_time + 's'"></span>
                         </div>
-                        <input type="range" min="0" max="1" step="0.1" x-model.number="form.temperature" class="w-full accent-indigo-500">
-                        <p class="text-xs text-slate-400">Higher values encourage more varied phrasing. Keep between 0.0 and 1.0 for grounded drafts.</p>
+                        <input type="range" min="5" max="60" step="5" x-model.number="form.thinking_time" class="w-full accent-indigo-500">
+                        <p class="text-xs text-slate-400">Give GPT-5 a little more time for deeper reasoning. Thirty seconds is a balanced default.</p>
                     </div>
                 </div>
 
@@ -202,8 +202,8 @@ $wizardJson = htmlspecialchars(
                                 <dd class="font-medium text-right" x-text="displayModelLabel"></dd>
                             </div>
                             <div class="flex items-start justify-between gap-4">
-                                <dt class="text-slate-400">Temperature</dt>
-                                <dd class="font-medium text-right" x-text="form.temperature.toFixed(1)"></dd>
+                                <dt class="text-slate-400">Thinking time</dt>
+                                <dd class="font-medium text-right" x-text="form.thinking_time + 's'"></dd>
                             </div>
                         </dl>
                     </div>
@@ -262,7 +262,7 @@ $wizardJson = htmlspecialchars(
                         <th class="px-4 py-3">Job description</th>
                         <th class="px-4 py-3">CV</th>
                         <th class="px-4 py-3">Model</th>
-                        <th class="px-4 py-3">Temperature</th>
+                        <th class="px-4 py-3">Thinking time</th>
                         <th class="px-4 py-3">Status</th>
                     </tr>
                 </thead>
@@ -280,7 +280,7 @@ $wizardJson = htmlspecialchars(
                             <td class="px-4 py-4 font-medium text-slate-200" x-text="item.job_document.filename"></td>
                             <td class="px-4 py-4" x-text="item.cv_document.filename"></td>
                             <td class="px-4 py-4" x-text="item.model"></td>
-                            <td class="px-4 py-4" x-text="item.temperature.toFixed(1)"></td>
+                            <td class="px-4 py-4" x-text="item.thinking_time + 's'"></td>
                             <td class="px-4 py-4">
                                 <span class="inline-flex items-center rounded-full bg-slate-800 px-3 py-1 text-xs font-semibold uppercase tracking-wide" :class="item.status === 'queued' ? 'text-amber-200 bg-amber-500/10 border border-amber-400/30' : 'text-emerald-200 bg-emerald-500/10 border border-emerald-400/30'" x-text="item.status"></span>
                             </td>
@@ -299,7 +299,7 @@ $wizardJson = htmlspecialchars(
             steps: [
                 { index: 1, title: 'Choose job description', description: 'Select the role you want to tailor for.', helper: 'Pick the job posting that best matches the next application.' },
                 { index: 2, title: 'Choose CV', description: 'Decide which base CV to tailor.', helper: 'Use the CV with the strongest baseline for this role.' },
-                { index: 3, title: 'Set parameters', description: 'Adjust the model and creativity.', helper: 'Balance quality and speed with the right model and temperature.' },
+                { index: 3, title: 'Set parameters', description: 'Adjust the model and thinking time.', helper: 'Choose the best model and allow enough thinking time for complex roles.' },
                 { index: 4, title: 'Confirm & queue', description: 'Review before submitting.', helper: 'Double-check your selections before queuing the request.' },
             ],
             jobDocuments: config.jobDocuments ?? [],
@@ -310,7 +310,7 @@ $wizardJson = htmlspecialchars(
                 job_document_id: null,
                 cv_document_id: null,
                 model: (config.models?.[0]?.value) ?? '',
-                temperature: 0.2,
+                thinking_time: 30,
             },
             isSubmitting: false,
             error: '',
@@ -326,15 +326,15 @@ $wizardJson = htmlspecialchars(
                     return this.form.cv_document_id !== null;
                 }
                 if (this.step === 3) {
-                    return this.form.model !== '' && this.temperatureIsValid;
+                    return this.form.model !== '' && this.thinkingTimeIsValid;
                 }
                 return true;
             },
             get canSubmit() {
-                return this.selectedJobDocument && this.selectedCvDocument && this.temperatureIsValid;
+                return this.selectedJobDocument && this.selectedCvDocument && this.thinkingTimeIsValid;
             },
-            get temperatureIsValid() {
-                return typeof this.form.temperature === 'number' && this.form.temperature >= 0 && this.form.temperature <= 1;
+            get thinkingTimeIsValid() {
+                return Number.isFinite(this.form.thinking_time) && this.form.thinking_time >= 5 && this.form.thinking_time <= 60;
             },
             get selectedJobDocument() {
                 return this.jobDocuments.find((doc) => doc.id === this.form.job_document_id) ?? null;
@@ -378,7 +378,7 @@ $wizardJson = htmlspecialchars(
                             job_document_id: this.form.job_document_id,
                             cv_document_id: this.form.cv_document_id,
                             model: this.form.model,
-                            temperature: this.form.temperature,
+                            thinking_time: this.form.thinking_time,
                         }),
                     });
 
@@ -391,6 +391,7 @@ $wizardJson = htmlspecialchars(
 
                     this.generations.unshift({
                         ...data,
+                        thinking_time: data.thinking_time ?? this.form.thinking_time,
                         job_document: this.selectedJobDocument,
                         cv_document: this.selectedCvDocument,
                     });

--- a/src/AI/OpenAIProvider.php
+++ b/src/AI/OpenAIProvider.php
@@ -123,7 +123,6 @@ final class OpenAIProvider
         $payload = [
             'model' => $this->modelPlan,
             'messages' => $messages,
-            'temperature' => 0.2,
             'max_tokens' => $this->maxTokens,
             'response_format' => ['type' => 'json_object'],
         ];
@@ -169,7 +168,6 @@ final class OpenAIProvider
         $payload = [
             'model' => $this->modelDraft,
             'messages' => $messages,
-            'temperature' => 0.6,
             'max_tokens' => $this->maxTokens,
         ];
 

--- a/src/Generations/Generation.php
+++ b/src/Generations/Generation.php
@@ -23,8 +23,8 @@ final class Generation
     /** @var string */
     private $model;
 
-    /** @var float */
-    private $temperature;
+    /** @var int */
+    private $thinkingTime;
 
     /** @var string */
     private $status;
@@ -43,7 +43,7 @@ final class Generation
         int $jobDocumentId,
         int $cvDocumentId,
         string $model,
-        float $temperature,
+        int $thinkingTime,
         string $status,
         DateTimeImmutable $createdAt
     ) {
@@ -52,7 +52,7 @@ final class Generation
         $this->jobDocumentId = $jobDocumentId;
         $this->cvDocumentId = $cvDocumentId;
         $this->model = $model;
-        $this->temperature = $temperature;
+        $this->thinkingTime = $thinkingTime;
         $this->status = $status;
         $this->createdAt = $createdAt;
     }
@@ -108,13 +108,13 @@ final class Generation
     }
 
     /**
-     * Handle the temperature operation.
+     * Handle the thinking time operation.
      *
      * Documenting this helper clarifies its role within the wider workflow.
      */
-    public function temperature(): float
+    public function thinkingTime(): int
     {
-        return $this->temperature;
+        return $this->thinkingTime;
     }
 
     /**

--- a/src/Generations/GenerationRepository.php
+++ b/src/Generations/GenerationRepository.php
@@ -27,13 +27,13 @@ final class GenerationRepository
      *
      * Documenting this helper clarifies its role within the wider workflow.
      */
-    public function create(int $userId, int $jobDocumentId, int $cvDocumentId, string $model, float $temperature): array
+    public function create(int $userId, int $jobDocumentId, int $cvDocumentId, string $model, int $thinkingTime): array
     {
         $now = (new DateTimeImmutable())->format('Y-m-d H:i:s');
 
         $statement = $this->pdo->prepare(
-            'INSERT INTO generations (user_id, job_document_id, cv_document_id, model, temperature, status, created_at, updated_at)
-             VALUES (:user_id, :job_document_id, :cv_document_id, :model, :temperature, :status, :created_at, :updated_at)'
+            'INSERT INTO generations (user_id, job_document_id, cv_document_id, model, thinking_time, status, created_at, updated_at)
+             VALUES (:user_id, :job_document_id, :cv_document_id, :model, :thinking_time, :status, :created_at, :updated_at)'
         );
 
         $statement->execute([
@@ -41,7 +41,7 @@ final class GenerationRepository
             ':job_document_id' => $jobDocumentId,
             ':cv_document_id' => $cvDocumentId,
             ':model' => $model,
-            ':temperature' => $temperature,
+            ':thinking_time' => $thinkingTime,
             ':status' => 'queued',
             ':created_at' => $now,
             ':updated_at' => $now,
@@ -60,7 +60,7 @@ final class GenerationRepository
     public function findForUser(int $userId, int $generationId): ?array
     {
         $statement = $this->pdo->prepare(
-            'SELECT g.id, g.model, g.temperature, g.status, g.created_at,
+            'SELECT g.id, g.model, g.thinking_time, g.status, g.created_at,
                     jd.id AS job_document_id, jd.filename AS job_filename,
                     cv.id AS cv_document_id, cv.filename AS cv_filename
              FROM generations g
@@ -89,7 +89,7 @@ final class GenerationRepository
     public function listForUser(int $userId): array
     {
         $statement = $this->pdo->prepare(
-            'SELECT g.id, g.model, g.temperature, g.status, g.created_at,
+            'SELECT g.id, g.model, g.thinking_time, g.status, g.created_at,
                     jd.id AS job_document_id, jd.filename AS job_filename,
                     cv.id AS cv_document_id, cv.filename AS cv_filename
              FROM generations g
@@ -122,7 +122,7 @@ final class GenerationRepository
         return [
             'id' => (int) $row['id'],
             'model' => (string) $row['model'],
-            'temperature' => (float) $row['temperature'],
+            'thinking_time' => (int) $row['thinking_time'],
             'status' => (string) $row['status'],
             'created_at' => (string) $row['created_at'],
             'job_document' => [


### PR DESCRIPTION
## Summary
- replace the generation temperature parameter with a thinking time value across controllers, repositories, and entities
- update schema management to store `thinking_time` and remove the obsolete `temperature` column
- refresh the dashboard wizard UI to expose a thinking-time slider and drop the temperature option while aligning OpenAI payloads

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d6a3a3b66c832e8da6a623e6ad8db0