### PR TITLE
Prevent tailored CV prompt from adding suggestion section

### DIFF
--- a/prompts/tailor.txt
+++ b/prompts/tailor.txt
@@ -9,10 +9,12 @@ Tasks:
 1. Draft a role-specific summary that links the candidate's experience to the job title and company.
 2. Reorder or trim the supplied CV sections so the most relevant accomplishments for the listed competencies appear first.
 3. Only quantify achievements when the original CV already provides the numbers.
-4. For any employment or education gap you notice, create an "Optional evidence to add" note with appropriate supporting material.
+4. For any employment or education gap you notice, create an "Optional evidence to add" note with appropriate supporting material immediately after the gap's related section.
 5. Never introduce employers or qualifications that are absent from the source CV.
+6. Do not append a standalone suggestions section at the end of the tailored CV.
 
 Output:
 - Return the tailored CV as valid Markdown.
 - Use British English throughout.
 - Preserve factual accuracy and clearly flag any gaps.
+- Ensure every "Optional evidence to add" note sits beside its relevant section rather than at the bottom of the document.


### PR DESCRIPTION
## Summary
- update the tailoring prompt instructions so optional evidence notes stay next to the relevant section
- forbid adding a standalone suggestions footer to the tailored CV output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfba86e900832eb36a142f9c1d6a97