### PR TITLE
Fix cover letter PDF downloads by converting only requested format

### DIFF
--- a/src/Conversion/Converter.php
+++ b/src/Conversion/Converter.php
@@ -100,9 +100,29 @@ class Converter
     public function renderFormats(string $markdown): array
     {
         return [
-            'docx' => $this->convertMarkdownToDocx($markdown),
-            'pdf' => $this->convertMarkdownToPdf($markdown),
+            'docx' => $this->renderFormat($markdown, 'docx'),
+            'pdf' => $this->renderFormat($markdown, 'pdf'),
         ];
+    }
+
+    /**
+     * Render the markdown into a single requested format.
+     *
+     * Centralising this helper ensures controllers can request specific binaries without converting unused formats.
+     */
+    public function renderFormat(string $markdown, string $format): string
+    {
+        $normalizedFormat = strtolower($format);
+
+        if ($normalizedFormat === 'docx') {
+            return $this->convertMarkdownToDocx($markdown);
+        }
+
+        if ($normalizedFormat === 'pdf') {
+            return $this->convertMarkdownToPdf($markdown);
+        }
+
+        throw new RuntimeException('Unsupported format requested for rendering.');
     }
 
     /**

--- a/src/Generations/GenerationDownloadService.php
+++ b/src/Generations/GenerationDownloadService.php
@@ -133,7 +133,7 @@ final class GenerationDownloadService
         $markdown = $this->loadMarkdown($generationId, $artifact);
 
         try {
-            $rendered = $this->converter->renderFormats($markdown);
+            $binary = $this->converter->renderFormat($markdown, $extension);
         } catch (Throwable $exception) {
             error_log(
                 sprintf(
@@ -146,12 +146,6 @@ final class GenerationDownloadService
 
             throw new GenerationOutputUnavailableException('Failed to convert markdown into the requested format.');
         }
-
-        if (!isset($rendered[$extension])) {
-            throw new GenerationOutputUnavailableException('Requested format is not available for this generation.');
-        }
-
-        $binary = (string) $rendered[$extension];
 
         if ($binary === '') {
             throw new GenerationOutputUnavailableException('Requested format is not available for this generation.');


### PR DESCRIPTION
## Summary
- add a converter helper for rendering a single format to support targeted downloads
- call the single-format renderer during generation downloads so PDF exports no longer fail when other conversions raise exceptions

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dfa54cc1a8832e94349688a3f1856f