### PR TITLE
Normalize OpenAI response input message types

### DIFF
--- a/src/AI/OpenAIProvider.php
+++ b/src/AI/OpenAIProvider.php
@@ -514,6 +514,9 @@ final class OpenAIProvider
     /**
      * Transform chat-style message arrays into the Responses API input schema.
      *
+     * The method ensures all text-based segments adopt the Responses API
+     * `input_text` label while preserving any explicitly provided types.
+     *
      * @param array<int, array<string, mixed>> $messages
      * @return array<int, array{role: string, content: array<int, array{type: string, text: string}>}>
      */
@@ -529,14 +532,20 @@ final class OpenAIProvider
                 $parts = [];
 
                 foreach ($content as $part) {
-                    if (is_array($part) && isset($part['type'], $part['text'])) {
+                    if (is_array($part) && isset($part['text'])) {
+                        $type = isset($part['type']) ? (string) $part['type'] : 'input_text';
+
+                        if ($type === 'text') {
+                            $type = 'input_text';
+                        }
+
                         $parts[] = [
-                            'type' => (string) $part['type'],
+                            'type' => $type,
                             'text' => (string) $part['text'],
                         ];
                     } elseif (is_string($part)) {
                         $parts[] = [
-                            'type' => 'text',
+                            'type' => 'input_text',
                             'text' => $part,
                         ];
                     }
@@ -544,13 +553,13 @@ final class OpenAIProvider
 
                 if ($parts === []) {
                     $parts[] = [
-                        'type' => 'text',
-                        'text' => is_string($content) ? $content : '',
+                        'type' => 'input_text',
+                        'text' => '',
                     ];
                 }
             } else {
                 $parts = [[
-                    'type' => 'text',
+                    'type' => 'input_text',
                     'text' => (string) $content,
                 ]];
             }
@@ -591,7 +600,7 @@ final class OpenAIProvider
 
                 $type = isset($segment['type']) ? (string) $segment['type'] : '';
 
-                if (($type === 'output_text' || $type === 'text') && isset($segment['text'])) {
+                if (($type === 'output_text' || $type === 'text' || $type === 'input_text') && isset($segment['text'])) {
                     $content .= (string) $segment['text'];
                 }
             }


### PR DESCRIPTION
## Summary
- ensure response message formatting emits `input_text` segments and normalises legacy `text` parts
- update downstream output parsing to accept the new `input_text` label

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dba0b04bf0832ea9dfd750ece22307