### PR TITLE
Handle binary conversion failures gracefully

### DIFF
--- a/resources/views/document-view.php
+++ b/resources/views/document-view.php
@@ -1,5 +1,5 @@
 <?php
-/** @var array{filename: string, created_at: string, size: string, mime_type: string, type_label: string, preview: string, id: int|null} $document */
+/** @var array{filename: string, created_at: string, size: string, mime_type: string, type_label: string, preview: string, id: int|null, download_url: string|null} $document */
 /** @var string $title */
 /** @var string $subtitle */
 /** @var array<int, array{href: string, label: string, current: bool}> $navLinks */
@@ -63,6 +63,11 @@
                     <h3 class="text-lg font-semibold text-white">Contents</h3>
                     <p class="text-sm text-slate-400">Plain text preview extracted for quick review.</p>
                 </div>
+                <?php if (!empty($document['download_url'])) : ?>
+                    <a href="<?= htmlspecialchars($document['download_url'], ENT_QUOTES) ?>" class="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-100 transition hover:border-emerald-300 hover:text-emerald-50">
+                        Download original
+                    </a>
+                <?php endif; ?>
             </header>
             <div class="mt-4 max-h-[540px] overflow-auto rounded-xl border border-slate-800/60 bg-slate-950/60 p-4 text-sm leading-relaxed text-slate-200">
                 <?php if ($document['preview'] === '') : ?>

--- a/resources/views/documents.php
+++ b/resources/views/documents.php
@@ -2,8 +2,8 @@
 /** @var string $title */
 /** @var string $subtitle */
 /** @var array<int, array{href: string, label: string, current: bool}> $navLinks */
-/** @var array<int, array{id: int|null, filename: string, created_at: string, size: string}> $jobDocuments */
-/** @var array<int, array{id: int|null, filename: string, created_at: string, size: string}> $cvDocuments */
+/** @var array<int, array{id: int|null, filename: string, created_at: string, size: string, view_url: string|null, download_url: string|null}> $jobDocuments */
+/** @var array<int, array{id: int|null, filename: string, created_at: string, size: string, view_url: string|null, download_url: string|null}> $cvDocuments */
 /** @var array<int, array<string, mixed>> $tailoredGenerations */
 /** @var array<int, string> $errors */
 /** @var string|null $status */
@@ -108,6 +108,11 @@
                                 </div>
                                 <?php if (!empty($document['id'])) : ?>
                                     <div class="flex items-center gap-2 self-start sm:self-auto">
+                                        <?php if (!empty($document['download_url'])) : ?>
+                                            <a href="<?= htmlspecialchars($document['download_url'], ENT_QUOTES) ?>" class="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-100 transition hover:border-emerald-300 hover:text-emerald-50">
+                                                Download
+                                            </a>
+                                        <?php endif; ?>
                                         <?php if (!empty($document['view_url'])) : ?>
                                             <a href="<?= htmlspecialchars($document['view_url'], ENT_QUOTES) ?>" class="inline-flex items-center gap-2 rounded-full border border-indigo-400/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-100 transition hover:border-indigo-300 hover:text-indigo-50">
                                                 View
@@ -149,6 +154,11 @@
                                 </div>
                                 <?php if (!empty($document['id'])) : ?>
                                     <div class="flex items-center gap-2 self-start sm:self-auto">
+                                        <?php if (!empty($document['download_url'])) : ?>
+                                            <a href="<?= htmlspecialchars($document['download_url'], ENT_QUOTES) ?>" class="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-100 transition hover:border-emerald-300 hover:text-emerald-50">
+                                                Download
+                                            </a>
+                                        <?php endif; ?>
                                         <?php if (!empty($document['view_url'])) : ?>
                                             <a href="<?= htmlspecialchars($document['view_url'], ENT_QUOTES) ?>" class="inline-flex items-center gap-2 rounded-full border border-indigo-400/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-100 transition hover:border-indigo-300 hover:text-indigo-50">
                                                 View

--- a/src/Queue/Handler/TailorCvJobHandler.php
+++ b/src/Queue/Handler/TailorCvJobHandler.php
@@ -214,7 +214,8 @@ final class TailorCvJobHandler implements JobHandlerInterface
     /**
      * Generate DOCX and PDF binaries for the supplied markdown document.
      *
-     * Having a shared helper keeps binary conversion consistent across CV and cover letter outputs.
+     * Having a shared helper keeps binary conversion consistent across CV and cover letter outputs
+     * while gracefully degrading to markdown-only storage if the conversion stack raises an error.
      *
      * @return array<string, string>
      */
@@ -223,7 +224,14 @@ final class TailorCvJobHandler implements JobHandlerInterface
         try {
             return $converter->renderFormats($markdown);
         } catch (Throwable $exception) {
-            throw new RuntimeException('Failed to convert markdown into binary formats.', 0, $exception);
+            error_log(
+                sprintf(
+                    'TailorCvJobHandler failed to render binary formats: %s',
+                    $exception->getMessage()
+                )
+            );
+
+            return [];
         }
     }
 

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -57,6 +57,10 @@ class Routes
             return $container->get(DocumentController::class)->show($request, $response, $args);
         });
 
+        $app->get('/documents/{id}/download', function (Request $request, Response $response, array $args) use ($container) {
+            return $container->get(DocumentController::class)->download($request, $response, $args);
+        });
+
         $app->post('/documents/upload', function (Request $request, Response $response) use ($container) {
             return $container->get(DocumentController::class)->upload($request, $response);
         });


### PR DESCRIPTION
## Summary
- guard the tailored CV job against converter failures by logging and falling back to markdown-only outputs
- document the graceful degradation within the job handler comments

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68df9487a8b8832e8b1bc915076181b8