### PR TITLE
Ensure plan fallback keeps Responses payload format

### DIFF
--- a/src/AI/OpenAIProvider.php
+++ b/src/AI/OpenAIProvider.php
@@ -172,9 +172,10 @@ final class OpenAIProvider
                         throw $legacyException;
                     }
 
-                    $legacyPayload['response_format'] = ['type' => 'json_object'];
-                    error_log('Falling back to json_object legacy response format after plan request failure: ' . $legacyException->getMessage());
-                    $result = $this->performChatRequest($legacyPayload, 'plan', $streamHandler, true);
+                    $jsonObjectPayload = $payload;
+                    $jsonObjectPayload['response']['text']['format'] = ['type' => 'json_object'];
+                    error_log('Retrying plan request with json_object response format after legacy response_format failure: ' . $legacyException->getMessage());
+                    $result = $this->performChatRequest($jsonObjectPayload, 'plan', $streamHandler);
                 }
             } else {
                 if (!$this->shouldFallbackToJsonObject($exception)) {


### PR DESCRIPTION
## Summary
- retry plan generation with the modern response.text.format structure when the legacy response_format fallback fails
- adjust logging to reflect the new fallback path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dab4827dec832ebc25ddd12d865303