### PR TITLE
Add tailoring process logs to CV wizard dashboard

### DIFF
--- a/public/assets/js/tailor.js
+++ b/public/assets/js/tailor.js
@@ -186,6 +186,7 @@
             cvDocuments: toArray(config && config.cvDocuments),
             models: toArray(config && config.models),
             generations: toArray(config && config.generations),
+            processingLogs: toArray(config && config.logs),
             defaultThinkingTime: defaultThinkingTime,
             defaultPrompt: defaultPrompt,
             form: {

--- a/public/index.php
+++ b/public/index.php
@@ -35,6 +35,7 @@ use DI\Container;
 use Slim\Factory\AppFactory;
 use Slim\Middleware\ErrorMiddleware;
 use App\Generations\GenerationDownloadService;
+use App\Generations\GenerationLogRepository;
 use App\Generations\GenerationRepository;
 use App\Generations\GenerationTokenService;
 
@@ -119,6 +120,10 @@ $container->set(GenerationRepository::class, static function (Container $c): Gen
     return new GenerationRepository($c->get(\PDO::class), $c->get(DocumentPreviewer::class));
 });
 
+$container->set(GenerationLogRepository::class, static function (Container $c): GenerationLogRepository {
+    return new GenerationLogRepository($c->get(\PDO::class));
+});
+
 $container->set(AuditLogger::class, static function (Container $c): AuditLogger {
     return new AuditLogger($c->get(\PDO::class));
 });
@@ -163,7 +168,8 @@ $container->set(TailorController::class, static function (Container $c): TailorC
     return new TailorController(
         $c->get(Renderer::class),
         $c->get(DocumentRepository::class),
-        $c->get(GenerationRepository::class)
+        $c->get(GenerationRepository::class),
+        $c->get(GenerationLogRepository::class)
     );
 });
 

--- a/resources/views/tailor.php
+++ b/resources/views/tailor.php
@@ -5,6 +5,7 @@
 /** @var array<int, array<string, mixed>> $jobDocuments */
 /** @var array<int, array<string, mixed>> $cvDocuments */
 /** @var array<int, array<string, mixed>> $generations */
+/** @var array<int, array<string, mixed>> $generationLogs */
 /** @var array<int, array<string, mixed>> $modelOptions */
 /** @var array<int, array{href: string, label: string, current: bool}> $navLinks */
 /** @var string|null $csrfToken */
@@ -44,6 +45,7 @@ $wizardState = [
     'cvDocuments' => $cvDocuments,
     'models' => $modelOptions,
     'generations' => $generations,
+    'logs' => $generationLogs,
     'steps' => $wizardSteps,
     'defaultThinkingTime' => 30,
     'prompt' => $defaultPrompt,
@@ -392,6 +394,51 @@ $additionalHead = '<script src="/assets/js/tailor.js" defer></script>';
                     </template>
                 </tbody>
             </table>
+        </div>
+    </section>
+
+    <section class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl">
+        <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+                <h3 class="text-xl font-semibold text-white">Processing logs</h3>
+                <p class="text-sm text-slate-400">Review recent failures recorded while tailoring CVs.</p>
+            </div>
+            <template x-if="processingLogs.length">
+                <span class="rounded-full border border-rose-400/40 bg-rose-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-200">
+                    <span x-text="processingLogs.length"></span>
+                    <span class="ml-1">issue<span x-text="processingLogs.length === 1 ? '' : 's'"></span></span>
+                </span>
+            </template>
+        </div>
+        <div class="mt-6 space-y-4">
+            <template x-if="processingLogs.length === 0">
+                <p class="rounded-xl border border-slate-800 bg-slate-900/60 p-5 text-sm text-slate-400">
+                    No processing issues recorded. This list updates when the queue reports a problem.
+                </p>
+            </template>
+            <template x-for="log in processingLogs" :key="log.id">
+                <article class="space-y-3 rounded-xl border border-rose-500/30 bg-rose-500/5 p-5 text-sm text-slate-200">
+                    <header class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                        <div class="space-y-1">
+                            <p class="font-semibold text-white" x-text="log.message || 'Processing log'"></p>
+                            <p class="text-xs text-slate-400">
+                                <span x-text="formatDateTime(log.created_at)"></span>
+                                <template x-if="log.generation_id">
+                                    <span>
+                                        · Generation <span x-text="'#' + log.generation_id"></span>
+                                    </span>
+                                </template>
+                            </p>
+                        </div>
+                        <span class="inline-flex items-center rounded-full border border-rose-400/40 bg-rose-500/20 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100">
+                            Failure
+                        </span>
+                    </header>
+                    <template x-if="log.error">
+                        <p class="rounded-lg border border-rose-400/40 bg-rose-500/15 p-3 text-xs text-rose-100" x-text="log.error"></p>
+                    </template>
+                </article>
+            </template>
         </div>
     </section>
 </div>

--- a/src/Controllers/TailorController.php
+++ b/src/Controllers/TailorController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controllers;
 
 use App\Documents\DocumentRepository;
+use App\Generations\GenerationLogRepository;
 use App\Generations\GenerationRepository;
 use App\Prompts\PromptLibrary;
 use App\Views\Renderer;
@@ -22,6 +23,9 @@ final class TailorController
     /** @var GenerationRepository */
     private $generationRepository;
 
+    /** @var GenerationLogRepository */
+    private $generationLogRepository;
+
     /**
      * Construct the object with its required dependencies.
      *
@@ -30,11 +34,13 @@ final class TailorController
     public function __construct(
         Renderer $renderer,
         DocumentRepository $documentRepository,
-        GenerationRepository $generationRepository
+        GenerationRepository $generationRepository,
+        GenerationLogRepository $generationLogRepository
     ) {
         $this->renderer = $renderer;
         $this->documentRepository = $documentRepository;
         $this->generationRepository = $generationRepository;
+        $this->generationLogRepository = $generationLogRepository;
     }
 
     /**
@@ -61,6 +67,7 @@ final class TailorController
             'jobDocuments' => $this->mapDocuments($this->documentRepository->listForUserAndType($userId, 'job_description')),
             'cvDocuments' => $this->mapDocuments($this->documentRepository->listForUserAndType($userId, 'cv')),
             'generations' => $this->generationRepository->listForUser($userId),
+            'generationLogs' => $this->generationLogRepository->listRecentForUser($userId),
             'modelOptions' => GenerationController::availableModels(),
             'defaultPrompt' => PromptLibrary::tailorPrompt(),
         ]);

--- a/src/Generations/GenerationLogRepository.php
+++ b/src/Generations/GenerationLogRepository.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Generations;
+
+use JsonException;
+use PDO;
+use PDOException;
+
+use function is_array;
+use function is_string;
+use function json_decode;
+use function max;
+use function min;
+use function sprintf;
+use function trim;
+
+use const JSON_THROW_ON_ERROR;
+
+final class GenerationLogRepository
+{
+    /** @var PDO */
+    private $pdo;
+
+    /**
+     * Construct the object with its required dependencies.
+     *
+     * This ensures collaborating services are available for subsequent method calls.
+     */
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * Retrieve the most recent tailoring process logs recorded for the user.
+     *
+     * Centralising the lookup keeps the Tailor dashboard lean and consistent.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function listRecentForUser(int $userId, int $limit = 20): array
+    {
+        $safeLimit = min(max(1, $limit), 50);
+
+        try {
+            $statement = $this->pdo->prepare(
+                'SELECT id, action, details, created_at '
+                . 'FROM audit_logs '
+                . 'WHERE user_id = :user_id AND action IN ("generation_failed") '
+                . 'ORDER BY created_at DESC '
+                . 'LIMIT :limit'
+            );
+        } catch (PDOException $exception) {
+            return [];
+        }
+
+        $statement->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        $statement->bindValue(':limit', $safeLimit, PDO::PARAM_INT);
+        $statement->execute();
+
+        $logs = [];
+
+        while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+            $logs[] = $this->mapRow($row);
+        }
+
+        return $logs;
+    }
+
+    /**
+     * Transform a raw database row into a structured log representation.
+     *
+     * @param array<string, mixed> $row The database row fetched from audit_logs.
+     * @return array<string, mixed> The normalised log payload ready for rendering.
+     */
+    private function mapRow(array $row): array
+    {
+        $action = isset($row['action']) ? (string) $row['action'] : '';
+        $details = $this->decodeDetails($row['details'] ?? null);
+        $error = $this->extractError($details);
+        $generationId = isset($details['generation_id']) ? (int) $details['generation_id'] : null;
+
+        return [
+            'id' => isset($row['id']) ? (int) $row['id'] : 0,
+            'action' => $action,
+            'generation_id' => $generationId,
+            'created_at' => isset($row['created_at']) ? (string) $row['created_at'] : '',
+            'error' => $error,
+            'message' => $this->buildMessage($action, $generationId, $error, $details),
+        ];
+    }
+
+    /**
+     * Decode the JSON payload stored within the audit log details column.
+     *
+     * @param mixed $payload The JSON string or null when details are absent.
+     * @return array<string, mixed> A decoded representation suitable for inspection.
+     */
+    private function decodeDetails($payload): array
+    {
+        if (!is_string($payload) || trim($payload) === '') {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($payload, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            return ['raw' => $payload];
+        }
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * Extract a human-readable error string from the decoded details payload.
+     *
+     * @param array<string, mixed> $details The decoded details payload for the log entry.
+     */
+    private function extractError(array $details): ?string
+    {
+        if (isset($details['error']) && is_string($details['error'])) {
+            $trimmed = trim($details['error']);
+
+            if ($trimmed !== '') {
+                return $trimmed;
+            }
+        }
+
+        if (isset($details['raw']) && is_string($details['raw'])) {
+            $trimmed = trim($details['raw']);
+
+            if ($trimmed !== '') {
+                return $trimmed;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Build the headline message presented alongside each log entry.
+     *
+     * @param array<string, mixed> $details The decoded details payload for the log entry.
+     */
+    private function buildMessage(string $action, ?int $generationId, ?string $error, array $details): string
+    {
+        if ($action === 'generation_failed') {
+            $prefix = $generationId !== null && $generationId > 0
+                ? sprintf('Generation #%d failed', $generationId)
+                : 'Generation failed';
+
+            if ($error !== null) {
+                return $prefix . ' · review the error below';
+            }
+
+            return $prefix;
+        }
+
+        if ($error !== null) {
+            return $error;
+        }
+
+        if (isset($details['message']) && is_string($details['message'])) {
+            $trimmed = trim($details['message']);
+
+            if ($trimmed !== '') {
+                return $trimmed;
+            }
+        }
+
+        return 'Processing log recorded.';
+    }
+}


### PR DESCRIPTION
## Summary
- create a GenerationLogRepository to pull recent generation failure entries from audit logs
- register the repository in the container and surface log data in the tailor controller payload
- expand the tailor wizard UI/JS to show a processing logs panel alongside recent generations

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d9b469e274832eb9210a025574df8f