### PR TITLE
Handle missing tailor prompt gracefully

### DIFF
--- a/public/assets/js/tailor.js
+++ b/public/assets/js/tailor.js
@@ -460,6 +460,10 @@
                 this.successMessage = '';
 
                 try {
+                    const promptPayload = typeof this.form.prompt === 'string' && this.form.prompt.trim() !== ''
+                        ? this.form.prompt
+                        : this.defaultPrompt;
+
                     const response = await fetch('/generations', {
                         method: 'POST',
                         headers: {
@@ -472,7 +476,7 @@
                             cv_document_id: this.form.cv_document_id,
                             model: this.form.model,
                             thinking_time: this.form.thinking_time,
-                            prompt: this.form.prompt,
+                            prompt: promptPayload,
                             _token: csrfToken,
                         }),
                     });

--- a/src/Controllers/GenerationController.php
+++ b/src/Controllers/GenerationController.php
@@ -6,6 +6,7 @@ namespace App\Controllers;
 
 use App\Documents\DocumentRepository;
 use App\Generations\GenerationRepository;
+use App\Prompts\PromptLibrary;
 use RuntimeException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -64,6 +65,14 @@ final class GenerationController
         $thinkingTime = $this->extractInt($payload['thinking_time'] ?? null);
         $prompt = isset($payload['prompt']) ? trim((string) $payload['prompt']) : '';
 
+        if ($prompt === '') {
+            $prompt = PromptLibrary::tailorPrompt();
+        }
+
+        if ($prompt === '') {
+            throw new HttpBadRequestException($request, 'Provide tailoring instructions before submitting.');
+        }
+
         if ($jobDocumentId === null || $cvDocumentId === null) {
             throw new HttpBadRequestException($request, 'Both job and CV documents are required.');
         }
@@ -74,10 +83,6 @@ final class GenerationController
 
         if ($thinkingTime === null || $thinkingTime < 5 || $thinkingTime > 60) {
             throw new HttpBadRequestException($request, 'Thinking time must be between 5 and 60 seconds.');
-        }
-
-        if ($prompt === '') {
-            throw new HttpBadRequestException($request, 'Provide tailoring instructions before submitting.');
         }
 
         $userId = (int) $user['user_id'];


### PR DESCRIPTION
## Summary
- fall back to the library tailoring prompt on the server when the request payload omits instructions
- ensure the Tailor wizard submits the default prompt when the textarea is empty to keep submissions resilient

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d9b674d5e0832e924318472b33714c