### PR TITLE
Restore PHP 7.4 compatible catch clause

### DIFF
--- a/bin/smoke.php
+++ b/bin/smoke.php
@@ -159,10 +159,13 @@ namespace Psr\Http\Message {
          */
         public function close(): void;
 
-        /** @return resource|null */
+        /**
          * Handle the detach workflow.
          *
          * This helper keeps the detach logic centralised for clarity and reuse.
+         *
+         * @return resource|null
+         */
         public function detach();
 
         /**
@@ -242,10 +245,14 @@ namespace Psr\Http\Message {
          */
         public function getContents(): string;
 
-        /** @return array<string, mixed>|mixed|null */
+        /**
          * Retrieve the metadata.
          *
          * The helper centralises access to the metadata so callers stay tidy.
+         *
+         * @param string|null $key
+         * @return array<string, mixed>|mixed|null
+         */
         public function getMetadata(?string $key = null);
     }
 
@@ -367,7 +374,7 @@ final class SmokeStream implements StreamInterface
             $this->rewind();
 
             return stream_get_contents($this->resource) ?: '';
-        } catch (Throwable) {
+        } catch (Throwable $exception) {
             return '';
         }
     }


### PR DESCRIPTION
## Summary
- update the SmokeStream __toString catch clause to bind the Throwable to a variable for PHP 7.4 compatibility

## Testing
- php -l bin/smoke.php

------
https://chatgpt.com/codex/tasks/task_e_68da53260ab0832ea99ef3eb95ddf157