### PR TITLE
Fix CSP hash format for inline Alpine init script

### DIFF
--- a/src/Security/CspConfig.php
+++ b/src/Security/CspConfig.php
@@ -15,6 +15,6 @@ final class CspConfig
      */
     public static function alpineInitHash(): string
     {
-        return 'sha256-' . base64_encode(hash('sha256', self::ALPINE_INIT_SCRIPT, true));
+        return "'sha256-" . base64_encode(hash('sha256', self::ALPINE_INIT_SCRIPT, true)) . "'";
     }
 }


### PR DESCRIPTION
## Summary
- wrap the generated Alpine inline script hash in quotes so Content Security Policy recognizes it as a valid source

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d7b295c56c832eb20540de05a84fc4