### PR TITLE
Improve dashboard wizard accessibility

### DIFF
--- a/public/assets/js/dashboard.js
+++ b/public/assets/js/dashboard.js
@@ -227,6 +227,63 @@
                     }
                 },
                 /**
+                 * Confirm whether the requested step can be accessed with the current selections.
+                 *
+                 * @param {number} targetStep The step identifier the user wants to open.
+                 * @returns {boolean} True when the step is available for navigation.
+                 */
+                isStepReachable(targetStep) {
+                    const parsedStep = typeof targetStep === 'number'
+                        ? targetStep
+                        : parseInt(targetStep, 10);
+
+                    if (!isFiniteNumber(parsedStep)) {
+                        return false;
+                    }
+
+                    const stepCount = isArray(this.steps) ? this.steps.length : 0;
+
+                    if (parsedStep < 1 || parsedStep > stepCount) {
+                        return false;
+                    }
+
+                    if (parsedStep === 1) {
+                        return true;
+                    }
+
+                    if (this.form.job_document_id === null) {
+                        return false;
+                    }
+
+                    if (parsedStep >= 3 && this.form.cv_document_id === null) {
+                        return false;
+                    }
+
+                    if (parsedStep >= 4 && (this.form.model === '' || !this.thinkingTimeIsValid)) {
+                        return false;
+                    }
+
+                    return true;
+                },
+                /**
+                 * Jump directly to a requested wizard step when prerequisites are satisfied.
+                 *
+                 * @param {number} targetStep The step identifier to make active.
+                 */
+                goToStep(targetStep) {
+                    const parsedStep = typeof targetStep === 'number'
+                        ? targetStep
+                        : parseInt(targetStep, 10);
+
+                    if (!this.isStepReachable(parsedStep)) {
+                        return;
+                    }
+
+                    this.step = parsedStep;
+                    this.error = '';
+                    this.successMessage = '';
+                },
+                /**
                  * Advance the wizard when the current step passes validation checks.
                  */
                 next() {

--- a/resources/views/dashboard.php
+++ b/resources/views/dashboard.php
@@ -81,7 +81,11 @@ $additionalHead = '<script src="/assets/js/dashboard.js" defer></script>';
     </div>
 
     <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
-        <a href="#tailor-wizard" class="group flex items-center justify-between gap-3 rounded-xl border border-slate-800/80 bg-slate-900/60 px-4 py-3 text-sm font-medium text-slate-200 transition hover:border-indigo-400/60 hover:bg-indigo-500/10 hover:text-indigo-100">
+        <a
+            href="#tailor-wizard"
+            class="group flex items-center justify-between gap-3 rounded-xl border border-slate-800/80 bg-slate-900/60 px-4 py-3 text-sm font-medium text-slate-200 transition hover:border-indigo-400/60 hover:bg-indigo-500/10 hover:text-indigo-100"
+            @click.prevent="startNewGeneration()"
+        >
             <span class="inline-flex items-center gap-2">
                 <span class="rounded-full bg-indigo-500/20 px-2 py-1 text-xs uppercase tracking-wide text-indigo-200">Tailor</span>
                 <span>Start tailoring</span>
@@ -173,25 +177,32 @@ $additionalHead = '<script src="/assets/js/dashboard.js" defer></script>';
             <ol class="space-y-4">
 
                 <?php foreach ($wizardSteps as $stepItem) : ?>
-                    <li
-                        class="flex items-start gap-3"
-                        :class="step === <?= (int) $stepItem['index'] ?> ? 'text-white' : 'text-slate-500'"
-                    >
-                        <span
-                            class="flex h-9 w-9 items-center justify-center rounded-full border"
-                            :class="step === <?= (int) $stepItem['index'] ?> ? 'border-indigo-400 bg-indigo-500/20 text-indigo-200' : 'border-slate-700'"
+                    <?php $stepIndex = (int) $stepItem['index']; ?>
+                    <li class="flex items-start gap-3">
+                        <button
+                            type="button"
+                            class="flex w-full items-start gap-3 text-left"
+                            :class="isStepReachable(<?= $stepIndex ?>) ? (step === <?= $stepIndex ?> ? 'text-white' : 'text-slate-500 hover:text-slate-300 transition') : 'cursor-not-allowed text-slate-700'"
+                            :disabled="!isStepReachable(<?= $stepIndex ?>)"
+                            :aria-disabled="isStepReachable(<?= $stepIndex ?>) ? 'false' : 'true'"
+                            @click="goToStep(<?= $stepIndex ?>)"
                         >
-                            <?= (int) $stepItem['index'] ?>
-                        </span>
+                            <span
+                                class="flex h-9 w-9 items-center justify-center rounded-full border"
+                                :class="step === <?= $stepIndex ?> ? 'border-indigo-400 bg-indigo-500/20 text-indigo-200' : (isStepReachable(<?= $stepIndex ?>) ? 'border-slate-700' : 'border-slate-800/80')"
+                            >
+                                <?= $stepIndex ?>
+                            </span>
 
-                        <div>
-                            <p class="text-sm font-semibold">
-                                <?= htmlspecialchars($stepItem['title'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
-                            </p>
-                            <p class="text-xs text-slate-500">
-                                <?= htmlspecialchars($stepItem['description'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
-                            </p>
-                        </div>
+                            <div>
+                                <p class="text-sm font-semibold">
+                                    <?= htmlspecialchars($stepItem['title'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
+                                </p>
+                                <p class="text-xs text-slate-500">
+                                    <?= htmlspecialchars($stepItem['description'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
+                                </p>
+                            </div>
+                        </button>
                     </li>
                 <?php endforeach; ?>
             </ol>


### PR DESCRIPTION
## Summary
- hook the Start tailoring call-to-action into the Alpine wizard so it resets and focuses the workflow panel
- render wizard step navigation as actionable buttons that respect validation state
- add Alpine helpers to guard step reachability before jumping between stages

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d7c9d2dd3c832ebc6802bb507eb15c