### PR TITLE
Add tailoring cleanup endpoint and UI

### DIFF
--- a/public/assets/js/tailor.js
+++ b/public/assets/js/tailor.js
@@ -200,6 +200,7 @@
             successMessage: '',
             isSubmitting: false,
             cancellingGenerations: [],
+            isCleaning: false,
 
             /**
              * Initialise the wizard with default selections and contextual messaging.
@@ -589,6 +590,79 @@
                     this.cancellingGenerations = this.cancellingGenerations.filter(function (value) {
                         return value !== id;
                     });
+                }
+            },
+
+            /**
+             * Remove stored queue jobs and failure logs linked to the workspace.
+             *
+             * Cleaning up keeps the tailoring dashboard focused on fresh runs and
+             * prevents historical noise from lingering in the interface.
+             */
+            async cleanupTailoringData() {
+                if (this.isCleaning) {
+                    return;
+                }
+
+                this.errorMessage = '';
+                this.successMessage = '';
+                this.isCleaning = true;
+
+                try {
+                    const response = await fetch('/tailor/cleanup', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-CSRF-Token': csrfToken,
+                        },
+                        credentials: 'same-origin',
+                        body: JSON.stringify({
+                            _token: csrfToken,
+                        }),
+                    });
+
+                    const data = await response.json();
+
+                    if (!response.ok) {
+                        const message = data && typeof data.error === 'string'
+                            ? data.error
+                            : 'Unable to clean up tailoring data.';
+
+                        this.errorMessage = message;
+
+                        return;
+                    }
+
+                    if (Array.isArray(data.generations)) {
+                        this.generations = data.generations.slice();
+                    }
+
+                    this.processingLogs = Array.isArray(data.generation_logs)
+                        ? data.generation_logs.slice()
+                        : [];
+
+                    const removedJobs = normaliseNumber(data.removed_jobs, 0);
+                    const clearedLogs = normaliseNumber(data.cleared_logs, 0);
+
+                    const parts = [];
+
+                    if (removedJobs > 0) {
+                        parts.push(`${removedJobs} job${removedJobs === 1 ? '' : 's'}`);
+                    }
+
+                    if (clearedLogs > 0) {
+                        parts.push(`${clearedLogs} log${clearedLogs === 1 ? '' : 's'}`);
+                    }
+
+                    if (parts.length === 0) {
+                        this.successMessage = 'Tailoring data already clean.';
+                    } else {
+                        this.successMessage = `Removed ${parts.join(' and ')}.`;
+                    }
+                } catch (error) {
+                    this.errorMessage = 'A network error prevented cleaning up tailoring data.';
+                } finally {
+                    this.isCleaning = false;
                 }
             },
 

--- a/resources/views/tailor.php
+++ b/resources/views/tailor.php
@@ -429,12 +429,29 @@ $additionalHead = '<script src="/assets/js/tailor.js" defer></script>';
                 <h3 class="text-xl font-semibold text-white">Processing logs</h3>
                 <p class="text-sm text-slate-400">Review recent failures recorded while tailoring CVs.</p>
             </div>
-            <template x-if="processingLogs.length">
-                <span class="rounded-full border border-rose-400/40 bg-rose-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-200">
-                    <span x-text="processingLogs.length"></span>
-                    <span class="ml-1">issue<span x-text="processingLogs.length === 1 ? '' : 's'"></span></span>
-                </span>
-            </template>
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+                <template x-if="processingLogs.length">
+                    <span class="rounded-full border border-rose-400/40 bg-rose-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-200">
+                        <span x-text="processingLogs.length"></span>
+                        <span class="ml-1">issue<span x-text="processingLogs.length === 1 ? '' : 's'"></span></span>
+                    </span>
+                </template>
+                <button
+                    type="button"
+                    class="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-200 transition hover:border-indigo-400/40 hover:bg-indigo-500/10 hover:text-indigo-100"
+                    @click="cleanupTailoringData()"
+                    :disabled="isCleaning"
+                    :class="isCleaning ? 'cursor-not-allowed opacity-60' : ''"
+                >
+                    <span x-show="!isCleaning">Clean up logs &amp; jobs</span>
+                    <span x-show="isCleaning" class="inline-flex items-center gap-2">
+                        <svg class="h-3 w-3 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                            <path d="M12 4v2m4.24.76l-1.42 1.42M20 12h-2m-.76 4.24l-1.42-1.42M12 20v-2m-4.24-.76l1.42-1.42M4 12h2m.76-4.24l1.42 1.42" stroke-linecap="round" stroke-linejoin="round"></path>
+                        </svg>
+                        Cleaning…
+                    </span>
+                </button>
+            </div>
         </div>
         <div class="mt-6 space-y-4">
             <template x-if="processingLogs.length === 0">

--- a/src/Generations/GenerationRepository.php
+++ b/src/Generations/GenerationRepository.php
@@ -11,7 +11,11 @@ use PDO;
 use RuntimeException;
 use Throwable;
 
+use function array_fill;
+use function array_values;
 use function in_array;
+use function is_array;
+use function is_string;
 use function json_decode;
 use function json_encode;
 use function preg_replace;
@@ -245,6 +249,64 @@ final class GenerationRepository
     }
 
     /**
+     * Remove residual queue jobs associated with the supplied user identifier.
+     *
+     * Cleaning the queue ensures abandoned tailoring runs do not accumulate and
+     * keeps the dashboard in sync with the background worker state.
+     */
+    public function cleanupJobsForUser(int $userId): int
+    {
+        try {
+            $select = $this->pdo->prepare('SELECT id, payload_json FROM jobs WHERE type = :type');
+            $select->execute([':type' => 'tailor_cv']);
+        } catch (Throwable $exception) {
+            throw new RuntimeException('Unable to retrieve tailoring jobs for cleanup.', 0, $exception);
+        }
+
+        try {
+            $delete = $this->pdo->prepare('DELETE FROM jobs WHERE id = :id');
+        } catch (Throwable $exception) {
+            throw new RuntimeException('Unable to prepare job deletion statement.', 0, $exception);
+        }
+
+        $removed = 0;
+        $affectedGenerations = [];
+
+        while ($row = $select->fetch(PDO::FETCH_ASSOC)) {
+            $jobId = isset($row['id']) ? (int) $row['id'] : 0;
+
+            if ($jobId <= 0) {
+                continue;
+            }
+
+            $payload = $this->decodeJobPayload($row['payload_json'] ?? null);
+            $payloadUserId = isset($payload['user_id']) ? (int) $payload['user_id'] : 0;
+
+            if ($payloadUserId !== $userId) {
+                continue;
+            }
+
+            $delete->execute([':id' => $jobId]);
+
+            if ($delete->rowCount() > 0) {
+                $removed++;
+
+                $generationId = isset($payload['generation_id']) ? (int) $payload['generation_id'] : 0;
+
+                if ($generationId > 0) {
+                    $affectedGenerations[] = $generationId;
+                }
+            }
+        }
+
+        if ($removed > 0 && $affectedGenerations !== []) {
+            $this->markGenerationsCancelled($affectedGenerations);
+        }
+
+        return $removed;
+    }
+
+    /**
      * Handle the normalise row workflow.
      *
      * This helper keeps the normalise row logic centralised for clarity and reuse.
@@ -268,6 +330,77 @@ final class GenerationRepository
                 'filename' => (string) $row['cv_filename'],
             ],
         ];
+    }
+
+    /**
+     * Update the supplied generations to reflect their removal from the queue.
+     *
+     * Marking affected runs as cancelled prevents the UI from reporting that a
+     * background task is still pending once its job record has been deleted.
+     *
+     * @param array<int, int> $generationIds
+     */
+    private function markGenerationsCancelled(array $generationIds): void
+    {
+        $unique = [];
+
+        foreach ($generationIds as $generationId) {
+            $id = (int) $generationId;
+
+            if ($id > 0) {
+                $unique[$id] = $id;
+            }
+        }
+
+        if ($unique === []) {
+            return;
+        }
+
+        $ids = array_values($unique);
+        $placeholders = implode(', ', array_fill(0, count($ids), '?'));
+
+        $sql = 'UPDATE generations SET status = ?, progress_percent = 0, error_message = NULL, updated_at = ? '
+            . 'WHERE id IN (' . $placeholders . ") AND status IN ('queued', 'processing')";
+
+        try {
+            $statement = $this->pdo->prepare($sql);
+            $parameters = array_merge(
+                ['cancelled', (new DateTimeImmutable('now'))->format('Y-m-d H:i:s')],
+                $ids
+            );
+            $statement->execute($parameters);
+        } catch (Throwable $exception) {
+            throw new RuntimeException('Failed to update generations after queue cleanup.', 0, $exception);
+        }
+    }
+
+    /**
+     * Decode the JSON payload stored alongside a queued job.
+     *
+     * A defensive decoder avoids propagating malformed payloads further into
+     * the cleanup workflow when older jobs contain unexpected structures.
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeJobPayload($payload): array
+    {
+        if (!is_string($payload)) {
+            return [];
+        }
+
+        $trimmed = trim($payload);
+
+        if ($trimmed === '') {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($trimmed, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable $exception) {
+            return [];
+        }
+
+        return is_array($decoded) ? $decoded : [];
     }
 
     /**

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -45,6 +45,10 @@ class Routes
             return $container->get(TailorController::class)->show($request, $response);
         });
 
+        $app->post('/tailor/cleanup', function (Request $request, Response $response) use ($container) {
+            return $container->get(TailorController::class)->cleanup($request, $response);
+        });
+
         $app->get('/documents', function (Request $request, Response $response) use ($container) {
             return $container->get(DocumentController::class)->index($request, $response);
         });


### PR DESCRIPTION
## Summary
- add a backend cleanup workflow that removes tailoring queue jobs, clears failure logs, and cancels affected generations
- expose a `/tailor/cleanup` route with controller support and surface a Tailor UI button plus Alpine helper to trigger the cleanup

## Testing
- composer test
- php -l src/Controllers/TailorController.php
- php -l src/Generations/GenerationRepository.php
- php -l src/Generations/GenerationLogRepository.php

------
https://chatgpt.com/codex/tasks/task_e_68dbdfcfa5d8832eac7b2d6e04a39fda