### PR TITLE
Fix CSP hash and allow Tailwind runtime

### DIFF
--- a/resources/views/layout.php
+++ b/resources/views/layout.php
@@ -70,6 +70,7 @@ $additionalHead = $additionalHead ?? '';
         };
     </script>
     <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <script><?= CspConfig::ALPINE_INIT_SCRIPT ?></script>
     <link rel="stylesheet" href="/assets/css/app.css">
     <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.13.5/dist/cdn.min.js" defer></script>
     <style>[x-cloak]{display:none!important;}</style>

--- a/src/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Middleware/SecurityHeadersMiddleware.php
@@ -69,6 +69,7 @@ final class SecurityHeadersMiddleware implements MiddlewareInterface
         $scriptSources = [
             "'self'",
             "'unsafe-inline'",
+            "'unsafe-eval'",
             'https://cdn.tailwindcss.com',
             'https://cdn.jsdelivr.net',
             'https://code.highcharts.com',


### PR DESCRIPTION
## Summary
- add the Alpine initialisation helper inline so the existing CSP hash is valid
- allow the Tailwind CDN runtime to execute by permitting unsafe-eval in the script policy

## Testing
- php -l resources/views/layout.php
- php -l src/Middleware/SecurityHeadersMiddleware.php

------
https://chatgpt.com/codex/tasks/task_e_68d7b295c56c832eb20540de05a84fc4