### PR TITLE
Update plan response payload to use text JSON format

### DIFF
--- a/src/AI/OpenAIProvider.php
+++ b/src/AI/OpenAIProvider.php
@@ -134,7 +134,7 @@ final class OpenAIProvider
             'model' => $this->modelPlan,
             'input' => $this->formatMessagesForResponses($messages),
             'max_output_tokens' => $this->maxTokens,
-            'response_format' => $this->buildPlanJsonSchema(),
+            'response' => $this->buildPlanJsonSchema(),
         ];
 
         $result = $this->performChatRequest($payload, 'plan', $streamHandler);
@@ -519,57 +519,60 @@ final class OpenAIProvider
     private function buildPlanJsonSchema(): array
     {
         return [
-            'type' => 'json_schema',
-            'json_schema' => [
-                'name' => 'tailoring_plan',
-                'schema' => [
-                    'type' => 'object',
-                    'additionalProperties' => false,
-                    'required' => ['summary', 'strengths', 'gaps', 'next_steps'],
-                    'properties' => [
-                        'summary' => [
-                            'type' => 'string',
-                            'minLength' => 1,
-                        ],
-                        'strengths' => [
-                            'type' => 'array',
-                            'minItems' => 1,
-                            'items' => [
+            'modalities' => ['text'],
+            'text' => [
+                'format' => 'json',
+                'json_schema' => [
+                    'name' => 'tailoring_plan',
+                    'schema' => [
+                        'type' => 'object',
+                        'additionalProperties' => false,
+                        'required' => ['summary', 'strengths', 'gaps', 'next_steps'],
+                        'properties' => [
+                            'summary' => [
                                 'type' => 'string',
                                 'minLength' => 1,
                             ],
-                        ],
-                        'gaps' => [
-                            'type' => 'array',
-                            'minItems' => 1,
-                            'items' => [
-                                'type' => 'string',
-                                'minLength' => 1,
+                            'strengths' => [
+                                'type' => 'array',
+                                'minItems' => 1,
+                                'items' => [
+                                    'type' => 'string',
+                                    'minLength' => 1,
+                                ],
                             ],
-                        ],
-                        'next_steps' => [
-                            'type' => 'array',
-                            'minItems' => 1,
-                            'items' => [
-                                'type' => 'object',
-                                'additionalProperties' => false,
-                                'required' => ['task', 'rationale', 'priority', 'estimated_minutes'],
-                                'properties' => [
-                                    'task' => [
-                                        'type' => 'string',
-                                        'minLength' => 1,
-                                    ],
-                                    'rationale' => [
-                                        'type' => 'string',
-                                        'minLength' => 1,
-                                    ],
-                                    'priority' => [
-                                        'type' => 'string',
-                                        'enum' => ['high', 'medium', 'low'],
-                                    ],
-                                    'estimated_minutes' => [
-                                        'type' => 'integer',
-                                        'minimum' => 1,
+                            'gaps' => [
+                                'type' => 'array',
+                                'minItems' => 1,
+                                'items' => [
+                                    'type' => 'string',
+                                    'minLength' => 1,
+                                ],
+                            ],
+                            'next_steps' => [
+                                'type' => 'array',
+                                'minItems' => 1,
+                                'items' => [
+                                    'type' => 'object',
+                                    'additionalProperties' => false,
+                                    'required' => ['task', 'rationale', 'priority', 'estimated_minutes'],
+                                    'properties' => [
+                                        'task' => [
+                                            'type' => 'string',
+                                            'minLength' => 1,
+                                        ],
+                                        'rationale' => [
+                                            'type' => 'string',
+                                            'minLength' => 1,
+                                        ],
+                                        'priority' => [
+                                            'type' => 'string',
+                                            'enum' => ['high', 'medium', 'low'],
+                                        ],
+                                        'estimated_minutes' => [
+                                            'type' => 'integer',
+                                            'minimum' => 1,
+                                        ],
                                     ],
                                 ],
                             ],


### PR DESCRIPTION
## Summary
- update the plan request payload to use the new `response.text` JSON format
- retain the existing plan schema by embedding it under the text configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da6bc94828832ea367e2a335688400