### PR TITLE
Add deletion workflows for stored documents and job applications

### DIFF
--- a/resources/views/applications.php
+++ b/resources/views/applications.php
@@ -122,35 +122,43 @@
                                         </h4>
                                         <p class="text-xs text-slate-500">Added <?= htmlspecialchars($item['created_at'], ENT_QUOTES) ?></p>
                                     </div>
-                                    <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="self-start">
-                                        <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                        <input type="hidden" name="status" value="applied">
-                                        <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-200 transition hover:border-emerald-300 hover:text-emerald-100">
-                                            Mark applied
-                                        </button>
-                                    </form>
-                                    <?php $reasonFieldId = 'failure_reason_' . ($item['id'] ?? '0') . '_outstanding'; ?>
-                                    <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="mt-2 flex flex-col gap-2 rounded-xl border border-rose-500/40 bg-rose-500/10 p-3 text-xs text-rose-100 sm:flex-row sm:items-center sm:gap-3">
-                                        <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                        <input type="hidden" name="status" value="failed">
-                                        <label for="<?= htmlspecialchars($reasonFieldId, ENT_QUOTES) ?>" class="font-medium text-rose-100">Rejection reason</label>
-                                        <select
-                                            id="<?= htmlspecialchars($reasonFieldId, ENT_QUOTES) ?>"
-                                            name="reason_code"
-                                            required
-                                            class="w-full rounded-lg border border-rose-400/40 bg-rose-500/10 px-2 py-1 text-rose-100 focus:border-rose-200 focus:outline-none focus:ring-rose-200 sm:max-w-xs"
-                                        >
-                                            <option value="" disabled selected>Select reason</option>
-                                            <?php foreach ($failureReasons as $code => $label) : ?>
-                                                <option value="<?= htmlspecialchars($code, ENT_QUOTES) ?>">
-                                                    <?= htmlspecialchars($label, ENT_QUOTES) ?>
-                                                </option>
-                                            <?php endforeach; ?>
-                                        </select>
-                                        <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-full border border-rose-400/40 bg-rose-500/30 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-200 hover:text-rose-50">
-                                            Mark failed
-                                        </button>
-                                    </form>
+                                    <div class="flex flex-col gap-2 sm:items-end">
+                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="self-start sm:self-auto">
+                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                                            <input type="hidden" name="status" value="applied">
+                                            <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-200 transition hover:border-emerald-300 hover:text-emerald-100">
+                                                Mark applied
+                                            </button>
+                                        </form>
+                                        <?php $reasonFieldId = 'failure_reason_' . ($item['id'] ?? '0') . '_outstanding'; ?>
+                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="flex flex-col gap-2 rounded-xl border border-rose-500/40 bg-rose-500/10 p-3 text-xs text-rose-100 sm:flex-row sm:items-center sm:gap-3">
+                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                                            <input type="hidden" name="status" value="failed">
+                                            <label for="<?= htmlspecialchars($reasonFieldId, ENT_QUOTES) ?>" class="font-medium text-rose-100">Rejection reason</label>
+                                            <select
+                                                id="<?= htmlspecialchars($reasonFieldId, ENT_QUOTES) ?>"
+                                                name="reason_code"
+                                                required
+                                                class="w-full rounded-lg border border-rose-400/40 bg-rose-500/10 px-2 py-1 text-rose-100 focus:border-rose-200 focus:outline-none focus:ring-rose-200 sm:max-w-xs"
+                                            >
+                                                <option value="" disabled selected>Select reason</option>
+                                                <?php foreach ($failureReasons as $code => $label) : ?>
+                                                    <option value="<?= htmlspecialchars($code, ENT_QUOTES) ?>">
+                                                        <?= htmlspecialchars($label, ENT_QUOTES) ?>
+                                                    </option>
+                                                <?php endforeach; ?>
+                                            </select>
+                                            <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-full border border-rose-400/40 bg-rose-500/30 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-200 hover:text-rose-50">
+                                                Mark failed
+                                            </button>
+                                        </form>
+                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/delete" class="self-start sm:self-auto">
+                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                                            <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-rose-500/60 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-300 hover:text-rose-50">
+                                                Delete
+                                            </button>
+                                        </form>
+                                    </div>
                                 </header>
                                 <?php if (!empty($item['source_url'])) : ?>
                                     <a href="<?= htmlspecialchars($item['source_url'], ENT_QUOTES) ?>" target="_blank" rel="noopener" class="mt-2 inline-flex items-center gap-2 text-xs text-indigo-300 hover:text-indigo-200">
@@ -196,35 +204,43 @@
                                             Applied <?= htmlspecialchars($item['applied_at'] ?? $item['created_at'], ENT_QUOTES) ?>
                                         </p>
                                     </div>
-                                    <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="self-start">
-                                        <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                        <input type="hidden" name="status" value="outstanding">
-                                        <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-300 transition hover:border-slate-500 hover:text-slate-100">
-                                            Move back to queue
-                                        </button>
-                                    </form>
-                                    <?php $appliedReasonFieldId = 'failure_reason_' . ($item['id'] ?? '0') . '_applied'; ?>
-                                    <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="mt-2 flex flex-col gap-2 rounded-xl border border-rose-500/40 bg-rose-500/10 p-3 text-xs text-rose-100 sm:flex-row sm:items-center sm:gap-3">
-                                        <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                        <input type="hidden" name="status" value="failed">
-                                        <label for="<?= htmlspecialchars($appliedReasonFieldId, ENT_QUOTES) ?>" class="font-medium text-rose-100">Rejection reason</label>
-                                        <select
-                                            id="<?= htmlspecialchars($appliedReasonFieldId, ENT_QUOTES) ?>"
-                                            name="reason_code"
-                                            required
-                                            class="w-full rounded-lg border border-rose-400/40 bg-rose-500/10 px-2 py-1 text-rose-100 focus:border-rose-200 focus:outline-none focus:ring-rose-200 sm:max-w-xs"
-                                        >
-                                            <option value="" disabled selected>Select reason</option>
-                                            <?php foreach ($failureReasons as $code => $label) : ?>
-                                                <option value="<?= htmlspecialchars($code, ENT_QUOTES) ?>">
-                                                    <?= htmlspecialchars($label, ENT_QUOTES) ?>
-                                                </option>
-                                            <?php endforeach; ?>
-                                        </select>
-                                        <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-full border border-rose-400/40 bg-rose-500/30 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-200 hover:text-rose-50">
-                                            Mark failed
-                                        </button>
-                                    </form>
+                                    <div class="flex flex-col gap-2 sm:items-end">
+                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="self-start sm:self-auto">
+                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                                            <input type="hidden" name="status" value="outstanding">
+                                            <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-300 transition hover:border-slate-500 hover:text-slate-100">
+                                                Move back to queue
+                                            </button>
+                                        </form>
+                                        <?php $appliedReasonFieldId = 'failure_reason_' . ($item['id'] ?? '0') . '_applied'; ?>
+                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="flex flex-col gap-2 rounded-xl border border-rose-500/40 bg-rose-500/10 p-3 text-xs text-rose-100 sm:flex-row sm:items-center sm:gap-3">
+                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                                            <input type="hidden" name="status" value="failed">
+                                            <label for="<?= htmlspecialchars($appliedReasonFieldId, ENT_QUOTES) ?>" class="font-medium text-rose-100">Rejection reason</label>
+                                            <select
+                                                id="<?= htmlspecialchars($appliedReasonFieldId, ENT_QUOTES) ?>"
+                                                name="reason_code"
+                                                required
+                                                class="w-full rounded-lg border border-rose-400/40 bg-rose-500/10 px-2 py-1 text-rose-100 focus:border-rose-200 focus:outline-none focus:ring-rose-200 sm:max-w-xs"
+                                            >
+                                                <option value="" disabled selected>Select reason</option>
+                                                <?php foreach ($failureReasons as $code => $label) : ?>
+                                                    <option value="<?= htmlspecialchars($code, ENT_QUOTES) ?>">
+                                                        <?= htmlspecialchars($label, ENT_QUOTES) ?>
+                                                    </option>
+                                                <?php endforeach; ?>
+                                            </select>
+                                            <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-full border border-rose-400/40 bg-rose-500/30 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-200 hover:text-rose-50">
+                                                Mark failed
+                                            </button>
+                                        </form>
+                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/delete" class="self-start sm:self-auto">
+                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                                            <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-rose-500/60 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-300 hover:text-rose-50">
+                                                Delete
+                                            </button>
+                                        </form>
+                                    </div>
                                 </header>
                                 <?php if (!empty($item['source_url'])) : ?>
                                     <a href="<?= htmlspecialchars($item['source_url'], ENT_QUOTES) ?>" target="_blank" rel="noopener" class="mt-2 inline-flex items-center gap-2 text-xs text-indigo-300 hover:text-indigo-200">
@@ -274,13 +290,21 @@
                                             <?= htmlspecialchars($failureLabel, ENT_QUOTES) ?>
                                         </span>
                                     </div>
-                                    <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="self-start">
-                                        <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                        <input type="hidden" name="status" value="outstanding">
-                                        <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-300 transition hover:border-slate-500 hover:text-slate-100">
-                                            Reopen opportunity
-                                        </button>
-                                    </form>
+                                    <div class="flex flex-col gap-2 sm:items-end">
+                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="self-start sm:self-auto">
+                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                                            <input type="hidden" name="status" value="outstanding">
+                                            <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-300 transition hover:border-slate-500 hover:text-slate-100">
+                                                Reopen opportunity
+                                            </button>
+                                        </form>
+                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/delete" class="self-start sm:self-auto">
+                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                                            <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-rose-500/60 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-300 hover:text-rose-50">
+                                                Delete
+                                            </button>
+                                        </form>
+                                    </div>
                                 </header>
                                 <?php if (!empty($item['source_url'])) : ?>
                                     <a href="<?= htmlspecialchars($item['source_url'], ENT_QUOTES) ?>" target="_blank" rel="noopener" class="mt-2 inline-flex items-center gap-2 text-xs text-indigo-300 hover:text-indigo-200">

--- a/resources/views/documents.php
+++ b/resources/views/documents.php
@@ -2,8 +2,8 @@
 /** @var string $title */
 /** @var string $subtitle */
 /** @var array<int, array{href: string, label: string, current: bool}> $navLinks */
-/** @var array<int, array{filename: string, created_at: string, size: string}> $jobDocuments */
-/** @var array<int, array{filename: string, created_at: string, size: string}> $cvDocuments */
+/** @var array<int, array{id: int|null, filename: string, created_at: string, size: string}> $jobDocuments */
+/** @var array<int, array{id: int|null, filename: string, created_at: string, size: string}> $cvDocuments */
 /** @var array<int, string> $errors */
 /** @var string|null $status */
 /** @var string|null $csrfToken */
@@ -100,11 +100,19 @@
                         <p class="py-4 text-slate-400">No job descriptions uploaded yet.</p>
                     <?php else : ?>
                         <?php foreach ($jobDocuments as $document) : ?>
-                            <article class="flex flex-col gap-1 py-3 sm:flex-row sm:items-center sm:justify-between">
+                            <article class="flex flex-col gap-2 py-3 sm:flex-row sm:items-center sm:justify-between">
                                 <div>
                                     <p class="font-medium text-white"><?= htmlspecialchars($document['filename'], ENT_QUOTES) ?></p>
                                     <p class="text-xs text-slate-400">Added <?= htmlspecialchars($document['created_at'], ENT_QUOTES) ?> · <?= htmlspecialchars($document['size'], ENT_QUOTES) ?></p>
                                 </div>
+                                <?php if (!empty($document['id'])) : ?>
+                                    <form method="post" action="/documents/<?= urlencode((string) $document['id']) ?>/delete" class="self-start sm:self-auto">
+                                        <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                                        <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-rose-500/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-300 hover:text-rose-50">
+                                            Delete
+                                        </button>
+                                    </form>
+                                <?php endif; ?>
                             </article>
                         <?php endforeach; ?>
                     <?php endif; ?>
@@ -126,11 +134,19 @@
                         <p class="py-4 text-slate-400">No CVs uploaded yet.</p>
                     <?php else : ?>
                         <?php foreach ($cvDocuments as $document) : ?>
-                            <article class="flex flex-col gap-1 py-3 sm:flex-row sm:items-center sm:justify-between">
+                            <article class="flex flex-col gap-2 py-3 sm:flex-row sm:items-center sm:justify-between">
                                 <div>
                                     <p class="font-medium text-white"><?= htmlspecialchars($document['filename'], ENT_QUOTES) ?></p>
                                     <p class="text-xs text-slate-400">Added <?= htmlspecialchars($document['created_at'], ENT_QUOTES) ?> · <?= htmlspecialchars($document['size'], ENT_QUOTES) ?></p>
                                 </div>
+                                <?php if (!empty($document['id'])) : ?>
+                                    <form method="post" action="/documents/<?= urlencode((string) $document['id']) ?>/delete" class="self-start sm:self-auto">
+                                        <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                                        <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-rose-500/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-300 hover:text-rose-50">
+                                            Delete
+                                        </button>
+                                    </form>
+                                <?php endif; ?>
                             </article>
                         <?php endforeach; ?>
                     <?php endif; ?>

--- a/src/Applications/JobApplicationRepository.php
+++ b/src/Applications/JobApplicationRepository.php
@@ -193,6 +193,21 @@ class JobApplicationRepository
     }
 
     /**
+     * Handle the delete for user operation.
+     *
+     * The helper keeps deletion logic consistent across the service layer.
+     */
+    public function deleteForUser(int $userId, int $applicationId): bool
+    {
+        $statement = $this->pdo->prepare('DELETE FROM job_applications WHERE id = :id AND user_id = :user_id');
+        $statement->bindValue(':id', $applicationId, PDO::PARAM_INT);
+        $statement->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        $statement->execute();
+
+        return $statement->rowCount() > 0;
+    }
+
+    /**
      * Handle the ensure schema operation.
      *
      * This helper keeps schema bootstrapping predictable across environments.

--- a/src/Applications/JobApplicationService.php
+++ b/src/Applications/JobApplicationService.php
@@ -107,6 +107,22 @@ class JobApplicationService
     }
 
     /**
+     * Handle the delete for user operation.
+     *
+     * This helper keeps ownership checks and messaging consistent for removals.
+     */
+    public function deleteForUser(int $userId, int $applicationId): void
+    {
+        if ($applicationId <= 0) {
+            throw new RuntimeException('The requested job application could not be found.');
+        }
+
+        if (!$this->repository->deleteForUser($userId, $applicationId)) {
+            throw new RuntimeException('The requested job application could not be found.');
+        }
+    }
+
+    /**
      * Handle the failure reasons workflow.
      *
      * This helper keeps the configured rejection codes available to consumers.

--- a/src/Controllers/JobApplicationController.php
+++ b/src/Controllers/JobApplicationController.php
@@ -176,6 +176,35 @@ final class JobApplicationController
     }
 
     /**
+     * Handle deletion of saved job applications.
+     *
+     * Centralising this logic keeps ownership validation and flash messaging aligned.
+     * @param array<string, string> $args
+     */
+    public function delete(ServerRequestInterface $request, ResponseInterface $response, array $args): ResponseInterface
+    {
+        $user = $request->getAttribute('user');
+
+        if ($user === null) {
+            return $response->withHeader('Location', '/auth/login')->withStatus(302);
+        }
+
+        $userId = (int) $user['user_id'];
+        $applicationId = isset($args['id']) ? (int) $args['id'] : 0;
+
+        try {
+            $this->service->deleteForUser($userId, $applicationId);
+            $message = 'Job application deleted successfully.';
+        } catch (RuntimeException $exception) {
+            $message = $exception->getMessage();
+        }
+
+        return $response
+            ->withHeader('Location', '/applications?status=' . rawurlencode($message))
+            ->withStatus(302);
+    }
+
+    /**
      * Handle the mapping workflow.
      *
      * This helper keeps response shaping consistent across controller actions.

--- a/src/Documents/DocumentRepository.php
+++ b/src/Documents/DocumentRepository.php
@@ -139,6 +139,21 @@ class DocumentRepository
     }
 
     /**
+     * Handle the delete for user operation.
+     *
+     * Documenting this helper clarifies its role within the wider workflow.
+     */
+    public function deleteForUser(int $userId, int $documentId): bool
+    {
+        $statement = $this->pdo->prepare('DELETE FROM documents WHERE id = :id AND user_id = :user_id');
+        $statement->bindValue(':id', $documentId, PDO::PARAM_INT);
+        $statement->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        $statement->execute();
+
+        return $statement->rowCount() > 0;
+    }
+
+    /**
      * Handle the ensure schema operation.
      *
      * Documenting this helper clarifies its role within the wider workflow.

--- a/src/Documents/DocumentService.php
+++ b/src/Documents/DocumentService.php
@@ -106,4 +106,20 @@ class DocumentService
     {
         return $this->repository->find($id);
     }
+
+    /**
+     * Handle the delete for user operation.
+     *
+     * Documenting this helper clarifies its role within the wider workflow.
+     */
+    public function deleteForUser(int $userId, int $documentId): void
+    {
+        if ($documentId <= 0) {
+            throw new RuntimeException('The requested document could not be found.');
+        }
+
+        if (!$this->repository->deleteForUser($userId, $documentId)) {
+            throw new RuntimeException('The requested document could not be found.');
+        }
+    }
 }

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -53,6 +53,10 @@ class Routes
             return $container->get(DocumentController::class)->upload($request, $response);
         });
 
+        $app->post('/documents/{id}/delete', function (Request $request, Response $response, array $args) use ($container) {
+            return $container->get(DocumentController::class)->delete($request, $response, $args);
+        });
+
         $app->get('/applications', function (Request $request, Response $response) use ($container) {
             return $container->get(JobApplicationController::class)->index($request, $response);
         });
@@ -63,6 +67,10 @@ class Routes
 
         $app->post('/applications/{id}/status', function (Request $request, Response $response, array $args) use ($container) {
             return $container->get(JobApplicationController::class)->updateStatus($request, $response, $args);
+        });
+
+        $app->post('/applications/{id}/delete', function (Request $request, Response $response, array $args) use ($container) {
+            return $container->get(JobApplicationController::class)->delete($request, $response, $args);
         });
 
 


### PR DESCRIPTION
## Summary
- add controller actions, services, and routes to let users delete their own stored documents and job applications
- update repositories and views so the listings expose delete controls with CSRF protection and tailored flash messaging

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d7dec1b2bc832e91a1cb8899ab1e6e