### PR TITLE
Move CV wizard to dedicated tailoring workspace

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -11,6 +11,7 @@ use App\Controllers\JobApplicationController;
 use App\Controllers\GenerationController;
 use App\Controllers\GenerationDownloadController;
 use App\Controllers\HomeController;
+use App\Controllers\TailorController;
 use App\Controllers\RetentionController;
 use App\Documents\DocumentRepository;
 use App\Documents\DocumentService;
@@ -144,9 +145,15 @@ $container->set(AuthController::class, static function (Container $c): AuthContr
 $container->set(HomeController::class, static function (Container $c): HomeController {
     return new HomeController(
         $c->get(Renderer::class),
-        $c->get(DocumentRepository::class),
-        $c->get(GenerationRepository::class),
         $c->get(JobApplicationRepository::class)
+    );
+});
+
+$container->set(TailorController::class, static function (Container $c): TailorController {
+    return new TailorController(
+        $c->get(Renderer::class),
+        $c->get(DocumentRepository::class),
+        $c->get(GenerationRepository::class)
     );
 });
 

--- a/resources/views/dashboard.php
+++ b/resources/views/dashboard.php
@@ -2,71 +2,22 @@
 /** @var string $title */
 /** @var string $subtitle */
 /** @var string $email */
-/** @var array<int, array<string, mixed>> $jobDocuments */
-/** @var array<int, array<string, mixed>> $cvDocuments */
-/** @var array<int, array<string, mixed>> $generations */
-/** @var array<int, array<string, mixed>> $modelOptions */
 /** @var array<int, array<string, mixed>> $outstandingApplications */
 /** @var int $outstandingApplicationsCount */
+/** @var array<int, array{href: string, label: string, current: bool}> $navLinks */
+/** @var string|null $csrfToken */
 
 $fullWidth = true;
-
-$wizardSteps = [
-    [
-        'index' => 1,
-        'title' => 'Choose job description',
-        'description' => 'Select the role you want to tailor for.',
-        'helper' => 'Pick the job posting that best matches the next application.',
-    ],
-    [
-        'index' => 2,
-        'title' => 'Choose CV',
-        'description' => 'Decide which base CV to tailor.',
-        'helper' => 'Use the CV with the strongest baseline for this role.',
-    ],
-    [
-        'index' => 3,
-        'title' => 'Set parameters',
-        'description' => 'Adjust the model and thinking time.',
-        'helper' => 'Choose the best model and allow enough thinking time for complex roles.',
-    ],
-    [
-        'index' => 4,
-        'title' => 'Confirm & queue',
-        'description' => 'Review before submitting.',
-        'helper' => 'Double-check your selections before queuing the request.',
-    ],
-];
-
-$wizardState = [
-    'jobDocuments' => $jobDocuments,
-    'cvDocuments' => $cvDocuments,
-    'models' => $modelOptions,
-    'generations' => $generations,
-    'steps' => $wizardSteps,
-];
-
-$wizardJson = htmlspecialchars(
-    json_encode($wizardState, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
-    ENT_QUOTES,
-    'UTF-8'
-);
-
-$additionalHead = '<script src="/assets/js/dashboard.js" defer></script>';
 ?>
 <?php ob_start(); ?>
 
-<div
-    x-data="generationWizard(<?= $wizardJson ?>)"
-    class="space-y-10"
->
+<div class="space-y-10">
     <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <div>
             <p class="text-sm uppercase tracking-widest text-indigo-400">Signed in as <?= htmlspecialchars($email, ENT_QUOTES) ?></p>
-            <h2 class="mt-2 text-3xl font-semibold tracking-tight text-white">Application tailoring</h2>
+            <h2 class="mt-2 text-3xl font-semibold tracking-tight text-white">Welcome back</h2>
             <p class="mt-2 text-base text-slate-400">
-                Queue a new generation by pairing a job description with your best CV.
-                Adjust generation parameters and confirm before sending it to the AI queue.
+                Stay on top of your applications, documents, and insights from one place.
             </p>
         </div>
         <div class="flex flex-col gap-3 md:items-end">
@@ -75,20 +26,18 @@ $additionalHead = '<script src="/assets/js/dashboard.js" defer></script>';
                 <button type="submit" class="inline-flex items-center justify-center rounded-lg border border-slate-700 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:bg-slate-800">
                     Sign out
                 </button>
-
             </form>
         </div>
     </div>
 
     <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
         <a
-            href="#tailor-wizard"
+            href="/tailor"
             class="group flex items-center justify-between gap-3 rounded-xl border border-slate-800/80 bg-slate-900/60 px-4 py-3 text-sm font-medium text-slate-200 transition hover:border-indigo-400/60 hover:bg-indigo-500/10 hover:text-indigo-100"
-            @click.prevent="startNewGeneration()"
         >
             <span class="inline-flex items-center gap-2">
                 <span class="rounded-full bg-indigo-500/20 px-2 py-1 text-xs uppercase tracking-wide text-indigo-200">Tailor</span>
-                <span>Start tailoring</span>
+                <span>Open CV workspace</span>
             </span>
             <svg aria-hidden="true" class="h-4 w-4 transition group-hover:translate-x-1" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
                 <path d="M5 12h14" stroke-linecap="round" stroke-linejoin="round"></path>
@@ -172,247 +121,43 @@ $additionalHead = '<script src="/assets/js/dashboard.js" defer></script>';
         </div>
     </section>
 
-    <div class="grid gap-6 lg:grid-cols-[320px,1fr]">
-        <nav class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6">
-            <ol class="space-y-4">
-
-                <?php foreach ($wizardSteps as $stepItem) : ?>
-                    <?php $stepIndex = (int) $stepItem['index']; ?>
-                    <li class="flex items-start gap-3">
-                        <button
-                            type="button"
-                            class="flex w-full items-start gap-3 text-left"
-                            :class="isStepReachable(<?= $stepIndex ?>) ? (step === <?= $stepIndex ?> ? 'text-white' : 'text-slate-500 hover:text-slate-300 transition') : 'cursor-not-allowed text-slate-700'"
-                            :disabled="!isStepReachable(<?= $stepIndex ?>)"
-                            :aria-disabled="isStepReachable(<?= $stepIndex ?>) ? 'false' : 'true'"
-                            @click="goToStep(<?= $stepIndex ?>)"
-                        >
-                            <span
-                                class="flex h-9 w-9 items-center justify-center rounded-full border"
-                                :class="step === <?= $stepIndex ?> ? 'border-indigo-400 bg-indigo-500/20 text-indigo-200' : (isStepReachable(<?= $stepIndex ?>) ? 'border-slate-700' : 'border-slate-800/80')"
-                            >
-                                <?= $stepIndex ?>
-                            </span>
-
-                            <div>
-                                <p class="text-sm font-semibold">
-                                    <?= htmlspecialchars($stepItem['title'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
-                                </p>
-                                <p class="text-xs text-slate-500">
-                                    <?= htmlspecialchars($stepItem['description'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
-                                </p>
-                            </div>
-                        </button>
-                    </li>
-                <?php endforeach; ?>
-            </ol>
-        </nav>
-        <section
-            x-ref="wizardPanel"
-            id="tailor-wizard"
-            tabindex="-1"
-            class="rounded-2xl border border-slate-800/80 bg-slate-900/70 shadow-xl"
-        >
-            <?php $firstWizardStep = $wizardSteps[0] ?? ['title' => 'Tailor your application', 'helper' => 'Follow the steps to queue a tailored CV.']; ?>
-            <div class="border-b border-slate-800/60 px-6 py-4">
-                <h3 class="text-lg font-semibold text-white" x-text="steps[step - 1] ? steps[step - 1].title : ''">
-                    <?= htmlspecialchars($firstWizardStep['title'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
-                </h3>
-                <p class="text-sm text-slate-400" x-text="steps[step - 1] ? steps[step - 1].helper : ''">
-                    <?= htmlspecialchars($firstWizardStep['helper'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
-                </p>
+    <section class="grid gap-6 lg:grid-cols-[1.2fr,1fr]">
+        <article class="rounded-2xl border border-indigo-500/30 bg-indigo-500/10 p-6 text-indigo-100 shadow-xl">
+            <div class="flex items-center justify-between gap-3">
+                <h3 class="text-lg font-semibold">Tailoring moved home</h3>
+                <span class="rounded-full bg-indigo-500/30 px-3 py-1 text-xs font-semibold uppercase tracking-wide">New</span>
             </div>
-            <div class="space-y-6 px-6 py-6">
-                <template x-if="isWizardDisabled">
-                    <div class="rounded-xl border border-amber-500/40 bg-amber-500/10 p-4 text-sm text-amber-200">
-                        Upload at least one job description and CV to begin.
-                    </div>
-                </template>
-
-                <div x-show="step === 1" x-cloak class="space-y-4">
-                    <template x-if="jobDocuments.length === 0">
-                        <p class="rounded-xl border border-slate-700 bg-slate-800/50 p-5 text-sm text-slate-300">
-                            You do not have any job descriptions yet. Upload one to start tailoring.
-                        </p>
-                    </template>
-                    <template x-for="job in jobDocuments" :key="job.id">
-                        <label class="flex cursor-pointer flex-col gap-1 rounded-xl border px-4 py-3 transition" :class="form.job_document_id === job.id ? 'border-indigo-400 bg-indigo-500/10 text-white' : 'border-slate-700 hover:border-slate-500 hover:bg-slate-800/40'">
-                            <div class="flex items-center justify-between">
-                                <div class="flex items-center gap-3">
-                                    <span class="flex h-8 w-8 items-center justify-center rounded-full bg-indigo-500/20 text-indigo-200">
-                                        <svg aria-hidden="true" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                                            <path d="M4 5h16M4 12h16M4 19h16" stroke-linecap="round" stroke-linejoin="round" />
-                                        </svg>
-                                    </span>
-                                    <div>
-                                        <p class="font-medium" x-text="job.filename"></p>
-                                        <p class="text-xs text-slate-400">Added <span x-text="formatDate(job.created_at)"></span></p>
-                                    </div>
-                                </div>
-                                <input type="radio" class="hidden" name="job_document" :value="job.id" x-model="form.job_document_id">
-                                <span class="text-xs uppercase tracking-wide" :class="form.job_document_id === job.id ? 'text-indigo-300' : 'text-slate-500'">
-                                    Select
-                                </span>
-                            </div>
-                        </label>
-                    </template>
-                </div>
-
-                <div x-show="step === 2" x-cloak class="space-y-4">
-                    <template x-if="cvDocuments.length === 0">
-                        <p class="rounded-xl border border-slate-700 bg-slate-800/50 p-5 text-sm text-slate-300">
-                            Upload a CV to continue.
-                        </p>
-                    </template>
-                    <template x-for="cv in cvDocuments" :key="cv.id">
-                        <label class="flex cursor-pointer flex-col gap-1 rounded-xl border px-4 py-3 transition" :class="form.cv_document_id === cv.id ? 'border-indigo-400 bg-indigo-500/10 text-white' : 'border-slate-700 hover:border-slate-500 hover:bg-slate-800/40'">
-                            <div class="flex items-center justify-between">
-                                <div class="flex items-center gap-3">
-                                    <span class="flex h-8 w-8 items-center justify-center rounded-full bg-emerald-500/20 text-emerald-200">
-                                        <svg aria-hidden="true" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                                            <path d="M5 7l5-4 5 4M5 17l5 4 5-4" stroke-linecap="round" stroke-linejoin="round" />
-                                        </svg>
-                                    </span>
-                                    <div>
-                                        <p class="font-medium" x-text="cv.filename"></p>
-                                        <p class="text-xs text-slate-400">Added <span x-text="formatDate(cv.created_at)"></span></p>
-                                    </div>
-                                </div>
-                                <input type="radio" class="hidden" name="cv_document" :value="cv.id" x-model="form.cv_document_id">
-                                <span class="text-xs uppercase tracking-wide" :class="form.cv_document_id === cv.id ? 'text-indigo-300' : 'text-slate-500'">
-                                    Select
-                                </span>
-                            </div>
-                        </label>
-                    </template>
-                </div>
-
-                <div x-show="step === 3" x-cloak class="space-y-6">
-                    <div>
-                        <p class="text-sm font-medium text-slate-200">Model</p>
-                        <div class="mt-3 grid gap-3 md:grid-cols-3">
-                            <template x-for="model in models" :key="model.value">
-                                <button type="button" class="w-full rounded-xl border px-4 py-3 text-left text-sm transition" :class="form.model === model.value ? 'border-indigo-400 bg-indigo-500/10 text-white' : 'border-slate-700 hover:border-slate-500 hover:bg-slate-800/40'" @click="form.model = model.value">
-                                    <p class="font-semibold" x-text="model.label"></p>
-                                    <p class="mt-1 text-xs text-slate-400" x-text="model.value"></p>
-                                </button>
-                            </template>
-                        </div>
-                    </div>
-                    <div class="space-y-2">
-                        <div class="flex items-center justify-between text-sm text-slate-200">
-                            <span>Thinking time (seconds)</span>
-                            <span class="font-semibold text-indigo-200" x-text="form.thinking_time + 's'"></span>
-                        </div>
-                        <input type="range" min="5" max="60" step="5" x-model.number="form.thinking_time" class="w-full accent-indigo-500">
-                        <p class="text-xs text-slate-400">Give GPT-5 a little more time for deeper reasoning. Thirty seconds is a balanced default.</p>
-                    </div>
-                </div>
-
-                <div x-show="step === 4" x-cloak class="space-y-4">
-                    <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-                        <h4 class="text-sm font-semibold text-slate-200">Review selections</h4>
-                        <dl class="mt-3 space-y-2 text-sm text-slate-300">
-                            <div class="flex items-start justify-between gap-4">
-                                <dt class="text-slate-400">Job description</dt>
-                                <dd class="font-medium text-right" x-text="selectedJobDocument ? selectedJobDocument.filename : 'None selected'"></dd>
-                            </div>
-                            <div class="flex items-start justify-between gap-4">
-                                <dt class="text-slate-400">CV</dt>
-                                <dd class="font-medium text-right" x-text="selectedCvDocument ? selectedCvDocument.filename : 'None selected'"></dd>
-                            </div>
-                            <div class="flex items-start justify-between gap-4">
-                                <dt class="text-slate-400">Model</dt>
-                                <dd class="font-medium text-right" x-text="displayModelLabel"></dd>
-                            </div>
-                            <div class="flex items-start justify-between gap-4">
-                                <dt class="text-slate-400">Thinking time</dt>
-                                <dd class="font-medium text-right" x-text="form.thinking_time + 's'"></dd>
-                            </div>
-                        </dl>
-                    </div>
-                    <div class="rounded-xl border border-indigo-500/30 bg-indigo-500/10 p-4 text-sm text-indigo-100">
-                        Once submitted, the request appears in your queue with status <strong class="font-semibold">queued</strong> until processing begins.
-                    </div>
-                </div>
-
-                <div class="flex flex-col gap-3 border-t border-slate-800/60 pt-4 sm:flex-row sm:justify-between">
-                    <div class="space-y-2">
-                        <template x-if="error">
-                            <div class="rounded-lg border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-200" x-text="error"></div>
-                        </template>
-                        <template x-if="successMessage">
-                            <div class="rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-200" x-text="successMessage"></div>
-                        </template>
-                    </div>
-                    <div class="flex flex-col gap-3 sm:flex-row">
-                        <button type="button" class="rounded-lg border border-slate-700 px-4 py-2 text-sm font-medium text-slate-300 transition hover:border-slate-500 hover:bg-slate-800/60" @click="previous()" :disabled="step === 1" :class="step === 1 ? 'cursor-not-allowed opacity-40' : ''">
-                            Back
-                        </button>
-                        <template x-if="step < steps.length">
-                            <button type="button" class="rounded-lg bg-indigo-500 px-5 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400 disabled:cursor-not-allowed disabled:opacity-50" @click="next()" :disabled="!canMoveForward || isWizardDisabled">
-                                Continue
-                            </button>
-                        </template>
-                        <template x-if="step === steps.length">
-                            <button type="button" class="rounded-lg bg-indigo-500 px-5 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400 disabled:cursor-not-allowed disabled:opacity-50" @click="submit()" :disabled="isSubmitting || isWizardDisabled || !canSubmit">
-                                <span x-show="!isSubmitting">Confirm &amp; queue</span>
-                                <span x-show="isSubmitting" class="inline-flex items-center gap-2">
-                                    <svg class="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                                        <path d="M12 4v2m4.24.76l-1.42 1.42M20 12h-2m-.76 4.24l-1.42-1.42M12 20v-2m-4.24-.76l1.42-1.42M4 12h2m.76-4.24l1.42 1.42" stroke-linecap="round" stroke-linejoin="round"></path>
-                                    </svg>
-                                    Queuing…
-                                </span>
-                            </button>
-                        </template>
-                    </div>
-                </div>
-            </div>
-        </section>
-    </div>
-
-    <section class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl">
-        <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div>
-                <h3 class="text-xl font-semibold text-white">Recent generations</h3>
-                <p class="text-sm text-slate-400">Track each request from submission through completion.</p>
-            </div>
-        </div>
-        <div class="mt-6 overflow-hidden rounded-xl border border-slate-800/80">
-            <table class="min-w-full divide-y divide-slate-800 text-left text-sm text-slate-300">
-                <thead class="bg-slate-900/80 text-xs uppercase tracking-wide text-slate-500">
-                    <tr>
-                        <th class="px-4 py-3">Requested</th>
-                        <th class="px-4 py-3">Job description</th>
-                        <th class="px-4 py-3">CV</th>
-                        <th class="px-4 py-3">Model</th>
-                        <th class="px-4 py-3">Thinking time</th>
-                        <th class="px-4 py-3">Status</th>
-                    </tr>
-                </thead>
-                <tbody class="divide-y divide-slate-800/60">
-                    <template x-if="generations.length === 0">
-                        <tr>
-                            <td colspan="6" class="px-4 py-5 text-center text-sm text-slate-400">
-                                No generations yet. Your queued requests will appear here.
-                            </td>
-                        </tr>
-                    </template>
-                    <template x-for="item in generations" :key="item.id">
-                        <tr class="hover:bg-slate-800/40">
-                            <td class="px-4 py-4 text-slate-300" x-text="formatDateTime(item.created_at)"></td>
-                            <td class="px-4 py-4 font-medium text-slate-200" x-text="item.job_document.filename"></td>
-                            <td class="px-4 py-4" x-text="item.cv_document.filename"></td>
-                            <td class="px-4 py-4" x-text="item.model"></td>
-                            <td class="px-4 py-4" x-text="item.thinking_time + 's'"></td>
-                            <td class="px-4 py-4">
-                                <span class="inline-flex items-center rounded-full bg-slate-800 px-3 py-1 text-xs font-semibold uppercase tracking-wide" :class="item.status === 'queued' ? 'text-amber-200 bg-amber-500/10 border border-amber-400/30' : 'text-emerald-200 bg-emerald-500/10 border border-emerald-400/30'" x-text="item.status"></span>
-                            </td>
-                        </tr>
-                    </template>
-                </tbody>
-            </table>
-        </div>
+            <p class="mt-3 text-sm leading-relaxed">
+                The CV wizard now lives in its own focused workspace. Open the tailor page to pair a job description with your best CV, adjust parameters, and queue generations without distractions.
+            </p>
+            <a href="/tailor" class="mt-4 inline-flex items-center gap-2 rounded-lg border border-indigo-400/60 bg-indigo-500/10 px-4 py-2 text-sm font-semibold text-indigo-100 transition hover:border-indigo-300 hover:bg-indigo-400/20">
+                Go to tailor workspace
+                <svg aria-hidden="true" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                    <path d="M5 12h14" stroke-linecap="round" stroke-linejoin="round"></path>
+                    <path d="M13 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round"></path>
+                </svg>
+            </a>
+        </article>
+        <article class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 text-slate-200 shadow-xl">
+            <h3 class="text-lg font-semibold text-white">Need a reminder?</h3>
+            <p class="mt-3 text-sm text-slate-400">
+                Upload documents and manage applications any time. Your data stays secure thanks to retention controls and detailed audit trails.
+            </p>
+            <ul class="mt-4 space-y-2 text-sm">
+                <li class="flex items-center gap-2">
+                    <span class="inline-flex h-2 w-2 rounded-full bg-indigo-300"></span>
+                    Tailor CVs and cover letters from the dedicated workspace.
+                </li>
+                <li class="flex items-center gap-2">
+                    <span class="inline-flex h-2 w-2 rounded-full bg-emerald-300"></span>
+                    Track outstanding applications to stay organised.
+                </li>
+                <li class="flex items-center gap-2">
+                    <span class="inline-flex h-2 w-2 rounded-full bg-sky-300"></span>
+                    Review retention and usage policies when you need a refresher.
+                </li>
+            </ul>
+        </article>
     </section>
 </div>
 <?php $body = ob_get_clean(); ?>

--- a/resources/views/tailor.php
+++ b/resources/views/tailor.php
@@ -1,0 +1,328 @@
+<?php
+/** @var string $title */
+/** @var string $subtitle */
+/** @var string $email */
+/** @var array<int, array<string, mixed>> $jobDocuments */
+/** @var array<int, array<string, mixed>> $cvDocuments */
+/** @var array<int, array<string, mixed>> $generations */
+/** @var array<int, array<string, mixed>> $modelOptions */
+/** @var array<int, array{href: string, label: string, current: bool}> $navLinks */
+/** @var string|null $csrfToken */
+
+$fullWidth = true;
+
+$wizardSteps = [
+    [
+        'index' => 1,
+        'title' => 'Choose job description',
+        'description' => 'Select the role you want to tailor for.',
+        'helper' => 'Pick the job posting that best matches the next application.',
+    ],
+    [
+        'index' => 2,
+        'title' => 'Choose CV',
+        'description' => 'Decide which base CV to tailor.',
+        'helper' => 'Use the CV with the strongest baseline for this role.',
+    ],
+    [
+        'index' => 3,
+        'title' => 'Set parameters',
+        'description' => 'Adjust the model and thinking time.',
+        'helper' => 'Choose the best model and allow enough thinking time for complex roles.',
+    ],
+    [
+        'index' => 4,
+        'title' => 'Confirm & queue',
+        'description' => 'Review before submitting.',
+        'helper' => 'Double-check your selections before queuing the request.',
+    ],
+];
+
+$wizardState = [
+    'jobDocuments' => $jobDocuments,
+    'cvDocuments' => $cvDocuments,
+    'models' => $modelOptions,
+    'generations' => $generations,
+    'steps' => $wizardSteps,
+];
+
+$wizardJson = htmlspecialchars(
+    json_encode($wizardState, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+    ENT_QUOTES,
+    'UTF-8'
+);
+
+$additionalHead = '<script src="/assets/js/dashboard.js" defer></script>';
+?>
+<?php ob_start(); ?>
+
+<div
+    x-data="generationWizard(<?= $wizardJson ?>)"
+    x-init="startNewGeneration()"
+    class="space-y-10"
+>
+    <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+            <p class="text-sm uppercase tracking-widest text-indigo-400">Signed in as <?= htmlspecialchars($email, ENT_QUOTES) ?></p>
+            <h2 class="mt-2 text-3xl font-semibold tracking-tight text-white">Tailor a CV</h2>
+            <p class="mt-2 text-base text-slate-400">
+                Pair a job description with your strongest CV, fine-tune the generation settings, and queue the request for processing.
+            </p>
+        </div>
+        <div class="flex flex-col gap-3 md:items-end">
+            <a href="/" class="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:bg-slate-800">
+                ← Back to dashboard
+            </a>
+            <form method="post" action="/auth/logout" class="md:self-end">
+                <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
+                <button type="submit" class="inline-flex items-center justify-center rounded-lg border border-slate-700 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:bg-slate-800">
+                    Sign out
+                </button>
+            </form>
+        </div>
+    </div>
+
+    <div class="grid gap-6 lg:grid-cols-[320px,1fr]">
+        <nav class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6">
+            <ol class="space-y-4">
+                <?php foreach ($wizardSteps as $stepItem) : ?>
+                    <?php $stepIndex = (int) $stepItem['index']; ?>
+                    <li class="flex items-start gap-3">
+                        <button
+                            type="button"
+                            class="flex w-full items-start gap-3 text-left"
+                            :class="isStepReachable(<?= $stepIndex ?>) ? (step === <?= $stepIndex ?> ? 'text-white' : 'text-slate-500 hover:text-slate-300 transition') : 'cursor-not-allowed text-slate-700'"
+                            :disabled="!isStepReachable(<?= $stepIndex ?>)"
+                            :aria-disabled="isStepReachable(<?= $stepIndex ?>) ? 'false' : 'true'"
+                            @click="goToStep(<?= $stepIndex ?>)"
+                        >
+                            <span
+                                class="flex h-9 w-9 items-center justify-center rounded-full border"
+                                :class="step === <?= $stepIndex ?> ? 'border-indigo-400 bg-indigo-500/20 text-indigo-200' : (isStepReachable(<?= $stepIndex ?>) ? 'border-slate-700' : 'border-slate-800/80')"
+                            >
+                                <?= $stepIndex ?>
+                            </span>
+
+                            <div>
+                                <p class="text-sm font-semibold">
+                                    <?= htmlspecialchars($stepItem['title'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
+                                </p>
+                                <p class="text-xs text-slate-500">
+                                    <?= htmlspecialchars($stepItem['description'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
+                                </p>
+                            </div>
+                        </button>
+                    </li>
+                <?php endforeach; ?>
+            </ol>
+        </nav>
+        <section
+            x-ref="wizardPanel"
+            id="tailor-wizard"
+            tabindex="-1"
+            class="rounded-2xl border border-slate-800/80 bg-slate-900/70 shadow-xl"
+        >
+            <?php $firstWizardStep = $wizardSteps[0] ?? ['title' => 'Tailor your application', 'helper' => 'Follow the steps to queue a tailored CV.']; ?>
+            <div class="border-b border-slate-800/60 px-6 py-4">
+                <h3 class="text-lg font-semibold text-white" x-text="steps[step - 1] ? steps[step - 1].title : ''">
+                    <?= htmlspecialchars($firstWizardStep['title'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
+                </h3>
+                <p class="text-sm text-slate-400" x-text="steps[step - 1] ? steps[step - 1].helper : ''">
+                    <?= htmlspecialchars($firstWizardStep['helper'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
+                </p>
+            </div>
+            <div class="space-y-6 px-6 py-6">
+                <template x-if="isWizardDisabled">
+                    <div class="rounded-xl border border-amber-500/40 bg-amber-500/10 p-4 text-sm text-amber-200">
+                        Upload at least one job description and CV to begin.
+                    </div>
+                </template>
+
+                <div x-show="step === 1" x-cloak class="space-y-4">
+                    <template x-if="jobDocuments.length === 0">
+                        <p class="rounded-xl border border-slate-700 bg-slate-800/50 p-5 text-sm text-slate-300">
+                            You do not have any job descriptions yet. Upload one to start tailoring.
+                        </p>
+                    </template>
+                    <template x-for="job in jobDocuments" :key="job.id">
+                        <label class="flex cursor-pointer flex-col gap-1 rounded-xl border px-4 py-3 transition" :class="form.job_document_id === job.id ? 'border-indigo-400 bg-indigo-500/10 text-white' : 'border-slate-700 hover:border-slate-500 hover:bg-slate-800/40'">
+                            <div class="flex items-center justify-between">
+                                <div class="flex items-center gap-3">
+                                    <span class="flex h-8 w-8 items-center justify-center rounded-full bg-indigo-500/20 text-indigo-200">
+                                        <svg aria-hidden="true" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                                            <path d="M4 5h16M4 12h16M4 19h16" stroke-linecap="round" stroke-linejoin="round" />
+                                        </svg>
+                                    </span>
+                                    <div>
+                                        <p class="font-medium" x-text="job.filename"></p>
+                                        <p class="text-xs text-slate-400">Added <span x-text="formatDate(job.created_at)"></span></p>
+                                    </div>
+                                </div>
+                                <input type="radio" class="hidden" name="job_document" :value="job.id" x-model="form.job_document_id">
+                                <span class="text-xs uppercase tracking-wide" :class="form.job_document_id === job.id ? 'text-indigo-300' : 'text-slate-500'">
+                                    Select
+                                </span>
+                            </div>
+                        </label>
+                    </template>
+                </div>
+
+                <div x-show="step === 2" x-cloak class="space-y-4">
+                    <template x-if="cvDocuments.length === 0">
+                        <p class="rounded-xl border border-slate-700 bg-slate-800/50 p-5 text-sm text-slate-300">
+                            Upload a CV to continue.
+                        </p>
+                    </template>
+                    <template x-for="cv in cvDocuments" :key="cv.id">
+                        <label class="flex cursor-pointer flex-col gap-1 rounded-xl border px-4 py-3 transition" :class="form.cv_document_id === cv.id ? 'border-indigo-400 bg-indigo-500/10 text-white' : 'border-slate-700 hover:border-slate-500 hover:bg-slate-800/40'">
+                            <div class="flex items-center justify-between">
+                                <div class="flex items-center gap-3">
+                                    <span class="flex h-8 w-8 items-center justify-center rounded-full bg-emerald-500/20 text-emerald-200">
+                                        <svg aria-hidden="true" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                                            <path d="M5 7l5-4 5 4M5 17l5 4 5-4" stroke-linecap="round" stroke-linejoin="round" />
+                                        </svg>
+                                    </span>
+                                    <div>
+                                        <p class="font-medium" x-text="cv.filename"></p>
+                                        <p class="text-xs text-slate-400">Added <span x-text="formatDate(cv.created_at)"></span></p>
+                                    </div>
+                                </div>
+                                <input type="radio" class="hidden" name="cv_document" :value="cv.id" x-model="form.cv_document_id">
+                                <span class="text-xs uppercase tracking-wide" :class="form.cv_document_id === cv.id ? 'text-indigo-300' : 'text-slate-500'">
+                                    Select
+                                </span>
+                            </div>
+                        </label>
+                    </template>
+                </div>
+
+                <div x-show="step === 3" x-cloak class="space-y-6">
+                    <div>
+                        <p class="text-sm font-medium text-slate-200">Model</p>
+                        <div class="mt-3 grid gap-3 md:grid-cols-3">
+                            <template x-for="model in models" :key="model.value">
+                                <button type="button" class="w-full rounded-xl border px-4 py-3 text-left text-sm transition" :class="form.model === model.value ? 'border-indigo-400 bg-indigo-500/10 text-white' : 'border-slate-700 hover:border-slate-500 hover:bg-slate-800/40'" @click="form.model = model.value">
+                                    <p class="font-semibold" x-text="model.label"></p>
+                                    <p class="mt-1 text-xs text-slate-400" x-text="model.value"></p>
+                                </button>
+                            </template>
+                        </div>
+                    </div>
+                    <div class="space-y-2">
+                        <div class="flex items-center justify-between text-sm text-slate-200">
+                            <span>Thinking time (seconds)</span>
+                            <span class="font-semibold text-indigo-200" x-text="form.thinking_time + 's'"></span>
+                        </div>
+                        <input type="range" min="5" max="60" step="5" x-model.number="form.thinking_time" class="w-full accent-indigo-500">
+                        <p class="text-xs text-slate-400">Give GPT-5 a little more time for deeper reasoning. Thirty seconds is a balanced default.</p>
+                    </div>
+                </div>
+
+                <div x-show="step === 4" x-cloak class="space-y-4">
+                    <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+                        <h4 class="text-sm font-semibold text-slate-200">Review selections</h4>
+                        <dl class="mt-3 space-y-2 text-sm text-slate-300">
+                            <div class="flex items-start justify-between gap-4">
+                                <dt class="text-slate-400">Job description</dt>
+                                <dd class="font-medium text-right" x-text="selectedJobDocument ? selectedJobDocument.filename : 'None selected'"></dd>
+                            </div>
+                            <div class="flex items-start justify-between gap-4">
+                                <dt class="text-slate-400">CV</dt>
+                                <dd class="font-medium text-right" x-text="selectedCvDocument ? selectedCvDocument.filename : 'None selected'"></dd>
+                            </div>
+                            <div class="flex items-start justify-between gap-4">
+                                <dt class="text-slate-400">Model</dt>
+                                <dd class="font-medium text-right" x-text="displayModelLabel"></dd>
+                            </div>
+                            <div class="flex items-start justify-between gap-4">
+                                <dt class="text-slate-400">Thinking time</dt>
+                                <dd class="font-medium text-right" x-text="form.thinking_time + 's'"></dd>
+                            </div>
+                        </dl>
+                    </div>
+                    <div class="rounded-xl border border-indigo-500/30 bg-indigo-500/10 p-4 text-sm text-indigo-100">
+                        Once submitted, the request appears in your queue with status <strong class="font-semibold">queued</strong> until processing begins.
+                    </div>
+                </div>
+
+                <div class="flex flex-col gap-3 border-t border-slate-800/60 pt-4 sm:flex-row sm:justify-between">
+                    <div class="space-y-2">
+                        <template x-if="error">
+                            <div class="rounded-lg border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-200" x-text="error"></div>
+                        </template>
+                        <template x-if="successMessage">
+                            <div class="rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-200" x-text="successMessage"></div>
+                        </template>
+                    </div>
+                    <div class="flex flex-col gap-3 sm:flex-row">
+                        <button type="button" class="rounded-lg border border-slate-700 px-4 py-2 text-sm font-medium text-slate-300 transition hover:border-slate-500 hover:bg-slate-800/60" @click="previous()" :disabled="step === 1" :class="step === 1 ? 'cursor-not-allowed opacity-40' : ''">
+                            Back
+                        </button>
+                        <template x-if="step < steps.length">
+                            <button type="button" class="rounded-lg bg-indigo-500 px-5 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400 disabled:cursor-not-allowed disabled:opacity-50" @click="next()" :disabled="!canMoveForward || isWizardDisabled">
+                                Continue
+                            </button>
+                        </template>
+                        <template x-if="step === steps.length">
+                            <button type="button" class="rounded-lg bg-indigo-500 px-5 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400 disabled:cursor-not-allowed disabled:opacity-50" @click="submit()" :disabled="isSubmitting || isWizardDisabled || !canSubmit">
+                                <span x-show="!isSubmitting">Confirm &amp; queue</span>
+                                <span x-show="isSubmitting" class="inline-flex items-center gap-2">
+                                    <svg class="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                                        <path d="M12 4v2m4.24.76l-1.42 1.42M20 12h-2m-.76 4.24l-1.42-1.42M12 20v-2m-4.24-.76l1.42-1.42M4 12h2m.76-4.24l1.42 1.42" stroke-linecap="round" stroke-linejoin="round"></path>
+                                    </svg>
+                                    Queuing…
+                                </span>
+                            </button>
+                        </template>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </div>
+
+    <section class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl">
+        <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+                <h3 class="text-xl font-semibold text-white">Recent generations</h3>
+                <p class="text-sm text-slate-400">Track each request from submission through completion.</p>
+            </div>
+        </div>
+        <div class="mt-6 overflow-hidden rounded-xl border border-slate-800/80">
+            <table class="min-w-full divide-y divide-slate-800 text-left text-sm text-slate-300">
+                <thead class="bg-slate-900/80 text-xs uppercase tracking-wide text-slate-500">
+                    <tr>
+                        <th class="px-4 py-3">Requested</th>
+                        <th class="px-4 py-3">Job description</th>
+                        <th class="px-4 py-3">CV</th>
+                        <th class="px-4 py-3">Model</th>
+                        <th class="px-4 py-3">Thinking time</th>
+                        <th class="px-4 py-3">Status</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-slate-800/60">
+                    <template x-if="generations.length === 0">
+                        <tr>
+                            <td colspan="6" class="px-4 py-5 text-center text-sm text-slate-400">
+                                No generations yet. Your queued requests will appear here.
+                            </td>
+                        </tr>
+                    </template>
+                    <template x-for="item in generations" :key="item.id">
+                        <tr class="hover:bg-slate-800/40">
+                            <td class="px-4 py-4 text-slate-300" x-text="formatDateTime(item.created_at)"></td>
+                            <td class="px-4 py-4 font-medium text-slate-200" x-text="item.job_document.filename"></td>
+                            <td class="px-4 py-4" x-text="item.cv_document.filename"></td>
+                            <td class="px-4 py-4" x-text="item.model"></td>
+                            <td class="px-4 py-4" x-text="item.thinking_time + 's'"></td>
+                            <td class="px-4 py-4">
+                                <span class="inline-flex items-center rounded-full bg-slate-800 px-3 py-1 text-xs font-semibold uppercase tracking-wide" :class="item.status === 'queued' ? 'text-amber-200 bg-amber-500/10 border border-amber-400/30' : 'text-emerald-200 bg-emerald-500/10 border border-emerald-400/30'" x-text="item.status"></span>
+                            </td>
+                        </tr>
+                    </template>
+                </tbody>
+            </table>
+        </div>
+    </section>
+</div>
+<?php $body = ob_get_clean(); ?>
+<?php include __DIR__ . '/layout.php'; ?>

--- a/resources/views/usage.php
+++ b/resources/views/usage.php
@@ -5,6 +5,7 @@ $fullWidth = true;
 $subtitle = 'Spend and token insight';
 $navLinks = [
     ['href' => '/', 'label' => 'Dashboard', 'current' => false],
+    ['href' => '/tailor', 'label' => 'Tailor CV', 'current' => false],
     ['href' => '/documents', 'label' => 'Documents', 'current' => false],
     ['href' => '/applications', 'label' => 'Applications', 'current' => false],
     ['href' => '/usage', 'label' => 'Usage', 'current' => true],

--- a/src/Controllers/DocumentController.php
+++ b/src/Controllers/DocumentController.php
@@ -182,6 +182,7 @@ final class DocumentController
     {
         $links = [
             'dashboard' => ['href' => '/', 'label' => 'Dashboard'],
+            'tailor' => ['href' => '/tailor', 'label' => 'Tailor CV'],
             'documents' => ['href' => '/documents', 'label' => 'Documents'],
             'applications' => ['href' => '/applications', 'label' => 'Applications'],
             'usage' => ['href' => '/usage', 'label' => 'Usage'],

--- a/src/Controllers/JobApplicationController.php
+++ b/src/Controllers/JobApplicationController.php
@@ -215,6 +215,7 @@ final class JobApplicationController
     {
         $links = [
             'dashboard' => ['href' => '/', 'label' => 'Dashboard'],
+            'tailor' => ['href' => '/tailor', 'label' => 'Tailor CV'],
             'documents' => ['href' => '/documents', 'label' => 'Documents'],
             'applications' => ['href' => '/applications', 'label' => 'Applications'],
             'usage' => ['href' => '/usage', 'label' => 'Usage'],

--- a/src/Controllers/RetentionController.php
+++ b/src/Controllers/RetentionController.php
@@ -144,6 +144,7 @@ class RetentionController
     {
         $links = [
             'dashboard' => ['href' => '/', 'label' => 'Dashboard'],
+            'tailor' => ['href' => '/tailor', 'label' => 'Tailor CV'],
             'documents' => ['href' => '/documents', 'label' => 'Documents'],
             'applications' => ['href' => '/applications', 'label' => 'Applications'],
             'usage' => ['href' => '/usage', 'label' => 'Usage'],

--- a/src/Controllers/TailorController.php
+++ b/src/Controllers/TailorController.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controllers;
+
+use App\Documents\DocumentRepository;
+use App\Generations\GenerationRepository;
+use App\Views\Renderer;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class TailorController
+{
+    /** @var Renderer */
+    private $renderer;
+
+    /** @var DocumentRepository */
+    private $documentRepository;
+
+    /** @var GenerationRepository */
+    private $generationRepository;
+
+    /**
+     * Construct the object with its required dependencies.
+     *
+     * This ensures collaborating services are available for subsequent method calls.
+     */
+    public function __construct(
+        Renderer $renderer,
+        DocumentRepository $documentRepository,
+        GenerationRepository $generationRepository
+    ) {
+        $this->renderer = $renderer;
+        $this->documentRepository = $documentRepository;
+        $this->generationRepository = $generationRepository;
+    }
+
+    /**
+     * Display the tailoring wizard page for authenticated users.
+     *
+     * Keeping the workflow isolated provides a dedicated space for managing generations.
+     */
+    public function show(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $user = $request->getAttribute('user');
+
+        if (!is_array($user) || !isset($user['user_id'])) {
+            return $response->withHeader('Location', '/auth/login')->withStatus(302);
+        }
+
+        $userId = (int) $user['user_id'];
+
+        return $this->renderer->render($response, 'tailor', [
+            'title' => 'Tailor your CV',
+            'subtitle' => 'Pair your CV with a job description and queue a generation.',
+            'fullWidth' => true,
+            'navLinks' => $this->navLinks('tailor'),
+            'email' => $user['email'],
+            'jobDocuments' => $this->mapDocuments($this->documentRepository->listForUserAndType($userId, 'job_description')),
+            'cvDocuments' => $this->mapDocuments($this->documentRepository->listForUserAndType($userId, 'cv')),
+            'generations' => $this->generationRepository->listForUser($userId),
+            'modelOptions' => GenerationController::availableModels(),
+        ]);
+    }
+
+    /**
+     * Map the provided documents into the structure expected by the wizard.
+     *
+     * @param array<int, \App\Documents\Document> $documents
+     * @return array<int, array<string, mixed>>
+     */
+    private function mapDocuments(array $documents): array
+    {
+        return array_map(static function ($document): array {
+            return [
+                'id' => $document->id(),
+                'filename' => $document->filename(),
+                'created_at' => $document->createdAt()->format('Y-m-d H:i'),
+            ];
+        }, $documents);
+    }
+
+    /**
+     * Handle the nav links workflow.
+     *
+     * This helper keeps the nav links logic centralised for clarity and reuse.
+     * @return array<int, array{href: string, label: string, current: bool}>
+     */
+    private function navLinks(string $current): array
+    {
+        $links = [
+            'dashboard' => ['href' => '/', 'label' => 'Dashboard'],
+            'tailor' => ['href' => '/tailor', 'label' => 'Tailor CV'],
+            'documents' => ['href' => '/documents', 'label' => 'Documents'],
+            'applications' => ['href' => '/applications', 'label' => 'Applications'],
+            'usage' => ['href' => '/usage', 'label' => 'Usage'],
+            'retention' => ['href' => '/retention', 'label' => 'Retention'],
+        ];
+
+        return array_map(static function ($key, $link) use ($current) {
+            return [
+                'href' => $link['href'],
+                'label' => $link['label'],
+                'current' => $key === $current,
+            ];
+        }, array_keys($links), $links);
+    }
+}

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -9,6 +9,7 @@ use App\Controllers\DocumentController;
 use App\Controllers\GenerationController;
 use App\Controllers\GenerationDownloadController;
 use App\Controllers\HomeController;
+use App\Controllers\TailorController;
 use App\Controllers\JobApplicationController;
 use App\Controllers\RetentionController;
 use App\Controllers\UsageController;
@@ -38,6 +39,10 @@ class Routes
 
         $app->get('/', function (Request $request, Response $response) use ($container) {
             return $container->get(HomeController::class)->index($request, $response);
+        });
+
+        $app->get('/tailor', function (Request $request, Response $response) use ($container) {
+            return $container->get(TailorController::class)->show($request, $response);
         });
 
         $app->get('/documents', function (Request $request, Response $response) use ($container) {


### PR DESCRIPTION
## Summary
- add a Tailor controller, route, and view to host the CV tailoring wizard on its own page
- refresh the dashboard to focus on quick actions, outstanding applications, and a link to the tailoring workspace
- update service bindings and navigation menus so every authenticated screen links to the new tailor experience

## Testing
- php -l src/Controllers/TailorController.php
- php -l src/Controllers/HomeController.php
- php -l resources/views/dashboard.php
- php -l resources/views/tailor.php
- php -l src/Controllers/DocumentController.php
- php -l src/Controllers/JobApplicationController.php
- php -l src/Controllers/RetentionController.php

------
https://chatgpt.com/codex/tasks/task_e_68d7cb891838832e8918b9ebc6cdd59c