### PR TITLE
Fix OpenAI Responses payload for plan and draft requests

### DIFF
--- a/src/AI/OpenAIProvider.php
+++ b/src/AI/OpenAIProvider.php
@@ -137,7 +137,6 @@ final class OpenAIProvider
             'model' => $this->modelPlan,
             'input' => $this->formatMessagesForResponses($messages),
             'max_output_tokens' => $this->maxTokens,
-            'modalities' => ['text'],
             'response_format' => $this->buildPlanJsonSchema(),
         ];
 
@@ -221,7 +220,6 @@ final class OpenAIProvider
             'model' => $this->modelDraft,
             'input' => $this->formatMessagesForResponses($messages),
             'max_output_tokens' => $this->maxTokens,
-            'modalities' => ['text'],
         ];
 
         $result = $this->performChatRequest($payload, 'draft', $streamHandler);


### PR DESCRIPTION
## Summary
- remove the unsupported modalities field from the plan and draft payloads so OpenAI accepts the request

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dbba54de94832eb9714cbc513f0407