### PR TITLE
Fix SQL syntax error in job application creation

### DIFF
--- a/src/Applications/JobApplicationRepository.php
+++ b/src/Applications/JobApplicationRepository.php
@@ -35,8 +35,8 @@ class JobApplicationRepository
         $createdAt = $now->format('Y-m-d H:i:s');
 
         $statement = $this->pdo->prepare(
-            'INSERT INTO job_applications (user_id, title, source_url, description, status, applied_at, reason_code, created_at, updated_at)'
-             VALUES (:user_id, :title, :source_url, :description, :status, :applied_at, :reason_code, :created_at, :updated_at)'
+            'INSERT INTO job_applications (user_id, title, source_url, description, status, applied_at, reason_code, created_at, updated_at) '
+            . 'VALUES (:user_id, :title, :source_url, :description, :status, :applied_at, :reason_code, :created_at, :updated_at)'
         );
 
         $statement->bindValue(':user_id', $userId, PDO::PARAM_INT);


### PR DESCRIPTION
## Summary
- fix the SQL insert statement in `JobApplicationRepository::create` so it is syntactically valid

## Testing
- php -l src/Applications/JobApplicationRepository.php

------
https://chatgpt.com/codex/tasks/task_e_68d6bc0c16d0832ea0f527b96f4cecc6