### PR TITLE
Add document preview page

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -13,6 +13,7 @@ use App\Controllers\GenerationDownloadController;
 use App\Controllers\HomeController;
 use App\Controllers\TailorController;
 use App\Controllers\RetentionController;
+use App\Documents\DocumentPreviewer;
 use App\Documents\DocumentRepository;
 use App\Documents\DocumentService;
 use App\Documents\DocumentValidator;
@@ -81,11 +82,16 @@ $container->set(DocumentService::class, static function (Container $c): Document
     return new DocumentService($c->get(DocumentRepository::class), $c->get(DocumentValidator::class));
 });
 
+$container->set(DocumentPreviewer::class, static function (): DocumentPreviewer {
+    return new DocumentPreviewer();
+});
+
 $container->set(DocumentController::class, static function (Container $c): DocumentController {
     return new DocumentController(
         $c->get(Renderer::class),
         $c->get(DocumentRepository::class),
-        $c->get(DocumentService::class)
+        $c->get(DocumentService::class),
+        $c->get(DocumentPreviewer::class)
     );
 });
 

--- a/resources/views/document-view.php
+++ b/resources/views/document-view.php
@@ -1,0 +1,78 @@
+<?php
+/** @var array{filename: string, created_at: string, size: string, mime_type: string, type_label: string, preview: string, id: int|null} $document */
+/** @var string $title */
+/** @var string $subtitle */
+/** @var array<int, array{href: string, label: string, current: bool}> $navLinks */
+?>
+<?php ob_start(); ?>
+<div class="space-y-8">
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+            <p class="text-sm uppercase tracking-[0.3em] text-indigo-400">Document preview</p>
+            <h2 class="mt-2 text-3xl font-semibold text-white"><?= htmlspecialchars($document['filename'], ENT_QUOTES) ?></h2>
+            <p class="mt-2 max-w-2xl text-sm text-slate-400">
+                Review the stored file and ensure it contains the latest information before pairing it with a generation.
+            </p>
+        </div>
+        <a href="/documents" class="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:bg-slate-800/60">
+            ← Back to documents
+        </a>
+    </div>
+
+    <section class="grid gap-6 lg:grid-cols-[320px,1fr]">
+        <div class="space-y-6">
+            <article class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl">
+                <h3 class="text-lg font-semibold text-white">File details</h3>
+                <dl class="mt-4 space-y-3 text-sm text-slate-300">
+                    <div class="flex items-baseline justify-between gap-4">
+                        <dt class="text-slate-400">Type</dt>
+                        <dd class="font-medium text-white"><?= htmlspecialchars($document['type_label'], ENT_QUOTES) ?></dd>
+                    </div>
+                    <div class="flex items-baseline justify-between gap-4">
+                        <dt class="text-slate-400">Uploaded</dt>
+                        <dd class="font-medium text-white"><?= htmlspecialchars($document['created_at'], ENT_QUOTES) ?></dd>
+                    </div>
+                    <div class="flex items-baseline justify-between gap-4">
+                        <dt class="text-slate-400">Size</dt>
+                        <dd class="font-medium text-white"><?= htmlspecialchars($document['size'], ENT_QUOTES) ?></dd>
+                    </div>
+                    <div class="flex items-baseline justify-between gap-4">
+                        <dt class="text-slate-400">MIME type</dt>
+                        <dd class="font-medium text-white"><?= htmlspecialchars($document['mime_type'], ENT_QUOTES) ?></dd>
+                    </div>
+                </dl>
+            </article>
+
+            <?php if (!empty($document['id'])) : ?>
+                <form method="post" action="/documents/<?= urlencode((string) $document['id']) ?>/delete" class="rounded-2xl border border-rose-500/40 bg-rose-500/10 p-6 shadow-xl space-y-4">
+                    <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                    <h3 class="text-lg font-semibold text-rose-100">Delete this document</h3>
+                    <p class="text-sm text-rose-100/80">
+                        Removing the file will also make it unavailable for the tailoring wizard.
+                    </p>
+                    <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-rose-500/40 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-300 hover:text-rose-50">
+                        Delete document
+                    </button>
+                </form>
+            <?php endif; ?>
+        </div>
+
+        <article class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl">
+            <header class="flex items-center justify-between gap-4">
+                <div>
+                    <h3 class="text-lg font-semibold text-white">Contents</h3>
+                    <p class="text-sm text-slate-400">Plain text preview extracted for quick review.</p>
+                </div>
+            </header>
+            <div class="mt-4 max-h-[540px] overflow-auto rounded-xl border border-slate-800/60 bg-slate-950/60 p-4 text-sm leading-relaxed text-slate-200">
+                <?php if ($document['preview'] === '') : ?>
+                    <p class="text-slate-500">A preview is not available for this file type, but the document remains stored securely.</p>
+                <?php else : ?>
+                    <pre class="whitespace-pre-wrap break-words font-mono text-[13px] text-slate-100"><?= htmlspecialchars($document['preview'], ENT_QUOTES) ?></pre>
+                <?php endif; ?>
+            </div>
+        </article>
+    </section>
+</div>
+<?php $body = ob_get_clean(); ?>
+<?php include __DIR__ . '/layout.php'; ?>

--- a/resources/views/documents.php
+++ b/resources/views/documents.php
@@ -106,12 +106,19 @@
                                     <p class="text-xs text-slate-400">Added <?= htmlspecialchars($document['created_at'], ENT_QUOTES) ?> · <?= htmlspecialchars($document['size'], ENT_QUOTES) ?></p>
                                 </div>
                                 <?php if (!empty($document['id'])) : ?>
-                                    <form method="post" action="/documents/<?= urlencode((string) $document['id']) ?>/delete" class="self-start sm:self-auto">
-                                        <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                        <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-rose-500/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-300 hover:text-rose-50">
-                                            Delete
-                                        </button>
-                                    </form>
+                                    <div class="flex items-center gap-2 self-start sm:self-auto">
+                                        <?php if (!empty($document['view_url'])) : ?>
+                                            <a href="<?= htmlspecialchars($document['view_url'], ENT_QUOTES) ?>" class="inline-flex items-center gap-2 rounded-full border border-indigo-400/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-100 transition hover:border-indigo-300 hover:text-indigo-50">
+                                                View
+                                            </a>
+                                        <?php endif; ?>
+                                        <form method="post" action="/documents/<?= urlencode((string) $document['id']) ?>/delete">
+                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                                            <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-rose-500/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-300 hover:text-rose-50">
+                                                Delete
+                                            </button>
+                                        </form>
+                                    </div>
                                 <?php endif; ?>
                             </article>
                         <?php endforeach; ?>
@@ -140,12 +147,19 @@
                                     <p class="text-xs text-slate-400">Added <?= htmlspecialchars($document['created_at'], ENT_QUOTES) ?> · <?= htmlspecialchars($document['size'], ENT_QUOTES) ?></p>
                                 </div>
                                 <?php if (!empty($document['id'])) : ?>
-                                    <form method="post" action="/documents/<?= urlencode((string) $document['id']) ?>/delete" class="self-start sm:self-auto">
-                                        <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                        <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-rose-500/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-300 hover:text-rose-50">
-                                            Delete
-                                        </button>
-                                    </form>
+                                    <div class="flex items-center gap-2 self-start sm:self-auto">
+                                        <?php if (!empty($document['view_url'])) : ?>
+                                            <a href="<?= htmlspecialchars($document['view_url'], ENT_QUOTES) ?>" class="inline-flex items-center gap-2 rounded-full border border-indigo-400/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-100 transition hover:border-indigo-300 hover:text-indigo-50">
+                                                View
+                                            </a>
+                                        <?php endif; ?>
+                                        <form method="post" action="/documents/<?= urlencode((string) $document['id']) ?>/delete">
+                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                                            <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-rose-500/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-300 hover:text-rose-50">
+                                                Delete
+                                            </button>
+                                        </form>
+                                    </div>
                                 <?php endif; ?>
                             </article>
                         <?php endforeach; ?>

--- a/src/Documents/DocumentService.php
+++ b/src/Documents/DocumentService.php
@@ -108,6 +108,26 @@ class DocumentService
     }
 
     /**
+     * Retrieve the requested document for the authenticated user.
+     *
+     * Guarding the lookup here keeps permission logic consistent everywhere the document is accessed.
+     */
+    public function getForUser(int $userId, int $documentId): Document
+    {
+        if ($documentId <= 0) {
+            throw new RuntimeException('The requested document could not be found.');
+        }
+
+        $document = $this->repository->findForUser($userId, $documentId);
+
+        if ($document === null) {
+            throw new RuntimeException('The requested document could not be found.');
+        }
+
+        return $document;
+    }
+
+    /**
      * Handle the delete for user operation.
      *
      * Documenting this helper clarifies its role within the wider workflow.

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -49,6 +49,10 @@ class Routes
             return $container->get(DocumentController::class)->index($request, $response);
         });
 
+        $app->get('/documents/{id}', function (Request $request, Response $response, array $args) use ($container) {
+            return $container->get(DocumentController::class)->show($request, $response, $args);
+        });
+
         $app->post('/documents/upload', function (Request $request, Response $response) use ($container) {
             return $container->get(DocumentController::class)->upload($request, $response);
         });


### PR DESCRIPTION
## Summary
- add a dedicated preview page so users can inspect stored document metadata and content
- expose view links from the documents list and register a route/controller action to serve previews
- wire the document previewer service into the container for rendering file contents

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d803a7ba14832e9fb389581a77f0dd