### PR TITLE
Allow tailoring prompt edits in wizard

### DIFF
--- a/public/assets/js/tailor.js
+++ b/public/assets/js/tailor.js
@@ -165,6 +165,7 @@
         };
 
         const defaultThinkingTime = normaliseNumber(config && config.defaultThinkingTime, 30);
+        const defaultPrompt = config && typeof config.prompt === 'string' ? config.prompt : '';
         let steps = buildSteps(config && config.steps);
 
         if (steps.length === 0) {
@@ -186,11 +187,13 @@
             models: toArray(config && config.models),
             generations: toArray(config && config.generations),
             defaultThinkingTime: defaultThinkingTime,
+            defaultPrompt: defaultPrompt,
             form: {
                 job_document_id: null,
                 cv_document_id: null,
                 model: '',
                 thinking_time: defaultThinkingTime,
+                prompt: defaultPrompt,
             },
             errorMessage: '',
             successMessage: '',
@@ -221,6 +224,7 @@
                     ? this.models[0].value
                     : '';
                 this.form.thinking_time = this.defaultThinkingTime;
+                this.form.prompt = this.defaultPrompt;
 
                 this.schedulePanelFocus();
             },
@@ -264,7 +268,7 @@
                 }
 
                 if (this.step === 3) {
-                    return this.form.model !== '' && this.thinkingTimeIsValid;
+                    return this.form.model !== '' && this.thinkingTimeIsValid && this.promptIsValid;
                 }
 
                 return true;
@@ -276,7 +280,10 @@
              * @returns {boolean} True when the wizard may queue a generation.
              */
             get canSubmit() {
-                return this.selectedJob !== null && this.selectedCv !== null && this.thinkingTimeIsValid;
+                return this.selectedJob !== null
+                    && this.selectedCv !== null
+                    && this.thinkingTimeIsValid
+                    && this.promptIsValid;
             },
 
 
@@ -287,6 +294,15 @@
              */
             get thinkingTimeIsValid() {
                 return typeof this.form.thinking_time === 'number' && this.form.thinking_time >= 5 && this.form.thinking_time <= 60;
+            },
+
+            /**
+             * Confirm the AI prompt field contains meaningful content.
+             *
+             * @returns {boolean} True when the prompt is present after trimming whitespace.
+             */
+            get promptIsValid() {
+                return typeof this.form.prompt === 'string' && this.form.prompt.trim() !== '';
             },
 
             /**
@@ -455,6 +471,7 @@
                             cv_document_id: this.form.cv_document_id,
                             model: this.form.model,
                             thinking_time: this.form.thinking_time,
+                            prompt: this.form.prompt,
                             _token: csrfToken,
                         }),
                     });

--- a/resources/views/tailor.php
+++ b/resources/views/tailor.php
@@ -8,6 +8,7 @@
 /** @var array<int, array<string, mixed>> $modelOptions */
 /** @var array<int, array{href: string, label: string, current: bool}> $navLinks */
 /** @var string|null $csrfToken */
+/** @var string $defaultPrompt */
 
 $fullWidth = true;
 
@@ -45,6 +46,7 @@ $wizardState = [
     'generations' => $generations,
     'steps' => $wizardSteps,
     'defaultThinkingTime' => 30,
+    'prompt' => $defaultPrompt,
 ];
 
 $wizardJson = htmlspecialchars(
@@ -249,6 +251,20 @@ $additionalHead = '<script src="/assets/js/tailor.js" defer></script>';
                         >
                         <p class="text-xs text-slate-400">
                             Give GPT-5 more time for complex roles. Thirty seconds is a balanced default.
+                        </p>
+                    </div>
+                    <div class="space-y-2">
+                        <div class="flex items-center justify-between">
+                            <p class="text-sm font-medium text-slate-200">AI prompt</p>
+                            <span class="text-xs text-slate-500">Edit before queuing if needed.</span>
+                        </div>
+                        <textarea
+                            x-model.trim="form.prompt"
+                            rows="10"
+                            class="min-h-[200px] w-full rounded-xl border border-slate-700 bg-slate-950/40 px-4 py-3 text-sm text-slate-100 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        ><?= htmlspecialchars($defaultPrompt, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></textarea>
+                        <p class="text-xs text-slate-400">
+                            Review or customise the instructions guiding the AI. The default prompt keeps outputs accurate and grounded.
                         </p>
                     </div>
                 </div>

--- a/src/Controllers/TailorController.php
+++ b/src/Controllers/TailorController.php
@@ -6,6 +6,7 @@ namespace App\Controllers;
 
 use App\Documents\DocumentRepository;
 use App\Generations\GenerationRepository;
+use App\Prompts\PromptLibrary;
 use App\Views\Renderer;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -61,6 +62,7 @@ final class TailorController
             'cvDocuments' => $this->mapDocuments($this->documentRepository->listForUserAndType($userId, 'cv')),
             'generations' => $this->generationRepository->listForUser($userId),
             'modelOptions' => GenerationController::availableModels(),
+            'defaultPrompt' => PromptLibrary::tailorPrompt(),
         ]);
     }
 


### PR DESCRIPTION
## Summary
- expose the default tailor prompt to the wizard payload so Alpine can bind it
- add a prompt editor textarea in the parameter step pre-populated with the default instructions
- require a non-empty prompt when queueing and include the edited value in the POST payload

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d80a0c45e0832e8235efa4702e690f