### PR TITLE
Add text modality to OpenAI request payloads

### DIFF
--- a/src/AI/OpenAIProvider.php
+++ b/src/AI/OpenAIProvider.php
@@ -136,6 +136,7 @@ final class OpenAIProvider
             'model' => $this->modelPlan,
             'input' => $this->formatMessagesForResponses($messages),
             'max_output_tokens' => $this->maxTokens,
+            'modalities' => ['text'],
             'response' => [
                 'text' => [
                     'format' => $this->buildPlanJsonSchema(),
@@ -229,6 +230,7 @@ final class OpenAIProvider
             'model' => $this->modelDraft,
             'input' => $this->formatMessagesForResponses($messages),
             'max_output_tokens' => $this->maxTokens,
+            'modalities' => ['text'],
         ];
 
         $result = $this->performChatRequest($payload, 'draft', $streamHandler);


### PR DESCRIPTION
## Summary
- add the `modalities` entry to plan and draft payloads so OpenAI calls request text output explicitly
- ensure retries and streaming use the same payloads so the text modality is preserved

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dba0b033f8832e912b1b804157c509