### PR TITLE
Fix duplicate generation download service injection

### DIFF
--- a/src/Controllers/DocumentController.php
+++ b/src/Controllers/DocumentController.php
@@ -48,9 +48,6 @@ final class DocumentController
     /** @var GenerationTokenService|null */
     private $generationTokenService;
 
-    /** @var GenerationDownloadService */
-    private $generationDownloadService;
-
     /**
      * Construct the object with its required dependencies.
      *
@@ -63,8 +60,7 @@ final class DocumentController
         DocumentPreviewer $documentPreviewer,
         GenerationDownloadService $generationDownloadService,
         GenerationRepository $generationRepository,
-        ?GenerationTokenService $generationTokenService,
-        GenerationDownloadService $generationDownloadService
+        ?GenerationTokenService $generationTokenService
     ) {
         $this->renderer = $renderer;
         $this->documentRepository = $documentRepository;
@@ -73,7 +69,6 @@ final class DocumentController
         $this->generationDownloadService = $generationDownloadService;
         $this->generationRepository = $generationRepository;
         $this->generationTokenService = $generationTokenService;
-        $this->generationDownloadService = $generationDownloadService;
     }
 
     /**


### PR DESCRIPTION
## Summary
- remove the duplicate GenerationDownloadService property from DocumentController
- fix the constructor signature to inject the download service only once

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dc0d104120832ebce756e33887dac3