### PR TITLE
Provide database fallback for OpenAI credentials

### DIFF
--- a/resources/systemd/job-worker.env.example
+++ b/resources/systemd/job-worker.env.example
@@ -14,3 +14,10 @@ DB_PASSWORD=secret
 
 # Queue configuration that mirrors the web application.
 QUEUE_CONNECTION=database
+
+# OpenAI credentials used by the background worker when site settings are not configured.
+OPENAI_API_KEY=change-me
+OPENAI_MODEL_PLAN=gpt-4o-mini
+OPENAI_MODEL_DRAFT=gpt-4o-mini
+OPENAI_TARIFF_JSON={"gpt-4o-mini":{"prompt":0.15,"completion":0.6}}
+OPENAI_MAX_TOKENS=2048

--- a/src/Infrastructure/Database/Migrator.php
+++ b/src/Infrastructure/Database/Migrator.php
@@ -40,6 +40,7 @@ class Migrator
         $this->createBackupCodesTable();
         $this->createAuditLogsTable();
         $this->createRetentionSettingsTable();
+        $this->createSiteSettingsTable();
         $this->createJobsTable();
     }
 
@@ -372,6 +373,43 @@ class Migrator
             created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
             updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        SQL;
+
+        $this->pdo->exec($sql);
+    }
+
+    /**
+     * Create the site settings table instance.
+     *
+     * Centralising configuration storage ensures both web and worker
+     * environments can retrieve shared credentials reliably.
+     */
+    private function createSiteSettingsTable(): void
+    {
+        $driver = (string) $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'mysql') {
+            $sql = <<<SQL
+            CREATE TABLE IF NOT EXISTS site_settings (
+                name VARCHAR(191) NOT NULL PRIMARY KEY,
+                value TEXT NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+            SQL;
+
+            $this->pdo->exec($sql);
+
+            return;
+        }
+
+        $sql = <<<'SQL'
+        CREATE TABLE IF NOT EXISTS site_settings (
+            name TEXT PRIMARY KEY,
+            value TEXT NULL,
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
         SQL;
 
         $this->pdo->exec($sql);

--- a/src/Queue/Handler/TailorCvJobHandler.php
+++ b/src/Queue/Handler/TailorCvJobHandler.php
@@ -9,6 +9,7 @@ use App\Prompts\PromptLibrary;
 use App\Queue\Job;
 use App\Queue\JobHandlerInterface;
 use App\Queue\TransientJobException;
+use App\Settings\SiteSettingsRepository;
 use DateTimeImmutable;
 use League\CommonMark\CommonMarkConverter;
 use PDO;
@@ -16,14 +17,14 @@ use PDOException;
 use RuntimeException;
 use Throwable;
 
-use const JSON_THROW_ON_ERROR;
-
 use function array_filter;
 use function array_map;
 use function array_values;
 use function implode;
 use function is_array;
 use function json_encode;
+use function json_last_error;
+use function json_last_error_msg;
 use function mb_substr;
 use function sprintf;
 use function strip_tags;
@@ -37,6 +38,9 @@ final class TailorCvJobHandler implements JobHandlerInterface
     /** @var PDO */
     private $pdo;
 
+    /** @var SiteSettingsRepository */
+    private $settingsRepository;
+
     /**
      * Construct the object with its required dependencies.
      *
@@ -45,6 +49,7 @@ final class TailorCvJobHandler implements JobHandlerInterface
     public function __construct(PDO $pdo)
     {
         $this->pdo = $pdo;
+        $this->settingsRepository = new SiteSettingsRepository($pdo);
         $this->markdownConverter = new CommonMarkConverter([
             'html_input' => 'strip',
             'allow_unsafe_links' => false,
@@ -66,7 +71,7 @@ final class TailorCvJobHandler implements JobHandlerInterface
 
         $this->updateGenerationStatus($generationId, 'processing');
 
-        $provider = new OpenAIProvider($userId, null, $this->pdo);
+        $provider = new OpenAIProvider($userId, null, $this->pdo, $this->settingsRepository);
 
         $plan = $this->generatePlan($provider, $jobDescription, $cvMarkdown);
         $constraints = $this->buildConstraints($payload, $cvMarkdown);
@@ -305,13 +310,37 @@ final class TailorCvJobHandler implements JobHandlerInterface
                 ':ip_address' => '127.0.0.1',
                 ':action' => 'generation_failed',
                 ':user_agent' => 'queue-worker',
-                ':details' => json_encode($this->buildFailureContext($generationId, $error, $context), JSON_THROW_ON_ERROR),
+                ':details' => $this->encodeFailureDetails($generationId, $error, $context),
                 ':created_at' => (new DateTimeImmutable('now'))->format('Y-m-d H:i:s'),
                 ':generation_id' => $generationId,
             ]);
         } catch (Throwable $throwable) {
             // Swallow logging errors to avoid masking the original failure.
         }
+    }
+
+    /**
+     * Safely encode the failure details into JSON for audit logging.
+     *
+     * Using a compatibility layer means the handler continues to operate on platforms
+     * where JSON_THROW_ON_ERROR might not be available while still surfacing
+     * encoding problems in a predictable way.
+     */
+    private function encodeFailureDetails(int $generationId, string $error, array $context): string
+    {
+        $payload = $this->buildFailureContext($generationId, $error, $context);
+
+        if (\defined('JSON_THROW_ON_ERROR')) {
+            return (string) json_encode($payload, \constant('JSON_THROW_ON_ERROR'));
+        }
+
+        $encoded = json_encode($payload);
+
+        if ($encoded === false || json_last_error() !== JSON_ERROR_NONE) {
+            throw new RuntimeException('Failed to encode failure details: ' . json_last_error_msg());
+        }
+
+        return $encoded;
     }
 
     /**

--- a/src/Settings/SiteSettingsRepository.php
+++ b/src/Settings/SiteSettingsRepository.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Settings;
+
+use PDO;
+use PDOException;
+use RuntimeException;
+
+/**
+ * SiteSettingsRepository provides a thin abstraction for reading global
+ * configuration values that are shared between the web front end and the
+ * background worker processes.
+ */
+final class SiteSettingsRepository
+{
+    /** @var PDO */
+    private $pdo;
+
+    /**
+     * Construct the repository with the database connection required for all
+     * lookups.
+     */
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * Retrieve the stored value for the provided configuration key.
+     *
+     * Keeping the lookup logic here lets application services reuse the same
+     * behaviour without duplicating SQL or error handling.
+     *
+     * @return string|null The stored configuration value or null when missing.
+     */
+    public function findValue(string $key): ?string
+    {
+        try {
+            $statement = $this->pdo->prepare(
+                'SELECT value FROM site_settings WHERE name = :name LIMIT 1'
+            );
+            $statement->execute([':name' => $key]);
+            $value = $statement->fetchColumn();
+
+            if ($value === false || $value === null) {
+                return null;
+            }
+
+            return (string) $value;
+        } catch (PDOException $exception) {
+            throw new RuntimeException('Unable to read site setting value.', 0, $exception);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a site settings repository and teach the OpenAI provider and queue handler to read credentials from it when environment variables are absent
- extend the database migrator and worker environment template so shared OpenAI configuration is always available, while fixing PHP 7.4 syntax in the streaming response loop

## Testing
- php -l src/AI/OpenAIProvider.php
- php -l src/Queue/Handler/TailorCvJobHandler.php
- php -l src/Settings/SiteSettingsRepository.php
- php -l src/Infrastructure/Database/Migrator.php

------
https://chatgpt.com/codex/tasks/task_e_68da5cdb30cc832e975c20d63fa41bbb