### PR TITLE
Queue tailor generation jobs

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -116,7 +116,7 @@ $container->set(JobApplicationController::class, static function (Container $c):
 });
 
 $container->set(GenerationRepository::class, static function (Container $c): GenerationRepository {
-    return new GenerationRepository($c->get(\PDO::class));
+    return new GenerationRepository($c->get(\PDO::class), $c->get(DocumentPreviewer::class));
 });
 
 $container->set(AuditLogger::class, static function (Container $c): AuditLogger {

--- a/src/Queue/Handler/TailorCvJobHandler.php
+++ b/src/Queue/Handler/TailorCvJobHandler.php
@@ -219,7 +219,8 @@ final class TailorCvJobHandler implements JobHandlerInterface
      */
     private function buildConstraints(array $payload, string $cvMarkdown): string
     {
-        $template = PromptLibrary::tailorPrompt();
+        $templateValue = isset($payload['prompt']) ? trim((string) $payload['prompt']) : '';
+        $template = $templateValue !== '' ? $templateValue : PromptLibrary::tailorPrompt();
         $jobTitle = $this->optionalString($payload, 'job_title');
         $company = $this->optionalString($payload, 'company');
         $competencies = $payload['competencies'] ?? [];


### PR DESCRIPTION
## Summary
- require the tailoring request to include a prompt and surface repository failures as 422 responses
- have GenerationRepository assemble job payloads, extract document text, and enqueue tailor_cv jobs
- use the shared document previewer for text extraction and honour custom prompts in the worker

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d9b067ffa8832ea3b38397c27e55ef