### PR TITLE
Handle response.format schema errors

### DIFF
--- a/src/AI/OpenAIProvider.php
+++ b/src/AI/OpenAIProvider.php
@@ -646,6 +646,7 @@ final class OpenAIProvider
     private function mentionsUnsupportedSchema(string $message): bool
     {
         return strpos($message, 'response_format') !== false
+            || strpos($message, 'response.format') !== false
             || strpos($message, 'json_schema') !== false
             || strpos($message, 'structured output') !== false;
     }


### PR DESCRIPTION
## Summary
- recognise response.format errors when checking for structured output fallback

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68da95ef0540832e9b95e92ece817282