### PR TITLE
Condense submitted applications layout

### DIFF
--- a/resources/views/applications.php
+++ b/resources/views/applications.php
@@ -340,47 +340,26 @@
                         </p>
                     <?php else : ?>
                         <?php foreach ($applied as $item) : ?>
-                            <article class="rounded-xl border border-slate-800 bg-slate-950/80 p-4 text-sm text-slate-200 shadow-inner">
-                                <header class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                                    <div>
+                            <article class="rounded-xl border border-slate-800/80 bg-slate-950/70 p-3 text-sm text-slate-200 shadow-inner sm:p-4">
+                                <header class="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+                                    <div class="space-y-1">
                                         <h4 class="text-base font-semibold text-white">
                                             <?= htmlspecialchars($item['title'] ?? 'Untitled application', ENT_QUOTES) ?>
                                         </h4>
-                                        <p class="text-xs text-slate-500">
-                                            Applied <?= htmlspecialchars($item['applied_at'] ?? $item['created_at'], ENT_QUOTES) ?>
+                                        <p class="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                                            <span class="font-medium text-slate-300">Applied</span>
+                                            <span><?= htmlspecialchars($item['applied_at'] ?? $item['created_at'], ENT_QUOTES) ?></span>
                                         </p>
                                     </div>
-                                    <div class="flex flex-col gap-2 sm:items-end">
-                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="self-start sm:self-auto">
+                                    <div class="flex flex-wrap items-center justify-end gap-2">
+                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="inline-flex">
                                             <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
                                             <input type="hidden" name="status" value="outstanding">
                                             <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-300 transition hover:border-slate-500 hover:text-slate-100">
-                                                Move back to queue
+                                                Move back
                                             </button>
                                         </form>
-                                        <?php $appliedReasonFieldId = 'failure_reason_' . ($item['id'] ?? '0') . '_applied'; ?>
-                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="flex flex-col gap-2 rounded-xl border border-rose-500/40 bg-rose-500/10 p-3 text-xs text-rose-100 sm:flex-row sm:items-center sm:gap-3">
-                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                            <input type="hidden" name="status" value="failed">
-                                            <label for="<?= htmlspecialchars($appliedReasonFieldId, ENT_QUOTES) ?>" class="font-medium text-rose-100">Rejection reason</label>
-                                            <select
-                                                id="<?= htmlspecialchars($appliedReasonFieldId, ENT_QUOTES) ?>"
-                                                name="reason_code"
-                                                required
-                                                class="w-full rounded-lg border border-rose-400/40 bg-rose-500/10 px-2 py-1 text-rose-100 focus:border-rose-200 focus:outline-none focus:ring-rose-200 sm:max-w-xs"
-                                            >
-                                                <option value="" disabled selected>Select reason</option>
-                                                <?php foreach ($failureReasons as $code => $label) : ?>
-                                                    <option value="<?= htmlspecialchars($code, ENT_QUOTES) ?>">
-                                                        <?= htmlspecialchars($label, ENT_QUOTES) ?>
-                                                    </option>
-                                                <?php endforeach; ?>
-                                            </select>
-                                            <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-full border border-rose-400/40 bg-rose-500/30 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-200 hover:text-rose-50">
-                                                Mark failed
-                                            </button>
-                                        </form>
-                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/delete" class="self-start sm:self-auto">
+                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/delete" class="inline-flex">
                                             <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
                                             <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-rose-500/60 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-300 hover:text-rose-50">
                                                 Delete
@@ -388,49 +367,69 @@
                                         </form>
                                     </div>
                                 </header>
+                                <?php $appliedReasonFieldId = 'failure_reason_' . ($item['id'] ?? '0') . '_applied'; ?>
+                                <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="mt-3 flex flex-wrap items-center gap-2 rounded-lg border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-100 sm:gap-3">
+                                    <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                                    <input type="hidden" name="status" value="failed">
+                                    <label for="<?= htmlspecialchars($appliedReasonFieldId, ENT_QUOTES) ?>" class="font-medium text-rose-100">Rejection reason</label>
+                                    <select
+                                        id="<?= htmlspecialchars($appliedReasonFieldId, ENT_QUOTES) ?>"
+                                        name="reason_code"
+                                        required
+                                        class="w-full rounded-lg border border-rose-400/40 bg-rose-500/10 px-2 py-1 text-rose-100 focus:border-rose-200 focus:outline-none focus:ring-rose-200 sm:max-w-xs"
+                                    >
+                                        <option value="" disabled selected>Select reason</option>
+                                        <?php foreach ($failureReasons as $code => $label) : ?>
+                                            <option value="<?= htmlspecialchars($code, ENT_QUOTES) ?>">
+                                                <?= htmlspecialchars($label, ENT_QUOTES) ?>
+                                            </option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                    <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-full border border-rose-400/40 bg-rose-500/30 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-200 hover:text-rose-50">
+                                        Mark failed
+                                    </button>
+                                </form>
                                 <?php $appliedGenerationFieldId = 'generation_' . ($item['id'] ?? '0') . '_applied'; ?>
-                                <div class="mt-3 rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-                                    <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-                                        <div class="space-y-1">
-                                            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Tailored CV link</p>
-                                            <?php if (!empty($item['generation'])) : ?>
-                                                <p class="text-sm text-slate-200">
-                                                    <?= htmlspecialchars($item['generation']['cv_filename'] ?? 'CV draft', ENT_QUOTES) ?>
-                                                    <span class="text-slate-500">→</span>
-                                                    <?= htmlspecialchars($item['generation']['job_filename'] ?? 'Job description', ENT_QUOTES) ?>
+                                <div class="mt-3 grid gap-3 rounded-lg border border-slate-800 bg-slate-900/60 p-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+                                    <div class="space-y-1">
+                                        <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Tailored CV</p>
+                                        <?php if (!empty($item['generation'])) : ?>
+                                            <p class="text-sm text-slate-200">
+                                                <?= htmlspecialchars($item['generation']['cv_filename'] ?? 'CV draft', ENT_QUOTES) ?>
+                                                <span class="text-slate-500">→</span>
+                                                <?= htmlspecialchars($item['generation']['job_filename'] ?? 'Job description', ENT_QUOTES) ?>
+                                            </p>
+                                            <?php if (!empty($item['generation']['created_at'])) : ?>
+                                                <p class="text-xs text-slate-500">
+                                                    Generated <?= htmlspecialchars($item['generation']['created_at'], ENT_QUOTES) ?>
                                                 </p>
-                                                <?php if (!empty($item['generation']['created_at'])) : ?>
-                                                    <p class="text-xs text-slate-500">
-                                                        Generated <?= htmlspecialchars($item['generation']['created_at'], ENT_QUOTES) ?>
-                                                    </p>
-                                                <?php endif; ?>
-                                            <?php else : ?>
-                                                <p class="text-sm text-slate-400">No tailored CV linked yet.</p>
                                             <?php endif; ?>
-                                        </div>
-                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/generation" class="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
-                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                            <label for="<?= htmlspecialchars($appliedGenerationFieldId, ENT_QUOTES) ?>" class="sr-only">Select tailored CV</label>
-                                            <select
-                                                id="<?= htmlspecialchars($appliedGenerationFieldId, ENT_QUOTES) ?>"
-                                                name="generation_id"
-                                                class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400 md:min-w-[220px]"
-                                            >
-                                                <option value="">No tailored CV</option>
-                                                <?php foreach ($generationOptions as $option) : ?>
-                                                    <?php $optionId = (int) $option['id']; ?>
-                                                    <option value="<?= htmlspecialchars((string) $optionId, ENT_QUOTES) ?>" <?= (isset($item['generation_id']) && (int) $item['generation_id'] === $optionId) ? 'selected' : '' ?>>
-                                                        <?= htmlspecialchars($option['label'], ENT_QUOTES) ?>
-                                                    </option>
-                                                <?php endforeach; ?>
-                                            </select>
-                                            <button type="submit" class="inline-flex items-center justify-center rounded-lg bg-slate-800 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:bg-slate-700">
-                                                Update link
-                                            </button>
-                                        </form>
+                                        <?php else : ?>
+                                            <p class="text-sm text-slate-400">No tailored CV linked yet.</p>
+                                        <?php endif; ?>
                                     </div>
+                                    <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/generation" class="flex flex-wrap items-center justify-end gap-2 sm:flex-nowrap sm:gap-3">
+                                        <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                                        <label for="<?= htmlspecialchars($appliedGenerationFieldId, ENT_QUOTES) ?>" class="sr-only">Select tailored CV</label>
+                                        <select
+                                            id="<?= htmlspecialchars($appliedGenerationFieldId, ENT_QUOTES) ?>"
+                                            name="generation_id"
+                                            class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400 sm:min-w-[220px]"
+                                        >
+                                            <option value="">No tailored CV</option>
+                                            <?php foreach ($generationOptions as $option) : ?>
+                                                <?php $optionId = (int) $option['id']; ?>
+                                                <option value="<?= htmlspecialchars((string) $optionId, ENT_QUOTES) ?>" <?= (isset($item['generation_id']) && (int) $item['generation_id'] === $optionId) ? 'selected' : '' ?>>
+                                                    <?= htmlspecialchars($option['label'], ENT_QUOTES) ?>
+                                                </option>
+                                            <?php endforeach; ?>
+                                        </select>
+                                        <button type="submit" class="inline-flex items-center justify-center rounded-lg bg-slate-800 px-3 py-2 text-sm font-semibold text-slate-100 transition hover:bg-slate-700">
+                                            Update link
+                                        </button>
+                                    </form>
                                     <?php if (empty($generationOptions)) : ?>
-                                        <p class="mt-3 text-xs text-slate-500">
+                                        <p class="text-xs text-slate-500 sm:col-span-2">
                                             Generate a tailored CV from the Tailor page to link it with this application.
                                         </p>
                                     <?php endif; ?>
@@ -443,7 +442,7 @@
                                         </svg>
                                     </a>
                                 <?php endif; ?>
-                                <p class="mt-3 text-sm text-slate-300">
+                                <p class="mt-2 text-xs leading-relaxed text-slate-400 sm:text-sm">
                                     <?= nl2br(htmlspecialchars($item['description_preview'], ENT_QUOTES)) ?>
                                 </p>
                             </article>


### PR DESCRIPTION
## Summary
- refactored the submitted applications card layout to reduce vertical spacing and tighten controls
- streamlined action buttons into inline groups and rebalanced form styling for a denser presentation
- compacted the tailored CV link block and description typography to emphasize key metadata

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dfba59d764832e94a3d78e7287d015