### PR TITLE
Add example systemd unit and environment files

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The application also respects `DB_DATABASE=':memory:'` when `DB_DRIVER=sqlite`, 
 * The runtime migrator now provisions authentication, document, generation, analytics, retention, and job tables in lock-step with the SQL definitions, adding columns when legacy installs are detected.【F:src/Infrastructure/Database/Migrator.php†L19-L205】
 * SQL migrations mirror the runtime schema so CLI-driven installs and on-request migrations converge on identical structures for analytics, retention, and background jobs.【F:database/migrations/20240326000000_initial.php†L7-L139】【F:database/migrations/20240401000000_jobs_overhaul.php†L6-L20】【F:database/migrations/20240718000001_add_generation_stream_columns.php†L1-L13】
 * Run the worker under a supervisor (systemd, supervisord, etc.) using `php bin/worker.php` so queued `tailor_cv` jobs are processed continuously.【F:bin/worker.php†L29-L68】
+* Example unit and environment definitions live in `resources/systemd/` to speed up provisioning of a managed worker service.【F:resources/systemd/job-worker.service.example†L1-L20】【F:resources/systemd/job-worker.env.example†L1-L16】
 * Configure a cron entry to execute `php bin/purge.php` daily. It honours the active retention policy and reports how many rows were removed per resource.【F:bin/purge.php†L18-L63】
 
 ## Usage analytics & retention

--- a/resources/systemd/job-worker.env.example
+++ b/resources/systemd/job-worker.env.example
@@ -1,0 +1,16 @@
+# Example environment file for the queue worker.
+# Copy to /etc/default/job-worker and adjust values for production.
+APP_ENV=production
+APP_DEBUG=false
+APP_URL=https://job.smeird.com
+
+# Database connection used by the worker.
+DB_CONNECTION=mysql
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_DATABASE=job
+DB_USERNAME=job
+DB_PASSWORD=secret
+
+# Queue configuration that mirrors the web application.
+QUEUE_CONNECTION=database

--- a/resources/systemd/job-worker.service.example
+++ b/resources/systemd/job-worker.service.example
@@ -1,0 +1,20 @@
+# Example systemd unit for the job queue worker.
+# Copy this file to /etc/systemd/system/job-worker.service and adjust paths as needed.
+[Unit]
+Description=Queue worker for job.smeird.com
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+User=www-data
+Group=www-data
+WorkingDirectory=/var/www/job
+ExecStart=/usr/bin/php /var/www/job/bin/worker.php
+Restart=always
+RestartSec=5
+Environment=APP_ENV=production
+EnvironmentFile=-/etc/default/job-worker
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add an example systemd unit file for the queue worker under `resources/systemd`
- provide a sample environment file that matches the worker’s runtime expectations
- mention the new artifacts in the background jobs documentation section

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68da47dd6ba8832e8c4274d2c5d0f30f