### PR TITLE
Update tailoring prompt to avoid closing notices

### DIFF
--- a/src/Prompts/PromptLibrary.php
+++ b/src/Prompts/PromptLibrary.php
@@ -31,6 +31,7 @@ Output:
 - Return the tailored CV as valid Markdown.
 - Use British English throughout.
 - Preserve factual accuracy and clearly flag any gaps.
+- Do not add closing statements inviting further customisation or referencing the tailoring process.
 TAILOR;
 
     private const COVER_LETTER_PROMPT = <<<'LETTER'


### PR DESCRIPTION
## Summary
- update the tailoring prompt instructions to forbid closing statements that mention customisation or processing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e151bde9ac832e9dc76368bb1b6de2