### PR TITLE
Fix plan generation payload for OpenAI responses API

### DIFF
--- a/src/AI/OpenAIProvider.php
+++ b/src/AI/OpenAIProvider.php
@@ -134,7 +134,7 @@ final class OpenAIProvider
             'model' => $this->modelPlan,
             'input' => $this->formatMessagesForResponses($messages),
             'max_output_tokens' => $this->maxTokens,
-            'response' => $this->buildPlanJsonSchema(),
+            'response_format' => $this->buildPlanJsonSchema(),
         ];
 
         $result = $this->performChatRequest($payload, 'plan', $streamHandler);
@@ -519,60 +519,57 @@ final class OpenAIProvider
     private function buildPlanJsonSchema(): array
     {
         return [
-            'modalities' => ['text'],
-            'text' => [
-                'format' => 'json',
-                'json_schema' => [
-                    'name' => 'tailoring_plan',
-                    'schema' => [
-                        'type' => 'object',
-                        'additionalProperties' => false,
-                        'required' => ['summary', 'strengths', 'gaps', 'next_steps'],
-                        'properties' => [
-                            'summary' => [
+            'type' => 'json_schema',
+            'json_schema' => [
+                'name' => 'tailoring_plan',
+                'schema' => [
+                    'type' => 'object',
+                    'additionalProperties' => false,
+                    'required' => ['summary', 'strengths', 'gaps', 'next_steps'],
+                    'properties' => [
+                        'summary' => [
+                            'type' => 'string',
+                            'minLength' => 1,
+                        ],
+                        'strengths' => [
+                            'type' => 'array',
+                            'minItems' => 1,
+                            'items' => [
                                 'type' => 'string',
                                 'minLength' => 1,
                             ],
-                            'strengths' => [
-                                'type' => 'array',
-                                'minItems' => 1,
-                                'items' => [
-                                    'type' => 'string',
-                                    'minLength' => 1,
-                                ],
+                        ],
+                        'gaps' => [
+                            'type' => 'array',
+                            'minItems' => 1,
+                            'items' => [
+                                'type' => 'string',
+                                'minLength' => 1,
                             ],
-                            'gaps' => [
-                                'type' => 'array',
-                                'minItems' => 1,
-                                'items' => [
-                                    'type' => 'string',
-                                    'minLength' => 1,
-                                ],
-                            ],
-                            'next_steps' => [
-                                'type' => 'array',
-                                'minItems' => 1,
-                                'items' => [
-                                    'type' => 'object',
-                                    'additionalProperties' => false,
-                                    'required' => ['task', 'rationale', 'priority', 'estimated_minutes'],
-                                    'properties' => [
-                                        'task' => [
-                                            'type' => 'string',
-                                            'minLength' => 1,
-                                        ],
-                                        'rationale' => [
-                                            'type' => 'string',
-                                            'minLength' => 1,
-                                        ],
-                                        'priority' => [
-                                            'type' => 'string',
-                                            'enum' => ['high', 'medium', 'low'],
-                                        ],
-                                        'estimated_minutes' => [
-                                            'type' => 'integer',
-                                            'minimum' => 1,
-                                        ],
+                        ],
+                        'next_steps' => [
+                            'type' => 'array',
+                            'minItems' => 1,
+                            'items' => [
+                                'type' => 'object',
+                                'additionalProperties' => false,
+                                'required' => ['task', 'rationale', 'priority', 'estimated_minutes'],
+                                'properties' => [
+                                    'task' => [
+                                        'type' => 'string',
+                                        'minLength' => 1,
+                                    ],
+                                    'rationale' => [
+                                        'type' => 'string',
+                                        'minLength' => 1,
+                                    ],
+                                    'priority' => [
+                                        'type' => 'string',
+                                        'enum' => ['high', 'medium', 'low'],
+                                    ],
+                                    'estimated_minutes' => [
+                                        'type' => 'integer',
+                                        'minimum' => 1,
                                     ],
                                 ],
                             ],


### PR DESCRIPTION
## Summary
- update the tailoring plan request to use the Responses API `response_format` key
- adapt the plan JSON schema helper to the current schema format expected by OpenAI

## Testing
- php -l src/AI/OpenAIProvider.php

------
https://chatgpt.com/codex/tasks/task_e_68da714c3468832ea9edcf4c844d3338