### PR TITLE
Add theme toggle to authenticated layout

### DIFF
--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -15,6 +15,11 @@ body {
     color: #f1f5f9;
 }
 
+html[data-theme='light'] body {
+    background-color: #f8fafc;
+    color: #0f172a;
+}
+
 a {
     color: inherit;
     text-decoration: none;
@@ -33,6 +38,110 @@ button {
     cursor: pointer;
     border: none;
     background: none;
+}
+
+.theme-toggle-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.55rem 0.95rem;
+    border-radius: 9999px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background-color: rgba(30, 41, 59, 0.6);
+    color: #e2e8f0;
+    font-size: 0.875rem;
+    font-weight: 600;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.theme-toggle-button svg {
+    width: 1.25rem;
+    height: 1.25rem;
+}
+
+.theme-toggle-button:focus-visible {
+    outline: 2px solid rgba(129, 140, 248, 0.8);
+    outline-offset: 3px;
+}
+
+.theme-toggle-button:hover {
+    background-color: rgba(99, 102, 241, 0.18);
+    border-color: rgba(129, 140, 248, 0.55);
+    color: #f8fafc;
+}
+
+html[data-theme='light'] .theme-toggle-button {
+    background-color: rgba(255, 255, 255, 0.85);
+    border-color: rgba(148, 163, 184, 0.45);
+    color: #0f172a;
+}
+
+html[data-theme='light'] .theme-toggle-button:hover {
+    background-color: rgba(129, 140, 248, 0.12);
+    border-color: rgba(99, 102, 241, 0.45);
+    color: #312e81;
+}
+
+html[data-theme='light'] .bg-slate-950 {
+    background-color: #ffffff !important;
+}
+
+html[data-theme='light'] .bg-slate-950\/80 {
+    background-color: rgba(255, 255, 255, 0.9) !important;
+}
+
+html[data-theme='light'] .bg-slate-950\/70 {
+    background-color: rgba(255, 255, 255, 0.85) !important;
+}
+
+html[data-theme='light'] .bg-slate-900 {
+    background-color: #f1f5f9 !important;
+}
+
+html[data-theme='light'] .bg-slate-900\/95 {
+    background-color: rgba(241, 245, 249, 0.95) !important;
+}
+
+html[data-theme='light'] .bg-slate-900\/80 {
+    background-color: rgba(241, 245, 249, 0.9) !important;
+}
+
+html[data-theme='light'] .bg-slate-900\/70 {
+    background-color: rgba(241, 245, 249, 0.85) !important;
+}
+
+html[data-theme='light'] .bg-slate-900\/60 {
+    background-color: rgba(241, 245, 249, 0.78) !important;
+}
+
+html[data-theme='light'] .border-slate-800,
+html[data-theme='light'] .border-slate-800\/80 {
+    border-color: rgba(148, 163, 184, 0.45) !important;
+}
+
+html[data-theme='light'] .border-slate-700 {
+    border-color: rgba(148, 163, 184, 0.4) !important;
+}
+
+html[data-theme='light'] .text-white,
+html[data-theme='light'] .text-slate-100 {
+    color: #0b1220 !important;
+}
+
+html[data-theme='light'] .text-slate-200 {
+    color: #1e293b !important;
+}
+
+html[data-theme='light'] .text-slate-300 {
+    color: #334155 !important;
+}
+
+html[data-theme='light'] .text-slate-400 {
+    color: #475569 !important;
+}
+
+html[data-theme='light'] .text-slate-500 {
+    color: #64748b !important;
 }
 
 .min-h-screen {

--- a/resources/views/layout.php
+++ b/resources/views/layout.php
@@ -7,9 +7,33 @@ use App\Security\CspConfig;
 $fullWidth = $fullWidth ?? false;
 $navLinks = $navLinks ?? [];
 $additionalHead = $additionalHead ?? '';
+
+ob_start();
+?>
+    <button
+        type="button"
+        class="theme-toggle-button"
+        data-theme-toggle
+        aria-pressed="false"
+    >
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+            <path d="M12 3v2"></path>
+            <path d="M12 19v2"></path>
+            <path d="M5.64 5.64l1.42 1.42"></path>
+            <path d="M16.94 16.94l1.42 1.42"></path>
+            <path d="M3 12h2"></path>
+            <path d="M19 12h2"></path>
+            <path d="M5.64 18.36l1.42-1.42"></path>
+            <path d="M16.94 7.06l1.42-1.42"></path>
+            <circle cx="12" cy="12" r="4.2"></circle>
+        </svg>
+        <span data-theme-label>Dark mode</span>
+    </button>
+<?php
+$themeToggleControl = trim((string) ob_get_clean());
 ?>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -24,6 +48,7 @@ $additionalHead = $additionalHead ?? '';
     <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
     <script><?= CspConfig::ALPINE_INIT_SCRIPT ?></script>
     <link rel="stylesheet" href="/assets/css/app.css">
+    <script src="/assets/js/theme.js" defer></script>
     <?= $additionalHead ?>
     <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.13.5/dist/cdn.min.js" defer></script>
     <style>[x-cloak]{display:none!important;}</style>
@@ -40,21 +65,24 @@ $additionalHead = $additionalHead ?? '';
                             <p class="mt-1 text-sm text-slate-400"><?= htmlspecialchars($subtitle, ENT_QUOTES) ?></p>
                         <?php endif; ?>
                     </div>
-                    <?php if (!empty($navLinks)) : ?>
-                        <nav class="flex flex-wrap gap-2 text-sm font-medium text-slate-300">
-                            <?php foreach ($navLinks as $link) : ?>
-                                <?php
-                                $isCurrent = !empty($link['current']);
-                                $classes = $isCurrent
-                                    ? 'inline-flex items-center gap-2 rounded-full border border-indigo-400/40 bg-indigo-500/20 px-4 py-2 text-indigo-100'
-                                    : 'inline-flex items-center gap-2 rounded-full border border-slate-700 px-4 py-2 text-slate-300 transition hover:border-slate-500 hover:bg-slate-800/60 hover:text-slate-100';
-                                ?>
-                                <a href="<?= htmlspecialchars($link['href'], ENT_QUOTES) ?>" class="<?= $classes ?>">
-                                    <?= htmlspecialchars($link['label'], ENT_QUOTES) ?>
-                                </a>
-                            <?php endforeach; ?>
-                        </nav>
-                    <?php endif; ?>
+                    <div class="flex flex-col gap-3 md:flex-row md:items-center md:gap-4 md:self-end md:justify-end">
+                        <?php if (!empty($navLinks)) : ?>
+                            <nav class="flex flex-wrap gap-2 text-sm font-medium text-slate-300">
+                                <?php foreach ($navLinks as $link) : ?>
+                                    <?php
+                                    $isCurrent = !empty($link['current']);
+                                    $classes = $isCurrent
+                                        ? 'inline-flex items-center gap-2 rounded-full border border-indigo-400/40 bg-indigo-500/20 px-4 py-2 text-indigo-100'
+                                        : 'inline-flex items-center gap-2 rounded-full border border-slate-700 px-4 py-2 text-slate-300 transition hover:border-slate-500 hover:bg-slate-800/60 hover:text-slate-100';
+                                    ?>
+                                    <a href="<?= htmlspecialchars($link['href'], ENT_QUOTES) ?>" class="<?= $classes ?>">
+                                        <?= htmlspecialchars($link['label'], ENT_QUOTES) ?>
+                                    </a>
+                                <?php endforeach; ?>
+                            </nav>
+                        <?php endif; ?>
+                        <?= $themeToggleControl ?>
+                    </div>
                 </div>
             </div>
         </header>
@@ -66,6 +94,9 @@ $additionalHead = $additionalHead ?? '';
     </div>
 <?php else : ?>
     <div class="min-h-screen flex flex-col items-center justify-center p-6">
+        <div class="mb-6 flex w-full justify-end">
+            <?= $themeToggleControl ?>
+        </div>
         <?php if (!empty($navLinks)) : ?>
             <nav class="mb-6 flex flex-wrap justify-center gap-2 text-sm font-medium text-slate-300">
                 <?php foreach ($navLinks as $link) : ?>


### PR DESCRIPTION
## Summary
- add a reusable light/dark mode toggle to the shared layout so the control is available after login
- load the theme initialisation script and extend CSS so authenticated pages respond to the selected theme

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68daabe5cae0832eb62088cb54a9c7b9