### PR TITLE
Fix Tailor wizard CSP violations

### DIFF
--- a/public/assets/js/tailwind-config.js
+++ b/public/assets/js/tailwind-config.js
@@ -1,0 +1,64 @@
+/**
+ * Immediately invoke the configuration wrapper so Tailwind's CDN build picks up the
+ * design tokens as soon as the script loads.
+ */
+(function () {
+    'use strict';
+
+    /**
+     * Configure the Tailwind CDN runtime with the design system overrides.
+     *
+     * Exporting the configuration ahead of the CDN bundle preserves compatibility
+     * with the previous inline script while satisfying the stricter CSP rules.
+     */
+    window.tailwind = window.tailwind || {};
+    window.tailwind.config = {
+        darkMode: 'class',
+        theme: {
+            extend: {
+                fontFamily: {
+                    sans: ['"Inter"', 'system-ui', '-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'sans-serif'],
+                    display: ['"Cal Sans"', '"Inter"', 'system-ui', '-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'sans-serif'],
+                    mono: ['"JetBrains Mono"', 'monospace'],
+                },
+                borderRadius: {
+                    xl: '1.25rem',
+                    '2xl': '1.75rem',
+                    '3xl': '2.25rem',
+                },
+                boxShadow: {
+                    soft: '0 25px 65px -25px rgba(15, 23, 42, 0.45)',
+                    'soft-xl': '0 40px 120px -45px rgba(15, 23, 42, 0.55)',
+                    inset: 'inset 0 1px 0 rgba(255, 255, 255, 0.35)',
+                },
+                colors: {
+                    primary: {
+                        50: '#eef2ff',
+                        100: '#e0e7ff',
+                        200: '#c7d2fe',
+                        300: '#a5b4fc',
+                        400: '#818cf8',
+                        500: '#6366f1',
+                        600: '#4f46e5',
+                        700: '#4338ca',
+                        800: '#3730a3',
+                        900: '#312e81',
+                    },
+                    accent: {
+                        500: '#14b8a6',
+                        600: '#0d9488',
+                        700: '#0f766e',
+                    },
+                    surface: {
+                        light: 'rgba(255, 255, 255, 0.72)',
+                        dark: 'rgba(15, 23, 42, 0.72)',
+                    },
+                },
+                transitionDuration: {
+                    350: '350ms',
+                    450: '450ms',
+                },
+            },
+        },
+    };
+})();

--- a/resources/views/layout.php
+++ b/resources/views/layout.php
@@ -17,58 +17,7 @@ $additionalHead = $additionalHead ?? '';
     <title><?= htmlspecialchars($title ?? 'job.smeird.com', ENT_QUOTES) ?></title>
     <meta name="application-name" content="job.smeird.com">
     <meta name="apple-mobile-web-app-title" content="job.smeird.com">
-    <script>
-        window.tailwind = window.tailwind || {};
-        window.tailwind.config = {
-            darkMode: 'class',
-            theme: {
-                extend: {
-                    fontFamily: {
-                        sans: ['"Inter"', 'system-ui', '-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'sans-serif'],
-                        display: ['"Cal Sans"', '"Inter"', 'system-ui', '-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'sans-serif'],
-                        mono: ['"JetBrains Mono"', 'monospace'],
-                    },
-                    borderRadius: {
-                        xl: '1.25rem',
-                        '2xl': '1.75rem',
-                        '3xl': '2.25rem',
-                    },
-                    boxShadow: {
-                        soft: '0 25px 65px -25px rgba(15, 23, 42, 0.45)',
-                        'soft-xl': '0 40px 120px -45px rgba(15, 23, 42, 0.55)',
-                        inset: 'inset 0 1px 0 rgba(255, 255, 255, 0.35)',
-                    },
-                    colors: {
-                        primary: {
-                            50: '#eef2ff',
-                            100: '#e0e7ff',
-                            200: '#c7d2fe',
-                            300: '#a5b4fc',
-                            400: '#818cf8',
-                            500: '#6366f1',
-                            600: '#4f46e5',
-                            700: '#4338ca',
-                            800: '#3730a3',
-                            900: '#312e81',
-                        },
-                        accent: {
-                            500: '#14b8a6',
-                            600: '#0d9488',
-                            700: '#0f766e',
-                        },
-                        surface: {
-                            light: 'rgba(255, 255, 255, 0.72)',
-                            dark: 'rgba(15, 23, 42, 0.72)',
-                        },
-                    },
-                    transitionDuration: {
-                        350: '350ms',
-                        450: '450ms',
-                    },
-                },
-            },
-        };
-    </script>
+    <script src="/assets/js/tailwind-config.js"></script>
     <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
     <script><?= CspConfig::ALPINE_INIT_SCRIPT ?></script>
     <link rel="stylesheet" href="/assets/css/app.css">

--- a/src/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Middleware/SecurityHeadersMiddleware.php
@@ -68,7 +68,6 @@ final class SecurityHeadersMiddleware implements MiddlewareInterface
 
         $scriptSources = [
             "'self'",
-            "'unsafe-inline'",
             "'unsafe-eval'",
             'https://cdn.tailwindcss.com',
             'https://cdn.jsdelivr.net',


### PR DESCRIPTION
## Summary
- move the Tailwind CDN configuration into a standalone asset so it no longer relies on inline scripts
- load the new configuration asset from the shared layout before the Tailwind CDN bundle
- tighten the content security policy by dropping the script-src unsafe-inline allowance while keeping required hashes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7ffe98380832eb7cb78e71769d305