### PR TITLE
Refine plan response format handling

### DIFF
--- a/src/AI/OpenAIProvider.php
+++ b/src/AI/OpenAIProvider.php
@@ -137,14 +137,8 @@ final class OpenAIProvider
             'model' => $this->modelPlan,
             'input' => $this->formatMessagesForResponses($messages),
             'max_output_tokens' => $this->maxTokens,
-
             'modalities' => ['text'],
-            'response' => [
-                'text' => [
-                    'responce_format' => $this->buildPlanJsonSchema(),
-                ],
-            ],
-
+            'response_format' => $this->buildPlanJsonSchema(),
         ];
 
         try {
@@ -152,6 +146,14 @@ final class OpenAIProvider
         } catch (RuntimeException $exception) {
             if ($this->shouldFallbackToLegacyResponseFormat($exception)) {
                 $legacyPayload = $payload;
+                if (isset($legacyPayload['response_format'])) {
+                    $legacyPayload['response'] = [
+                        'text' => [
+                            'format' => $legacyPayload['response_format'],
+                        ],
+                    ];
+                    unset($legacyPayload['response_format']);
+                }
 
                 error_log('Retrying plan request with legacy response_format parameter: ' . $exception->getMessage());
 


### PR DESCRIPTION
## Summary
- send plan generation requests using the supported top-level `response_format`
- translate the schema to the legacy `response.text.format` structure before retrying with the legacy flag

## Testing
- php -l src/AI/OpenAIProvider.php

------
https://chatgpt.com/codex/tasks/task_e_68dba7f01144832e836f50e3f77c9337