### PR TITLE
Fix structured response payload for Responses API

### DIFF
--- a/src/AI/OpenAIProvider.php
+++ b/src/AI/OpenAIProvider.php
@@ -136,7 +136,9 @@ final class OpenAIProvider
             'model' => $this->modelPlan,
             'input' => $this->formatMessagesForResponses($messages),
             'max_output_tokens' => $this->maxTokens,
-            'response_format' => $this->buildPlanJsonSchema(),
+            'response' => [
+                'format' => $this->buildPlanJsonSchema(),
+            ],
         ];
 
         try {
@@ -146,7 +148,7 @@ final class OpenAIProvider
                 throw $exception;
             }
 
-            $payload['response_format'] = ['type' => 'json_object'];
+            $payload['response'] = ['format' => ['type' => 'json_object']];
             error_log('Falling back to json_object response format after plan request failure: ' . $exception->getMessage());
             $result = $this->performChatRequest($payload, 'plan', $streamHandler);
         }


### PR DESCRIPTION
## Summary
- update the plan generation request to send the JSON schema via the Responses API `response.format` field
- adjust the fallback to request a plain `json_object` using the new payload shape

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68da77d31798832ea1798961d410fe46