### PR TITLE
Fix DocumentPreviewer Throwable catch for PHP 7.4

### DIFF
--- a/src/Documents/DocumentPreviewer.php
+++ b/src/Documents/DocumentPreviewer.php
@@ -108,7 +108,7 @@ class DocumentPreviewer
             $pdf = $this->pdfParser->parseContent($content);
 
             return $pdf->getText();
-        } catch (\Throwable) {
+        } catch (\Throwable $exception) {
             return '';
         }
     }


### PR DESCRIPTION
## Summary
- update the PDF rendering catch block to declare a Throwable variable for PHP 7.4 compatibility

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d805df1ce8832e9c585287ffb13736