### PR TITLE
Fix Tailor wizard step indicator rendering

### DIFF
--- a/resources/views/dashboard.php
+++ b/resources/views/dashboard.php
@@ -150,7 +150,11 @@ $wizardJson = htmlspecialchars(
             <ol class="space-y-4">
                 <template x-for="item in steps" :key="item.index">
                     <li class="flex items-start gap-3" :class="item.index === step ? 'text-white' : 'text-slate-500'">
-                        <span class="flex h-9 w-9 items-center justify-center rounded-full border" :class="item.index === step ? 'border-indigo-400 bg-indigo-500/20 text-indigo-200' : 'border-slate-700'">{{ item.index }}</span>
+                        <span
+                            class="flex h-9 w-9 items-center justify-center rounded-full border"
+                            :class="item.index === step ? 'border-indigo-400 bg-indigo-500/20 text-indigo-200' : 'border-slate-700'"
+                            x-text="item.index"
+                        ></span>
                         <div>
                             <p class="text-sm font-semibold" x-text="item.title"></p>
                             <p class="text-xs text-slate-500" x-text="item.description"></p>


### PR DESCRIPTION
## Summary
- render the Tailor wizard step numbers via Alpine's x-text binding so they appear in the navigation panel

## Testing
- php -l resources/views/dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68d6deaf58dc832e9b51358972214f92