### PR TITLE
Fix usage analytics model attribution

### DIFF
--- a/src/AI/OpenAIProvider.php
+++ b/src/AI/OpenAIProvider.php
@@ -436,10 +436,15 @@ final class OpenAIProvider
                     $finishReason = $responseMeta['output'][0]['finish_reason'];
                 }
 
+                $requestedModel = $payload['model'] ?? null;
+                $reportedModel = $responseMeta['model'] ?? null;
+
                 $metadata = [
                     'operation' => $operation,
                     'response_id' => $responseMeta['id'] ?? null,
-                    'model' => $responseMeta['model'] ?? ($payload['model'] ?? null),
+                    'model' => $requestedModel ?? $reportedModel,
+                    'model_requested' => $requestedModel,
+                    'model_reported' => $reportedModel,
                     'finish_reason' => $finishReason,
                 ];
 


### PR DESCRIPTION
## Summary
- capture both the requested and reported model identifiers when recording OpenAI usage metadata
- update the usage service to prioritise the requested model so the dashboard shows the correct value

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dfa8505fcc832eb0a19cce0dc946ca