### PR TITLE
Handle legacy response_format fallback triggers

### DIFF
--- a/src/AI/OpenAIProvider.php
+++ b/src/AI/OpenAIProvider.php
@@ -746,7 +746,7 @@ final class OpenAIProvider
 
         if ($message !== '') {
             if ($this->mentionsUnsupportedLegacyResponseFormat($message)) {
-                return false;
+                return true;
             }
 
             if ($this->mentionsUnknownResponseParameter($message)) {
@@ -758,7 +758,7 @@ final class OpenAIProvider
 
         if ($body !== '') {
             if ($this->mentionsUnsupportedLegacyResponseFormat($body)) {
-                return false;
+                return true;
             }
 
             if ($this->mentionsUnknownResponseParameter($body)) {
@@ -786,12 +786,26 @@ final class OpenAIProvider
     }
 
     /**
-     * Detect whether the message indicates the legacy response_format parameter is unsupported.
+     * Detect whether the message indicates the modern response_format parameter is unsupported or has moved.
      */
     private function mentionsUnsupportedLegacyResponseFormat(string $message): bool
     {
-        return strpos($message, "unsupported parameter") !== false
-            && strpos($message, "'response_format'") !== false;
+        $mentionsResponseFormat = strpos($message, 'response_format') !== false;
+        $mentionsUnsupported = strpos($message, 'unsupported parameter') !== false
+            || strpos($message, 'is unsupported') !== false
+            || strpos($message, 'not supported') !== false;
+
+        if ($mentionsResponseFormat && $mentionsUnsupported) {
+            return true;
+        }
+
+        if (strpos($message, 'moved to') !== false) {
+            if (strpos($message, 'text.format') !== false || strpos($message, 'response.format') !== false) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure errors mentioning the response_format key being unsupported trigger the legacy fallback
- recognise OpenAI error messages that state response_format moved to text.format as a legacy fallback trigger

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbaba6e4d4832ea126ea4f4787abf7