### PR TITLE
Add interactive wizard preview to landing page

### DIFF
--- a/public/assets/css/theme.css
+++ b/public/assets/css/theme.css
@@ -207,6 +207,17 @@ header p {
   box-shadow: 0 32px 60px -28px rgba(79, 70, 229, 0.6);
 }
 
+.gradient-button--compact {
+  font-size: 0.95rem;
+  padding: 0.75rem 1.4rem;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.gradient-button--compact:disabled {
+  box-shadow: none;
+}
+
 .gradient-button:focus-visible {
   outline: 3px solid var(--focus-ring);
   outline-offset: 3px;
@@ -261,6 +272,205 @@ header p {
 
 :root[data-theme='dark'] .surface-card {
   background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(2, 8, 23, 0.78));
+}
+
+.wizard-preview {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.wizard-preview__header h3 {
+  margin: 0.4rem 0 0.65rem;
+  font-size: 1.6rem;
+  font-family: var(--font-display);
+  color: var(--color-heading);
+}
+
+.wizard-preview__header p {
+  margin: 0;
+  color: var(--color-text-muted);
+  max-width: 56ch;
+}
+
+.wizard-preview__layout {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(220px, 260px) 1fr;
+  align-items: start;
+}
+
+.wizard-preview__steps {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.wizard-preview__step {
+  width: 100%;
+  display: flex;
+  gap: 0.85rem;
+  align-items: flex-start;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(99, 102, 241, 0.22);
+  background: rgba(99, 102, 241, 0.08);
+  padding: 0.85rem 1rem;
+  color: var(--color-text);
+  cursor: pointer;
+  transition: border-color var(--transition-fast) ease, background-color var(--transition-fast) ease, transform var(--transition-fast) ease;
+}
+
+.wizard-preview__step:focus-visible {
+  outline: 3px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+
+.wizard-preview__step:hover {
+  border-color: rgba(99, 102, 241, 0.4);
+  background: rgba(99, 102, 241, 0.14);
+  transform: translateX(2px);
+}
+
+.wizard-preview__step.is-active {
+  border-color: rgba(20, 184, 166, 0.55);
+  background: linear-gradient(135deg, rgba(129, 140, 248, 0.22), rgba(45, 212, 191, 0.18));
+  box-shadow: 0 16px 30px -20px rgba(79, 70, 229, 0.45);
+}
+
+.wizard-preview__step-number {
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-accent) 100%);
+  color: var(--color-primary-contrast);
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.wizard-preview__step-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-start;
+}
+
+.wizard-preview__step-content strong {
+  font-size: 0.95rem;
+  color: var(--color-heading);
+}
+
+.wizard-preview__step-content small {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.wizard-preview__panels {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.wizard-preview__panel {
+  display: grid;
+  gap: 1rem;
+  border-radius: calc(var(--radius-lg) + 0.35rem);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(255, 255, 255, 0.82);
+  padding: 1.4rem 1.6rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+}
+
+:root[data-theme='dark'] .wizard-preview__panel {
+  background: rgba(15, 23, 42, 0.82);
+  border-color: rgba(71, 85, 105, 0.5);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.18);
+}
+
+.wizard-preview__panel h4 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: var(--color-heading);
+}
+
+.wizard-preview__panel p {
+  margin: 0;
+  color: var(--color-text-muted);
+  line-height: 1.6;
+}
+
+.wizard-preview__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.wizard-preview__list li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: var(--radius-lg);
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.wizard-preview__list-title {
+  font-weight: 600;
+  color: var(--color-heading);
+}
+
+.wizard-preview__list-meta {
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.wizard-preview__options {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: var(--radius-lg);
+  background: rgba(20, 184, 166, 0.08);
+}
+
+.wizard-preview__option-label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.wizard-preview__option-value {
+  font-size: 0.95rem;
+  color: var(--color-heading);
+}
+
+.wizard-preview__summary {
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.wizard-preview__summary div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.92rem;
+}
+
+.wizard-preview__summary dt {
+  color: var(--color-text-muted);
+}
+
+.wizard-preview__summary dd {
+  margin: 0;
+  font-weight: 600;
+  color: var(--color-heading);
 }
 
 .card-heading {
@@ -664,6 +874,14 @@ footer small {
     align-items: flex-start;
   }
 
+  .wizard-preview__layout {
+    grid-template-columns: 1fr;
+  }
+
+  .wizard-preview__steps {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
   .wizard-stepper {
     gap: 1rem;
   }
@@ -681,6 +899,19 @@ footer small {
   main {
     width: min(95%, calc(100% - 2rem));
     padding-bottom: 4rem;
+  }
+
+  .wizard-preview__steps {
+    grid-template-columns: 1fr;
+  }
+
+  .wizard-preview__step {
+    flex-direction: row;
+  }
+
+  .wizard-preview__summary div {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .hero-card {

--- a/resources/views/home.php
+++ b/resources/views/home.php
@@ -74,13 +74,143 @@ if (is_string($generationIdRaw)) {
                         <path d="M13 6l6 6-6 6"></path>
                     </svg>
                 </a>
-                <a class="secondary-link focus-ring" href="#components">
+                <a class="secondary-link focus-ring" href="#wizard">
                     Explore the flow
                     <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
                         <path d="M5 12h14"></path>
                         <path d="M13 6l6 6-6 6"></path>
                     </svg>
                 </a>
+            </div>
+        </div>
+    </section>
+
+    <section class="surface-card wizard-preview" id="wizard" data-wizard-preview>
+        <header class="wizard-preview__header">
+            <div>
+                <span class="badge">Tailoring workflow</span>
+                <h3>How the tailored CV wizard works</h3>
+                <p>
+                    Step through the same guided experience you will use after signing in.
+                    Each stage focuses on pairing the right documents with the right AI guidance.
+                </p>
+            </div>
+        </header>
+        <div class="wizard-preview__layout">
+            <ol class="wizard-preview__steps" aria-label="Wizard steps">
+                <li>
+                    <button type="button" class="wizard-preview__step" data-step-button="1" aria-pressed="false">
+                        <span class="wizard-preview__step-number">1</span>
+                        <span class="wizard-preview__step-content">
+                            <strong>Choose job description</strong>
+                            <small>Select the role you are targeting next.</small>
+                        </span>
+                    </button>
+                </li>
+                <li>
+                    <button type="button" class="wizard-preview__step" data-step-button="2" aria-pressed="false">
+                        <span class="wizard-preview__step-number">2</span>
+                        <span class="wizard-preview__step-content">
+                            <strong>Select the best CV</strong>
+                            <small>Pick the baseline CV that fits the posting.</small>
+                        </span>
+                    </button>
+                </li>
+                <li>
+                    <button type="button" class="wizard-preview__step" data-step-button="3" aria-pressed="false">
+                        <span class="wizard-preview__step-number">3</span>
+                        <span class="wizard-preview__step-content">
+                            <strong>Configure generation</strong>
+                            <small>Set the model, tone, and thinking time.</small>
+                        </span>
+                    </button>
+                </li>
+                <li>
+                    <button type="button" class="wizard-preview__step" data-step-button="4" aria-pressed="false">
+                        <span class="wizard-preview__step-number">4</span>
+                        <span class="wizard-preview__step-content">
+                            <strong>Confirm &amp; queue</strong>
+                            <small>Review selections before sending.</small>
+                        </span>
+                    </button>
+                </li>
+            </ol>
+            <div class="wizard-preview__panels">
+                <article class="wizard-preview__panel" data-step-panel="1" aria-live="polite">
+                    <h4>Choose job description</h4>
+                    <p>
+                        Bring the job posting into the workspace so it is easy to reference later.
+                        The wizard highlights saved descriptions with dates and titles, keeping the choice straightforward.
+                    </p>
+                    <ul class="wizard-preview__list" aria-label="Sample job descriptions">
+                        <li>
+                            <span class="wizard-preview__list-title">Programme Manager — VodafoneThree</span>
+                            <span class="wizard-preview__list-meta">Added 3 days ago</span>
+                        </li>
+                        <li>
+                            <span class="wizard-preview__list-title">AI Operations Lead — Horizon Labs</span>
+                            <span class="wizard-preview__list-meta">Added 1 week ago</span>
+                        </li>
+                    </ul>
+                </article>
+                <article class="wizard-preview__panel" data-step-panel="2" aria-live="polite" hidden>
+                    <h4>Select the best CV</h4>
+                    <p>
+                        Switch between previously uploaded CVs to align tone and achievements with the role.
+                        The wizard confirms which version you are tailoring before moving on.
+                    </p>
+                    <ul class="wizard-preview__list" aria-label="Sample CVs">
+                        <li>
+                            <span class="wizard-preview__list-title">Delivery Manager · UK Market</span>
+                            <span class="wizard-preview__list-meta">Updated 2 weeks ago</span>
+                        </li>
+                        <li>
+                            <span class="wizard-preview__list-title">Product Strategy CV · EMEA</span>
+                            <span class="wizard-preview__list-meta">Updated 1 month ago</span>
+                        </li>
+                    </ul>
+                </article>
+                <article class="wizard-preview__panel" data-step-panel="3" aria-live="polite" hidden>
+                    <h4>Configure generation</h4>
+                    <p>
+                        Fine-tune how the AI responds by choosing the model and allowing extra thinking time when the role is complex.
+                        Defaults are balanced, yet every option is surfaced to help you tailor confidently.
+                    </p>
+                    <div class="wizard-preview__options">
+                        <div>
+                            <span class="wizard-preview__option-label">Model</span>
+                            <span class="wizard-preview__option-value">GPT-4o mini · Fast and affordable</span>
+                        </div>
+                        <div>
+                            <span class="wizard-preview__option-label">Thinking time</span>
+                            <span class="wizard-preview__option-value">30 seconds</span>
+                        </div>
+                    </div>
+                </article>
+                <article class="wizard-preview__panel" data-step-panel="4" aria-live="polite" hidden>
+                    <h4>Confirm &amp; queue</h4>
+                    <p>
+                        Review your selections and send the request to the queue.
+                        The workspace tracks status, token usage, and spend while your tailored draft is generated.
+                    </p>
+                    <dl class="wizard-preview__summary">
+                        <div>
+                            <dt>Job description</dt>
+                            <dd>Programme Manager — VodafoneThree</dd>
+                        </div>
+                        <div>
+                            <dt>CV</dt>
+                            <dd>Delivery Manager · UK Market</dd>
+                        </div>
+                        <div>
+                            <dt>Thinking time</dt>
+                            <dd>30 seconds</dd>
+                        </div>
+                    </dl>
+                    <button type="button" class="gradient-button gradient-button--compact" disabled>
+                        Confirm &amp; queue
+                    </button>
+                </article>
             </div>
         </div>
     </section>
@@ -234,5 +364,79 @@ if (is_string($generationIdRaw)) {
 </main>
 
 <script src="/assets/js/theme.js" defer></script>
+<script>
+    (function () {
+        'use strict';
+
+        /**
+         * Toggle the displayed wizard panel so visitors can explore the workflow.
+         *
+         * The helper wires up step buttons, applies active state styling, and
+         * reveals the corresponding panel while hiding the others.
+         *
+         * @param {HTMLElement} root The root element that wraps the wizard preview UI.
+         */
+        function initialiseWizardPreview(root) {
+            if (!root) {
+                return;
+            }
+
+            var buttons = Array.prototype.slice.call(root.querySelectorAll('[data-step-button]'));
+            var panels = Array.prototype.slice.call(root.querySelectorAll('[data-step-panel]'));
+
+            if (buttons.length === 0 || panels.length === 0) {
+                return;
+            }
+
+            /**
+             * Activate a given wizard step and ensure matching panel visibility.
+             *
+             * Keeping this logic in a dedicated function keeps the event handlers small.
+             *
+             * @param {number} stepNumber The wizard step that should become active.
+             */
+            function activateStep(stepNumber) {
+                buttons.forEach(function (button) {
+                    var isActive = Number(button.getAttribute('data-step-button')) === stepNumber;
+                    button.classList.toggle('is-active', isActive);
+                    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+                });
+
+                panels.forEach(function (panel) {
+                    var matches = Number(panel.getAttribute('data-step-panel')) === stepNumber;
+                    panel.toggleAttribute('hidden', !matches);
+                });
+            }
+
+            buttons.forEach(function (button) {
+                button.addEventListener('click', function () {
+                    var step = Number(button.getAttribute('data-step-button'));
+
+                    if (!isNaN(step)) {
+                        activateStep(step);
+                    }
+                });
+            });
+
+            activateStep(1);
+        }
+
+        /**
+         * Initialise the wizard preview after the DOM is ready.
+         *
+         * This keeps the behaviour working even when the script loads before the markup.
+         */
+        function handleContentLoaded() {
+            var preview = document.querySelector('[data-wizard-preview]');
+            initialiseWizardPreview(preview);
+        }
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', handleContentLoaded);
+        } else {
+            handleContentLoaded();
+        }
+    })();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add an interactive wizard preview section to the public home page so visitors can explore the tailoring flow
- style the new preview, including compact gradient button and responsive layout adjustments in the theme stylesheet
- wire up a lightweight script to toggle the preview steps without requiring the authenticated dashboard

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6ab4219a4832eb775403b48442982