### PR TITLE
Add production database schema verifier page

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -16,6 +16,7 @@ use App\Controllers\HomeController;
 use App\Controllers\TailorController;
 use App\Controllers\ContactDetailsController;
 use App\Controllers\RetentionController;
+use App\Controllers\SchemaTestController;
 use App\Documents\DocumentPreviewer;
 use App\Documents\DocumentRepository;
 use App\Documents\DocumentService;
@@ -30,6 +31,7 @@ use App\Middleware\SessionMiddleware;
 use App\Routes;
 use App\Services\AuthService;
 use App\Services\AuditLogger;
+use App\Services\DatabaseSchemaVerifier;
 use App\Services\RateLimiter;
 use App\Services\RetentionPolicyService;
 use App\Services\UsageService;
@@ -223,6 +225,17 @@ $container->set(UsageService::class, static function (Container $c): UsageServic
 $container->set(UsageController::class, static function (Container $c): UsageController {
     return new UsageController($c->get(UsageService::class), $c->get(Renderer::class));
 
+});
+
+$container->set(DatabaseSchemaVerifier::class, static function (Container $c): DatabaseSchemaVerifier {
+    return new DatabaseSchemaVerifier($c->get(\PDO::class));
+});
+
+$container->set(SchemaTestController::class, static function (Container $c): SchemaTestController {
+    return new SchemaTestController(
+        $c->get(Renderer::class),
+        $c->get(DatabaseSchemaVerifier::class)
+    );
 });
 
 $container->set(RetentionPolicyService::class, static function (Container $c): RetentionPolicyService {

--- a/resources/views/dashboard.php
+++ b/resources/views/dashboard.php
@@ -51,6 +51,20 @@ $fullWidth = true;
                         Retention settings
                         <span class="mt-1 block text-xs text-slate-400">Adjust data governance and purge rules.</span>
                     </a>
+                    <a href="/settings/schema-test" class="mt-1 block rounded-lg px-3 py-2 text-sm text-slate-200 transition hover:bg-slate-800/80 hover:text-indigo-100">
+                        <span class="flex items-start gap-3">
+                            <span class="mt-0.5 inline-flex rounded-lg bg-indigo-500/20 p-1 text-indigo-200">
+                                <svg aria-hidden="true" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                                    <path d="M9 12l2 2 4-4" stroke-linecap="round" stroke-linejoin="round"></path>
+                                    <path d="M12 21a9 9 0 110-18 9 9 0 010 18z" stroke-linecap="round" stroke-linejoin="round"></path>
+                                </svg>
+                            </span>
+                            <span>
+                                <span class="block font-medium text-slate-100">Schema test</span>
+                                <span class="mt-1 block text-xs text-slate-400">Run the production database table check.</span>
+                            </span>
+                        </span>
+                    </a>
                 </div>
             </div>
             <form method="post" action="/auth/logout" class="md:self-end">

--- a/resources/views/schema-test.php
+++ b/resources/views/schema-test.php
@@ -1,0 +1,125 @@
+<?php
+/** @var string $title */
+/** @var array{passed: bool, results: array<int, array{table: string, exists: bool, missing_columns: array<int, string>, unexpected_columns: array<int, string>, error: string|null, is_valid: bool}>} $report */
+
+$fullWidth = true;
+$subtitle = 'Schema health in a single click';
+$navLinks = [
+    ['href' => '/', 'label' => 'Dashboard', 'current' => false],
+    ['href' => '/tailor', 'label' => 'Tailor CV & letter', 'current' => false],
+    ['href' => '/documents', 'label' => 'Documents', 'current' => false],
+    ['href' => '/applications', 'label' => 'Applications', 'current' => false],
+    ['href' => '/profile/contact-details', 'label' => 'Contact details', 'current' => false],
+    ['href' => '/usage', 'label' => 'Usage', 'current' => false],
+    ['href' => '/retention', 'label' => 'Retention', 'current' => false],
+    ['href' => '/settings/schema-test', 'label' => 'Schema test', 'current' => true],
+];
+?>
+<?php ob_start(); ?>
+<div class="space-y-10">
+    <header class="space-y-3">
+        <p class="text-sm uppercase tracking-[0.3em] text-indigo-400">Diagnostics</p>
+        <div class="space-y-2">
+            <h1 class="text-4xl font-semibold text-slate-50 sm:text-5xl">Database schema test</h1>
+            <p class="max-w-2xl text-base text-slate-300">
+                Run this test directly in production to confirm every required table and column is available before shipping new features.
+            </p>
+        </div>
+    </header>
+
+    <section class="space-y-4">
+        <?php if ($report['passed']) : ?>
+            <div class="flex items-center gap-3 rounded-2xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100 shadow-lg">
+                <span class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-emerald-500/20">
+                    <svg aria-hidden="true" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                        <path d="M5 13l4 4L19 7" stroke-linecap="round" stroke-linejoin="round"></path>
+                    </svg>
+                </span>
+                <p class="text-sm font-medium">
+                    All tables look healthy. No action required.
+                </p>
+            </div>
+        <?php else : ?>
+            <div class="space-y-2 rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-4 text-sm text-rose-100 shadow-lg">
+                <div class="flex items-center gap-3">
+                    <span class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-rose-500/20">
+                        <svg aria-hidden="true" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                            <path d="M12 9v4" stroke-linecap="round" stroke-linejoin="round"></path>
+                            <path d="M12 17h.01" stroke-linecap="round" stroke-linejoin="round"></path>
+                            <path d="M10.29 3.86L1.82 18a1 1 0 00.86 1.5h18.64a1 1 0 00.86-1.5L13.71 3.86a1 1 0 00-1.72 0z" stroke-linecap="round" stroke-linejoin="round"></path>
+                        </svg>
+                    </span>
+                    <p class="text-sm font-semibold">
+                        Some tables need attention. Review the breakdown below and rerun after correcting the schema.
+                    </p>
+                </div>
+            </div>
+        <?php endif; ?>
+
+        <div class="grid gap-4 lg:grid-cols-2">
+            <?php foreach ($report['results'] as $tableResult) : ?>
+                <?php
+                $isValid = $tableResult['is_valid'];
+                $panelClasses = $isValid
+                    ? 'border-emerald-500/30 bg-emerald-500/5'
+                    : 'border-rose-500/40 bg-rose-500/5';
+                ?>
+                <article class="rounded-2xl border <?= $panelClasses ?> p-5 shadow-lg">
+                    <header class="flex items-center justify-between">
+                        <div>
+                            <h2 class="text-lg font-semibold text-slate-100"><?= htmlspecialchars($tableResult['table'], ENT_QUOTES) ?></h2>
+                            <p class="text-xs uppercase tracking-[0.25em] text-slate-400">Schema status</p>
+                        </div>
+                        <span class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold <?= $isValid ? 'bg-emerald-500/20 text-emerald-100' : 'bg-rose-500/20 text-rose-100' ?>">
+                            <?php if ($isValid) : ?>
+                                <svg aria-hidden="true" class="h-3 w-3" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                                    <path d="M5 13l4 4L19 7" stroke-linecap="round" stroke-linejoin="round"></path>
+                                </svg>
+                                Passing
+                            <?php else : ?>
+                                <svg aria-hidden="true" class="h-3 w-3" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                                    <path d="M6 18L18 6" stroke-linecap="round" stroke-linejoin="round"></path>
+                                    <path d="M6 6l12 12" stroke-linecap="round" stroke-linejoin="round"></path>
+                                </svg>
+                                Needs fixes
+                            <?php endif; ?>
+                        </span>
+                    </header>
+
+                    <dl class="mt-4 space-y-3 text-sm text-slate-300">
+                        <div class="flex items-start justify-between gap-3">
+                            <dt class="text-slate-400">Exists in database</dt>
+                            <dd class="font-medium text-slate-100"><?= $tableResult['exists'] ? 'Yes' : 'No' ?></dd>
+                        </div>
+                        <?php if ($tableResult['error'] !== null) : ?>
+                            <div class="rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+                                <?= htmlspecialchars($tableResult['error'], ENT_QUOTES) ?>
+                            </div>
+                        <?php endif; ?>
+                        <?php if ($tableResult['missing_columns'] !== []) : ?>
+                            <div>
+                                <dt class="text-slate-400">Missing columns</dt>
+                                <dd class="mt-1 font-medium text-rose-200">
+                                    <?= htmlspecialchars(implode(', ', $tableResult['missing_columns']), ENT_QUOTES) ?>
+                                </dd>
+                            </div>
+                        <?php endif; ?>
+                        <?php if ($tableResult['unexpected_columns'] !== []) : ?>
+                            <div>
+                                <dt class="text-slate-400">Unexpected columns</dt>
+                                <dd class="mt-1 font-medium text-amber-200">
+                                    <?= htmlspecialchars(implode(', ', $tableResult['unexpected_columns']), ENT_QUOTES) ?>
+                                </dd>
+                            </div>
+                        <?php endif; ?>
+                        <?php if ($tableResult['missing_columns'] === [] && $tableResult['unexpected_columns'] === [] && $tableResult['error'] === null) : ?>
+                            <p class="text-xs text-slate-400">All expected columns are present.</p>
+                        <?php endif; ?>
+                    </dl>
+                </article>
+            <?php endforeach; ?>
+        </div>
+    </section>
+</div>
+<?php $body = ob_get_clean(); ?>
+<?php include __DIR__ . '/layout.php'; ?>

--- a/src/Controllers/SchemaTestController.php
+++ b/src/Controllers/SchemaTestController.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controllers;
+
+use App\Services\DatabaseSchemaVerifier;
+use App\Views\Renderer;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class SchemaTestController
+{
+    /** @var Renderer */
+    private $renderer;
+
+    /** @var DatabaseSchemaVerifier */
+    private $schemaVerifier;
+
+    /**
+     * Construct the object with its required dependencies.
+     *
+     * This ensures collaborating services are available for subsequent method calls.
+     */
+    public function __construct(Renderer $renderer, DatabaseSchemaVerifier $schemaVerifier)
+    {
+        $this->renderer = $renderer;
+        $this->schemaVerifier = $schemaVerifier;
+    }
+
+    /**
+     * Display the schema verification report.
+     *
+     * Rendering the results through a controller keeps routing concerns and presentation logic tidy.
+     */
+    public function show(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $user = $request->getAttribute('user');
+
+        if ($user === null) {
+            return $response->withHeader('Location', '/auth/login')->withStatus(302);
+        }
+
+        $report = $this->schemaVerifier->verify();
+
+        return $this->renderer->render($response, 'schema-test', [
+            'title' => 'Database schema test',
+            'subtitle' => 'Verify production tables without leaving the dashboard.',
+            'report' => $report,
+        ]);
+    }
+}

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -14,6 +14,7 @@ use App\Controllers\JobApplicationController;
 use App\Controllers\RetentionController;
 use App\Controllers\UsageController;
 use App\Controllers\ContactDetailsController;
+use App\Controllers\SchemaTestController;
 use App\Prompts\PromptLibrary;
 use App\Validation\DraftValidator;
 use InvalidArgumentException;
@@ -236,6 +237,10 @@ class Routes
 
         $app->get('/retention', function (Request $request, Response $response) use ($container) {
             return $container->get(RetentionController::class)->show($request, $response);
+        });
+
+        $app->get('/settings/schema-test', function (Request $request, Response $response) use ($container) {
+            return $container->get(SchemaTestController::class)->show($request, $response);
         });
 
         $app->post('/retention', function (Request $request, Response $response) use ($container) {

--- a/src/Services/DatabaseSchemaVerifier.php
+++ b/src/Services/DatabaseSchemaVerifier.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use PDO;
+use PDOException;
+
+class DatabaseSchemaVerifier
+{
+    /**
+     * A whitelist of tables and the columns they must expose for the application to operate correctly.
+     *
+     * Keeping the schema definition in code allows the verifier to run in production without relying on external tooling.
+     */
+    private const EXPECTED_SCHEMA = [
+        'users' => [
+            'columns' => [
+                'id',
+                'email',
+                'totp_secret',
+                'totp_period_seconds',
+                'totp_digits',
+                'created_at',
+                'updated_at',
+            ],
+        ],
+        'pending_passcodes' => [
+            'columns' => [
+                'id',
+                'email',
+                'action',
+                'code_hash',
+                'totp_secret',
+                'period_seconds',
+                'digits',
+                'expires_at',
+                'created_at',
+            ],
+        ],
+        'sessions' => [
+            'columns' => [
+                'id',
+                'user_id',
+                'token_hash',
+                'created_at',
+                'expires_at',
+            ],
+        ],
+        'documents' => [
+            'columns' => [
+                'id',
+                'user_id',
+                'document_type',
+                'filename',
+                'mime_type',
+                'size_bytes',
+                'sha256',
+                'content',
+                'created_at',
+                'updated_at',
+            ],
+        ],
+        'generations' => [
+            'columns' => [
+                'id',
+                'user_id',
+                'job_document_id',
+                'cv_document_id',
+                'model',
+                'thinking_time',
+                'status',
+                'progress_percent',
+                'cost_pence',
+                'error_message',
+                'created_at',
+                'updated_at',
+            ],
+        ],
+        'generation_outputs' => [
+            'columns' => [
+                'id',
+                'generation_id',
+                'artifact',
+                'mime_type',
+                'content',
+                'output_text',
+                'tokens_used',
+                'created_at',
+            ],
+        ],
+        'job_applications' => [
+            'columns' => [
+                'id',
+                'user_id',
+                'title',
+                'source_url',
+                'description',
+                'status',
+                'applied_at',
+                'reason_code',
+                'generation_id',
+                'created_at',
+                'updated_at',
+            ],
+        ],
+        'api_usage' => [
+            'columns' => [
+                'id',
+                'user_id',
+                'provider',
+                'endpoint',
+                'tokens_used',
+                'cost_pence',
+                'metadata',
+                'created_at',
+            ],
+        ],
+        'backup_codes' => [
+            'columns' => [
+                'id',
+                'user_id',
+                'code_hash',
+                'used_at',
+                'created_at',
+            ],
+        ],
+        'audit_logs' => [
+            'columns' => [
+                'id',
+                'user_id',
+                'ip_address',
+                'email',
+                'action',
+                'user_agent',
+                'details',
+                'created_at',
+            ],
+        ],
+        'retention_settings' => [
+            'columns' => [
+                'id',
+                'purge_after_days',
+                'apply_to',
+                'created_at',
+                'updated_at',
+            ],
+        ],
+        'site_settings' => [
+            'columns' => [
+                'name',
+                'value',
+                'created_at',
+                'updated_at',
+            ],
+        ],
+        'jobs' => [
+            'columns' => [
+                'id',
+                'type',
+                'payload_json',
+                'run_after',
+                'attempts',
+                'status',
+                'error',
+                'created_at',
+            ],
+        ],
+    ];
+
+    /** @var PDO */
+    private $pdo;
+
+    /**
+     * Construct the object with its required dependencies.
+     *
+     * This ensures collaborating services are available for subsequent method calls.
+     */
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * Execute the schema verification routine.
+     *
+     * Returning a structured report keeps controllers and views simple while providing enough detail for troubleshooting.
+     *
+     * @return array{passed: bool, results: array<int, array{table: string, exists: bool, missing_columns: array<int, string>, unexpected_columns: array<int, string>, error: string|null, is_valid: bool}>}
+     */
+    public function verify(): array
+    {
+        $results = [];
+        $allPassed = true;
+
+        foreach (self::EXPECTED_SCHEMA as $table => $definition) {
+            $tableResult = $this->inspectTable($table, $definition['columns']);
+
+            if (!$tableResult['is_valid']) {
+                $allPassed = false;
+            }
+
+            $results[] = $tableResult;
+        }
+
+        return [
+            'passed' => $allPassed,
+            'results' => $results,
+        ];
+    }
+
+    /**
+     * Inspect the supplied table for expected columns and structure.
+     *
+     * Capturing per-table output enables the interface to highlight precisely what needs to be fixed.
+     *
+     * @param array<int, string> $expectedColumns Columns the table must expose.
+     * @return array{table: string, exists: bool, missing_columns: array<int, string>, unexpected_columns: array<int, string>, error: string|null, is_valid: bool}
+     */
+    private function inspectTable(string $table, array $expectedColumns): array
+    {
+        $result = [
+            'table' => $table,
+            'exists' => false,
+            'missing_columns' => [],
+            'unexpected_columns' => [],
+            'error' => null,
+            'is_valid' => false,
+        ];
+
+        try {
+            if (!$this->tableExists($table)) {
+                $result['missing_columns'] = $expectedColumns;
+
+                return $result;
+            }
+
+            $result['exists'] = true;
+            $columns = $this->fetchColumns($table);
+
+            $result['missing_columns'] = array_values(array_diff($expectedColumns, $columns));
+            $result['unexpected_columns'] = array_values(array_diff($columns, $expectedColumns));
+            $result['is_valid'] = $result['missing_columns'] === []
+                && $result['unexpected_columns'] === [];
+        } catch (PDOException $exception) {
+            $result['error'] = $exception->getMessage();
+        }
+
+        return $result;
+    }
+
+    /**
+     * Determine whether the given table exists in the connected database.
+     *
+     * Driver-specific inspection keeps the verifier portable between MySQL production and SQLite smoke tests.
+     */
+    private function tableExists(string $table): bool
+    {
+        $driver = (string) $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'mysql') {
+            $statement = $this->pdo->prepare(
+                'SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = :table'
+            );
+            $statement->execute(['table' => $table]);
+
+            return (int) $statement->fetchColumn() > 0;
+        }
+
+        $statement = $this->pdo->prepare(
+            'SELECT name FROM sqlite_master WHERE type = "table" AND name = :table LIMIT 1'
+        );
+        $statement->execute(['table' => $table]);
+
+        return $statement->fetchColumn() !== false;
+    }
+
+    /**
+     * Retrieve the column names for the supplied table.
+     *
+     * Normalising column reads across database engines ensures comparison logic stays consistent.
+     *
+     * @return array<int, string>
+     */
+    private function fetchColumns(string $table): array
+    {
+        $driver = (string) $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'mysql') {
+            $statement = $this->pdo->prepare(
+                'SELECT COLUMN_NAME FROM information_schema.columns '
+                . 'WHERE table_schema = DATABASE() AND table_name = :table ORDER BY ORDINAL_POSITION'
+            );
+            $statement->execute(['table' => $table]);
+
+            return array_map('strval', $statement->fetchAll(PDO::FETCH_COLUMN));
+        }
+
+        $query = sprintf('PRAGMA table_info(%s)', $this->quoteIdentifier($table));
+        $statement = $this->pdo->query($query);
+
+        if ($statement === false) {
+            return [];
+        }
+
+        $columns = [];
+
+        while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+            if (isset($row['name'])) {
+                $columns[] = (string) $row['name'];
+            }
+        }
+
+        return $columns;
+    }
+
+    /**
+     * Quote the provided identifier for safe inclusion in a PRAGMA statement.
+     *
+     * SQLite requires identifiers to be wrapped when they contain special characters, so we escape quotes defensively.
+     */
+    private function quoteIdentifier(string $identifier): string
+    {
+        return '"' . str_replace('"', '""', $identifier) . '"';
+    }
+}

--- a/tests/DatabaseSchemaVerifierTest.php
+++ b/tests/DatabaseSchemaVerifierTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\DatabaseSchemaVerifier;
+
+spl_autoload_register(static function (string $class): void {
+    $prefix = 'App\\';
+
+    if (strpos($class, $prefix) !== 0) {
+        return;
+    }
+
+    $relative = str_replace('\\', '/', substr($class, strlen($prefix)));
+    $path = __DIR__ . '/../src/' . $relative . '.php';
+
+    if (is_file($path)) {
+        require $path;
+    }
+});
+
+$pdo = new PDO('sqlite::memory:');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$createStatements = [
+    'CREATE TABLE users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        email TEXT NOT NULL,
+        totp_secret TEXT NULL,
+        totp_period_seconds INTEGER NULL,
+        totp_digits INTEGER NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    )',
+    'CREATE TABLE pending_passcodes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        email TEXT NOT NULL,
+        action TEXT NOT NULL,
+        code_hash TEXT NOT NULL,
+        totp_secret TEXT NULL,
+        period_seconds INTEGER NOT NULL,
+        digits INTEGER NOT NULL,
+        expires_at TEXT NOT NULL,
+        created_at TEXT NOT NULL
+    )',
+    'CREATE TABLE sessions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        token_hash TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        expires_at TEXT NOT NULL
+    )',
+    'CREATE TABLE documents (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        document_type TEXT NOT NULL,
+        filename TEXT NOT NULL,
+        mime_type TEXT NOT NULL,
+        size_bytes INTEGER NOT NULL,
+        sha256 TEXT NOT NULL,
+        content BLOB NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    )',
+    'CREATE TABLE generations (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        job_document_id INTEGER NOT NULL,
+        cv_document_id INTEGER NOT NULL,
+        model TEXT NOT NULL,
+        thinking_time INTEGER NOT NULL,
+        status TEXT NOT NULL,
+        progress_percent INTEGER NOT NULL,
+        cost_pence INTEGER NOT NULL,
+        error_message TEXT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    )',
+    'CREATE TABLE generation_outputs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        generation_id INTEGER NOT NULL,
+        artifact TEXT NOT NULL,
+        mime_type TEXT NULL,
+        content BLOB NULL,
+        output_text TEXT NULL,
+        tokens_used INTEGER NULL,
+        created_at TEXT NOT NULL
+    )',
+    'CREATE TABLE job_applications (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        title TEXT NOT NULL,
+        source_url TEXT NULL,
+        description TEXT NOT NULL,
+        status TEXT NOT NULL,
+        applied_at TEXT NULL,
+        reason_code TEXT NULL,
+        generation_id INTEGER NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    )',
+    'CREATE TABLE api_usage (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        provider TEXT NOT NULL,
+        endpoint TEXT NOT NULL,
+        tokens_used INTEGER NULL,
+        cost_pence INTEGER NOT NULL,
+        metadata TEXT NULL,
+        created_at TEXT NOT NULL
+    )',
+    'CREATE TABLE backup_codes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        code_hash TEXT NOT NULL,
+        used_at TEXT NULL,
+        created_at TEXT NOT NULL
+    )',
+    'CREATE TABLE audit_logs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NULL,
+        ip_address TEXT NOT NULL,
+        email TEXT NULL,
+        action TEXT NOT NULL,
+        user_agent TEXT NULL,
+        details TEXT NULL,
+        created_at TEXT NOT NULL
+    )',
+    'CREATE TABLE retention_settings (
+        id INTEGER PRIMARY KEY,
+        purge_after_days INTEGER NOT NULL,
+        apply_to TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    )',
+    'CREATE TABLE site_settings (
+        name TEXT PRIMARY KEY,
+        value TEXT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    )',
+    'CREATE TABLE jobs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        type TEXT NOT NULL,
+        payload_json TEXT NOT NULL,
+        run_after TEXT NOT NULL,
+        attempts INTEGER NOT NULL,
+        status TEXT NOT NULL,
+        error TEXT NULL,
+        created_at TEXT NOT NULL
+    )',
+];
+
+foreach ($createStatements as $sql) {
+    $pdo->exec($sql);
+}
+
+$verifier = new DatabaseSchemaVerifier($pdo);
+$report = $verifier->verify();
+
+if (!$report['passed']) {
+    throw new RuntimeException('Expected schema to pass immediately after migrations.');
+}
+
+$pdo->exec('DROP TABLE documents');
+$pdo->exec('CREATE TABLE documents (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER NOT NULL)');
+
+$reportAfterBreakage = $verifier->verify();
+
+if ($reportAfterBreakage['passed']) {
+    throw new RuntimeException('Schema verifier should detect missing columns in documents table.');
+}
+
+$documentsResult = null;
+
+foreach ($reportAfterBreakage['results'] as $tableResult) {
+    if ($tableResult['table'] === 'documents') {
+        $documentsResult = $tableResult;
+
+        break;
+    }
+}
+
+if ($documentsResult === null) {
+    throw new RuntimeException('Schema verifier did not return a result for documents table.');
+}
+
+if (!in_array('document_type', $documentsResult['missing_columns'], true)) {
+    throw new RuntimeException('Schema verifier did not record missing columns for documents table.');
+}
+
+echo 'DatabaseSchemaVerifierTest passed' . PHP_EOL;


### PR DESCRIPTION
## Summary
- add a DatabaseSchemaVerifier service and controller that generate a schema health report in production
- expose the report through a new schema test view linked from the dashboard settings menu
- cover the verifier with a sqlite-based regression test

## Testing
- php tests/DatabaseSchemaVerifierTest.php
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dfb640a710832ea1a1c6c0ee88924d