### PR TITLE
Fix migration order for generation dependencies

### DIFF
--- a/src/Infrastructure/Database/Migrator.php
+++ b/src/Infrastructure/Database/Migrator.php
@@ -33,9 +33,9 @@ class Migrator
         $this->createPendingPasscodesTable();
         $this->createSessionsTable();
         $this->createDocumentsTable();
-        $this->createJobApplicationsTable();
         $this->createGenerationsTable();
         $this->createGenerationOutputsTable();
+        $this->createJobApplicationsTable();
         $this->createApiUsageTable();
         $this->createBackupCodesTable();
         $this->createAuditLogsTable();


### PR DESCRIPTION
## Summary
- ensure the generations tables are created before job application tables so foreign keys can be applied

## Testing
- not run (database not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68daa8831be4832e85210d0ee59936fa