### PR TITLE
Fix PHP 7 compatibility in download controller

### DIFF
--- a/src/Controllers/GenerationDownloadController.php
+++ b/src/Controllers/GenerationDownloadController.php
@@ -72,9 +72,9 @@ final class GenerationDownloadController
 
         try {
             $download = $this->downloadService->fetch($generationId, $userId, $format);
-        } catch (GenerationNotFoundException) {
+        } catch (GenerationNotFoundException $exception) {
             return $this->error($response, 404, 'Generation not found.');
-        } catch (GenerationAccessDeniedException) {
+        } catch (GenerationAccessDeniedException $exception) {
             return $this->error($response, 403, 'You do not have access to this generation.');
         } catch (GenerationOutputUnavailableException $exception) {
             return $this->error($response, 409, $exception->getMessage());


### PR DESCRIPTION
## Summary
- add explicit exception variables in GenerationDownloadController catch blocks to remain compatible with PHP 7.4

## Testing
- php -l src/Controllers/GenerationDownloadController.php

------
https://chatgpt.com/codex/tasks/task_e_68df91d2c120832e8f14cf0efed22860