### PR TITLE
Update GPT-5 usage pricing defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ MAIL_LOG_PATH=/var/log/job/mail.log
 # OpenAI configuration
 OPENAI_API_KEY=sk-your-key
 OPENAI_BASE_URL=https://api.openai.com/v1
-OPENAI_MODEL_PLAN=gpt-4o-mini-plan
-OPENAI_MODEL_DRAFT=gpt-4o-mini
-OPENAI_TARIFF_JSON={"gpt-4o-mini":{"prompt":0.00025,"completion":0.001}}
+OPENAI_MODEL_PLAN=gpt-5
+OPENAI_MODEL_DRAFT=gpt-5-mini
+OPENAI_TARIFF_JSON={"gpt-5":{"prompt":0.099,"completion":0.79},"gpt-5-mini":{"prompt":0.02,"completion":0.158},"gpt-5-nano":{"prompt":0.004,"completion":0.032}}
 OPENAI_MAX_TOKENS=4000

--- a/bin/verify.php
+++ b/bin/verify.php
@@ -270,7 +270,7 @@ record_check($checks, 'Create generation', function () use (&$state, $client, $c
     $payload = [
         'job_description_id' => $state['documents'][1],
         'cv_source_id' => $state['documents'][0],
-        'model' => verify_env($config, 'OPENAI_MODEL_PLAN') ?? 'gpt-5-mini',
+        'model' => verify_env($config, 'OPENAI_MODEL_PLAN') ?? 'gpt-5',
     ];
 
     $response = $client->post('generations', ['json' => $payload]);

--- a/resources/systemd/job-worker.env.example
+++ b/resources/systemd/job-worker.env.example
@@ -17,7 +17,7 @@ QUEUE_CONNECTION=database
 
 # OpenAI credentials used by the background worker when site settings are not configured.
 OPENAI_API_KEY=change-me
-OPENAI_MODEL_PLAN=gpt-4o-mini
-OPENAI_MODEL_DRAFT=gpt-4o-mini
-OPENAI_TARIFF_JSON={"gpt-4o-mini":{"prompt":0.15,"completion":0.6}}
+OPENAI_MODEL_PLAN=gpt-5
+OPENAI_MODEL_DRAFT=gpt-5-mini
+OPENAI_TARIFF_JSON={"gpt-5":{"prompt":0.099,"completion":0.79},"gpt-5-mini":{"prompt":0.02,"completion":0.158},"gpt-5-nano":{"prompt":0.004,"completion":0.032}}
 OPENAI_MAX_TOKENS=2048

--- a/src/AI/OpenAIProvider.php
+++ b/src/AI/OpenAIProvider.php
@@ -44,8 +44,8 @@ final class OpenAIProvider
     private const INITIAL_BACKOFF_MS = 200;
     private const MAX_BACKOFF_MS = 4000;
 
-    private const PLAN_MODEL_FALLBACKS = ['gpt-4o-mini'];
-    private const DRAFT_MODEL_FALLBACKS = ['gpt-4o-mini'];
+    private const PLAN_MODEL_FALLBACKS = ['gpt-5-mini', 'gpt-5-nano'];
+    private const DRAFT_MODEL_FALLBACKS = ['gpt-5-mini', 'gpt-5-nano'];
 
     /** @var ClientInterface */
     private $client;

--- a/src/Controllers/GenerationController.php
+++ b/src/Controllers/GenerationController.php
@@ -17,7 +17,7 @@ final class GenerationController
     /** @var array<int, array{value: string, label: string}> */
     private const MODELS = [
         ['value' => 'gpt-5-mini', 'label' => 'GPT-5 Mini · Balanced performance'],
-        ['value' => 'gpt-5-main', 'label' => 'GPT-5 Main · Highest quality'],
+        ['value' => 'gpt-5', 'label' => 'GPT-5 · Highest quality'],
         ['value' => 'gpt-5-nano', 'label' => 'GPT-5 Nano · Fastest responses'],
     ];
 

--- a/src/Services/UsageService.php
+++ b/src/Services/UsageService.php
@@ -130,22 +130,46 @@ class UsageService
         $requested = isset($metadata['model_requested']) ? (string) $metadata['model_requested'] : '';
 
         if ($requested !== '') {
-            return $requested;
+            return $this->normaliseModelIdentifier($requested);
         }
 
         $primary = isset($metadata['model']) ? (string) $metadata['model'] : '';
 
         if ($primary !== '') {
-            return $primary;
+            return $this->normaliseModelIdentifier($primary);
         }
 
         $reported = isset($metadata['model_reported']) ? (string) $metadata['model_reported'] : '';
 
         if ($reported !== '') {
-            return $reported;
+            return $this->normaliseModelIdentifier($reported);
         }
 
         return 'unknown';
+    }
+
+    /**
+     * Harmonise known model aliases into their canonical identifiers.
+     *
+     * Centralising the mapping ensures legacy rows that reference older labels
+     * continue to render alongside the current GPT-5 line-up without confusing
+     * suffixes leaking into the analytics table.
+     */
+    private function normaliseModelIdentifier(string $model): string
+    {
+        $key = strtolower($model);
+
+        $aliases = [
+            'gpt-5-main' => 'gpt-5',
+            'gpt5-main' => 'gpt-5',
+            'gpt5' => 'gpt-5',
+        ];
+
+        if (isset($aliases[$key])) {
+            return $aliases[$key];
+        }
+
+        return $model;
     }
 
     /**

--- a/tests/OpenAIProviderPlanTest.php
+++ b/tests/OpenAIProviderPlanTest.php
@@ -253,7 +253,7 @@ if (!is_array($initialFallbackRequest) || $initialFallbackRequest['model'] !== '
     throw new RuntimeException('Initial plan request did not target the configured missing model.');
 }
 
-if (!is_array($secondFallbackRequest) || $secondFallbackRequest['model'] !== 'gpt-4o-mini') {
+if (!is_array($secondFallbackRequest) || $secondFallbackRequest['model'] !== 'gpt-5-mini') {
     throw new RuntimeException('Fallback plan request did not target the expected default model.');
 }
 


### PR DESCRIPTION
## Summary
- switch default OpenAI models and fallback sequence to the GPT-5 lineup
- document current GPT-5 pricing in environment examples for the app and worker
- normalise stored usage metadata so GPT-5 aliases render consistently in analytics

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e115f7d264832e81072a54e3f94c52