### PR TITLE
Handle CommonMark converter API compatibility

### DIFF
--- a/src/Conversion/Converter.php
+++ b/src/Conversion/Converter.php
@@ -233,8 +233,12 @@ class Converter
      */
     private function convertMarkdownToPdf(string $markdown): string
     {
-        $converted = $this->markdownConverter->convert($markdown);
-        $html = $converted instanceof RenderedContentInterface ? $converted->getContent() : (string) $converted;
+        if (method_exists($this->markdownConverter, 'convertToHtml')) {
+            $html = (string) $this->markdownConverter->convertToHtml($markdown);
+        } else {
+            $converted = $this->markdownConverter->convert($markdown);
+            $html = $converted instanceof RenderedContentInterface ? $converted->getContent() : (string) $converted;
+        }
 
         $options = new Options();
         $options->set('isRemoteEnabled', false);


### PR DESCRIPTION
## Summary
- update the PDF conversion workflow to support the CommonMark converter API available in newer releases
- retain backwards compatibility with older CommonMark versions when rendering markdown

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dfa6ef4b58832eb2f3f033d5ad5a0b