### PR TITLE
Fix CSRF handling for tailor queue requests

### DIFF
--- a/public/assets/js/tailor.js
+++ b/public/assets/js/tailor.js
@@ -71,6 +71,23 @@
         };
 
         /**
+         * Resolve the CSRF token stored within the document meta tags.
+         *
+         * @returns {string} The token string or an empty value when unavailable.
+         */
+        const resolveCsrfToken = function () {
+            const meta = document.querySelector('meta[name="csrf-token"]');
+
+            if (!meta) {
+                return '';
+            }
+
+            const value = meta.getAttribute('content');
+
+            return typeof value === 'string' ? value : '';
+        };
+
+        /**
          * Prepare an ordered list of wizard steps from the configuration payload.
          *
          * @param {*} value A potential array of step descriptors.
@@ -158,6 +175,8 @@
                 { index: 4, title: 'Confirm & queue', helper: 'Review your selections before submission.', summary: '' },
             ];
         }
+
+        const csrfToken = resolveCsrfToken();
 
         return {
             step: 1,
@@ -412,7 +431,7 @@
             },
 
             /**
-             * Queue the tailoring request by sending a JSON payload to the server.
+             * Queue the tailoring request by sending a JSON payload with CSRF protection to the server.
              */
             async queue() {
                 if (this.isSubmitting || !this.canSubmit) {
@@ -428,6 +447,7 @@
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',
+                            'X-CSRF-Token': csrfToken,
                         },
                         credentials: 'same-origin',
                         body: JSON.stringify({
@@ -435,6 +455,7 @@
                             cv_document_id: this.form.cv_document_id,
                             model: this.form.model,
                             thinking_time: this.form.thinking_time,
+                            _token: csrfToken,
                         }),
                     });
 

--- a/resources/views/layout.php
+++ b/resources/views/layout.php
@@ -17,6 +17,9 @@ $additionalHead = $additionalHead ?? '';
     <title><?= htmlspecialchars($title ?? 'job.smeird.com', ENT_QUOTES) ?></title>
     <meta name="application-name" content="job.smeird.com">
     <meta name="apple-mobile-web-app-title" content="job.smeird.com">
+    <?php if (!empty($csrfToken)) : ?>
+        <meta name="csrf-token" content="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES, 'UTF-8') ?>">
+    <?php endif; ?>
     <script src="/assets/js/tailwind-config.js"></script>
     <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
     <script><?= CspConfig::ALPINE_INIT_SCRIPT ?></script>


### PR DESCRIPTION
## Summary
- expose the CSRF token in the shared layout so client scripts can reference it
- update the tailor wizard queue request to send the CSRF token header and payload when dispatching generations

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d804db0528832eb4a2b88ef9586ce1