### PR TITLE
Fix PHP 7.4 compatible Throwable catch

### DIFF
--- a/src/Queue/Handler/TailorCvJobHandler.php
+++ b/src/Queue/Handler/TailorCvJobHandler.php
@@ -301,7 +301,7 @@ final class TailorCvJobHandler implements JobHandlerInterface
                 ], JSON_THROW_ON_ERROR),
                 ':generation_id' => $generationId,
             ]);
-        } catch (Throwable) {
+        } catch (Throwable $throwable) {
             // Swallow logging errors to avoid masking the original failure.
         }
     }


### PR DESCRIPTION
## Summary
- restore PHP 7.4 compatible syntax by adding a variable to the Throwable catch block in TailorCvJobHandler

## Testing
- php -l src/Queue/Handler/TailorCvJobHandler.php

------
https://chatgpt.com/codex/tasks/task_e_68da4e9e5654832eb91fa35ee8da4d33