### PR TITLE
Update Tailor wizard to use GPT-5 model options

### DIFF
--- a/bin/smoke.php
+++ b/bin/smoke.php
@@ -1093,7 +1093,7 @@ final class SmokeGeneration
         $insertGeneration->execute([
             'user_id' => $userId,
             'document_id' => $document['document_id'],
-            'model' => 'gpt-4o-mini',
+            'model' => 'gpt-5-mini',
             'prompt' => 'Tailor CV',
             'status' => 'pending',
             'created_at' => $now,

--- a/bin/verify.php
+++ b/bin/verify.php
@@ -270,7 +270,7 @@ record_check($checks, 'Create generation', function () use (&$state, $client, $c
     $payload = [
         'job_description_id' => $state['documents'][1],
         'cv_source_id' => $state['documents'][0],
-        'model' => verify_env($config, 'OPENAI_MODEL_PLAN') ?? 'gpt-4.1-mini',
+        'model' => verify_env($config, 'OPENAI_MODEL_PLAN') ?? 'gpt-5-mini',
     ];
 
     $response = $client->post('generations', ['json' => $payload]);

--- a/resources/views/home.php
+++ b/resources/views/home.php
@@ -179,7 +179,7 @@ if (is_string($generationIdRaw)) {
                     <div class="wizard-preview__options">
                         <div>
                             <span class="wizard-preview__option-label">Model</span>
-                            <span class="wizard-preview__option-value">GPT-4o mini · Fast and affordable</span>
+                            <span class="wizard-preview__option-value">GPT-5 Mini · Balanced performance</span>
                         </div>
                         <div>
                             <span class="wizard-preview__option-label">Thinking time</span>

--- a/src/Controllers/GenerationController.php
+++ b/src/Controllers/GenerationController.php
@@ -14,9 +14,9 @@ final class GenerationController
 {
     /** @var array<int, array{value: string, label: string}> */
     private const MODELS = [
-        ['value' => 'gpt-4o-mini', 'label' => 'GPT-4o mini · Fast and affordable'],
-        ['value' => 'gpt-4o', 'label' => 'GPT-4o · Highest quality'],
-        ['value' => 'claude-3-5-sonnet', 'label' => 'Claude 3.5 Sonnet · Balanced reasoning'],
+        ['value' => 'gpt-5-mini', 'label' => 'GPT-5 Mini · Balanced performance'],
+        ['value' => 'gpt-5-main', 'label' => 'GPT-5 Main · Highest quality'],
+        ['value' => 'gpt-5-nano', 'label' => 'GPT-5 Nano · Fastest responses'],
     ];
 
     /** @var GenerationRepository */


### PR DESCRIPTION
## Summary
- replace the Tailor wizard model list with GPT-5 Mini, Main, and Nano variants
- refresh dependent scripts and marketing copy to align with the new GPT-5 defaults

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d804750980832e84509a52e9b5177e