### PR TITLE
Expose application job descriptions to tailor wizard

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -104,7 +104,8 @@ $container->set(JobApplicationRepository::class, static function (Container $c):
 $container->set(JobApplicationService::class, static function (Container $c): JobApplicationService {
     return new JobApplicationService(
         $c->get(JobApplicationRepository::class),
-        $c->get(GenerationRepository::class)
+        $c->get(GenerationRepository::class),
+        $c->get(DocumentRepository::class)
     );
 });
 


### PR DESCRIPTION
## Summary
- persist each saved job application's description as a text document for the owning user
- surface the generated job description documents to the Tailor CV wizard via the service container

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68daa5e6fea8832e90ee68469992cc04