### PR TITLE
Add tailored CV deletion and promotion actions

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -94,7 +94,8 @@ $container->set(DocumentController::class, static function (Container $c): Docum
         $c->get(DocumentService::class),
         $c->get(DocumentPreviewer::class),
         $c->get(GenerationRepository::class),
-        $c->get(GenerationTokenService::class)
+        $c->get(GenerationTokenService::class),
+        $c->get(GenerationDownloadService::class)
     );
 });
 

--- a/resources/views/documents.php
+++ b/resources/views/documents.php
@@ -198,16 +198,32 @@
                                     <p class="font-medium text-white">Job: <?= htmlspecialchars($generation['job_document']['filename'], ENT_QUOTES) ?></p>
                                     <p class="text-xs text-slate-400">Source CV: <?= htmlspecialchars($generation['cv_document']['filename'], ENT_QUOTES) ?></p>
                                 </div>
-                                <?php if ($statusValue === 'completed' && !empty($generation['downloads']['md'])) : ?>
-                                    <div class="flex flex-wrap gap-2">
+                                <div class="flex flex-wrap gap-2">
+                                    <?php if ($statusValue === 'completed' && !empty($generation['downloads']['md'])) : ?>
                                         <a
                                             href="<?= htmlspecialchars($generation['downloads']['md'], ENT_QUOTES) ?>"
                                             class="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-100 transition hover:border-emerald-300 hover:text-emerald-50"
                                         >
                                             Download markdown
                                         </a>
-                                    </div>
-                                <?php endif; ?>
+                                    <?php endif; ?>
+                                    <?php if (!empty($generation['promote_url'])) : ?>
+                                        <form method="post" action="<?= htmlspecialchars($generation['promote_url'], ENT_QUOTES) ?>" class="inline">
+                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                                            <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-indigo-400/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-100 transition hover:border-indigo-300 hover:text-indigo-50">
+                                                Save as CV
+                                            </button>
+                                        </form>
+                                    <?php endif; ?>
+                                    <?php if (!empty($generation['delete_url'])) : ?>
+                                        <form method="post" action="<?= htmlspecialchars($generation['delete_url'], ENT_QUOTES) ?>" class="inline">
+                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                                            <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-rose-500/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-300 hover:text-rose-50">
+                                                Delete
+                                            </button>
+                                        </form>
+                                    <?php endif; ?>
+                                </div>
                                 <dl class="grid gap-2 text-xs text-slate-300 sm:grid-cols-3">
                                     <div>
                                         <dt class="font-semibold text-slate-200">Model</dt>

--- a/src/Documents/DocumentService.php
+++ b/src/Documents/DocumentService.php
@@ -98,6 +98,31 @@ class DocumentService
     }
 
     /**
+     * Persist a document sourced from an existing content string.
+     *
+     * Providing a centralised helper keeps tailored draft promotion aligned
+     * with the upload workflow so validation and hashing remain consistent.
+     */
+    public function storeDocumentFromContent(int $userId, string $documentType, string $filename, string $content): Document
+    {
+        $validation = $this->validator->validate($filename, $content, null);
+
+        $document = new Document(
+            null,
+            $userId,
+            $documentType,
+            $filename,
+            $validation['mime'],
+            $validation['size'],
+            hash('sha256', $content),
+            $content,
+            new DateTimeImmutable()
+        );
+
+        return $this->repository->save($document);
+    }
+
+    /**
      * Handle the find operation.
      *
      * Documenting this helper clarifies its role within the wider workflow.

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -65,6 +65,14 @@ class Routes
             return $container->get(DocumentController::class)->delete($request, $response, $args);
         });
 
+        $app->post('/documents/tailored/{id}/delete', function (Request $request, Response $response, array $args) use ($container) {
+            return $container->get(DocumentController::class)->deleteGeneration($request, $response, $args);
+        });
+
+        $app->post('/documents/tailored/{id}/promote', function (Request $request, Response $response, array $args) use ($container) {
+            return $container->get(DocumentController::class)->promoteGeneration($request, $response, $args);
+        });
+
         $app->get('/applications', function (Request $request, Response $response) use ($container) {
             return $container->get(JobApplicationController::class)->index($request, $response);
         });


### PR DESCRIPTION
## Summary
- allow tailored CV runs to be deleted or promoted into the CV library via new document controller actions and generation repository support
- expose the new actions in the documents view and ensure the controller can persist generated markdown through the document service
- wire container and route registrations so the tailored CV management endpoints are reachable

## Testing
- php -l src/Documents/DocumentService.php
- php -l src/Controllers/DocumentController.php
- php -l src/Generations/GenerationRepository.php
- php -l src/Routes.php
- php -l public/index.php
- php -l resources/views/documents.php

------
https://chatgpt.com/codex/tasks/task_e_68dc08438710832e9159ab7058719b3a