### PR TITLE
Add markdown viewer option to documents workspace

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -21,6 +21,7 @@ use App\Documents\DocumentPreviewer;
 use App\Documents\DocumentRepository;
 use App\Documents\DocumentService;
 use App\Documents\DocumentValidator;
+use App\Documents\MarkdownRenderer;
 use App\Infrastructure\Database\Connection;
 use App\Infrastructure\Database\Migrator;
 use App\Middleware\CsrfMiddleware;
@@ -91,12 +92,17 @@ $container->set(DocumentPreviewer::class, static function (): DocumentPreviewer 
     return new DocumentPreviewer();
 });
 
+$container->set(MarkdownRenderer::class, static function (): MarkdownRenderer {
+    return new MarkdownRenderer();
+});
+
 $container->set(DocumentController::class, static function (Container $c): DocumentController {
     return new DocumentController(
         $c->get(Renderer::class),
         $c->get(DocumentRepository::class),
         $c->get(DocumentService::class),
         $c->get(DocumentPreviewer::class),
+        $c->get(MarkdownRenderer::class),
         $c->get(GenerationDownloadService::class),
         $c->get(GenerationRepository::class)
     );

--- a/resources/views/document-markdown.php
+++ b/resources/views/document-markdown.php
@@ -1,0 +1,76 @@
+<?php
+/** @var array{filename: string, created_at: string, size: string, mime_type: string, type_label: string, download_url: string|null, plain_view_url: string} $document */
+/** @var array{raw: string, html: string} $markdown */
+/** @var string $title */
+/** @var string $subtitle */
+/** @var array<int, array{href: string, label: string, current: bool}> $navLinks */
+?>
+<?php ob_start(); ?>
+<div class="space-y-8">
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+            <p class="text-sm uppercase tracking-[0.3em] text-indigo-400">Document preview</p>
+            <h2 class="mt-2 text-3xl font-semibold text-white">Formatted markdown</h2>
+            <p class="mt-2 max-w-2xl text-sm text-slate-400">
+                Headings, lists, and emphasis are rendered exactly as they will appear in generated content.
+            </p>
+        </div>
+        <a href="<?= htmlspecialchars($document['plain_view_url'], ENT_QUOTES) ?>" class="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:bg-slate-800/60">
+            ← Back to plain view
+        </a>
+    </div>
+
+    <section class="grid gap-6 lg:grid-cols-[320px,1fr]">
+        <div class="space-y-6">
+            <article class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl">
+                <h3 class="text-lg font-semibold text-white">File details</h3>
+                <dl class="mt-4 space-y-3 text-sm text-slate-300">
+                    <div class="flex items-baseline justify-between gap-4">
+                        <dt class="text-slate-400">Type</dt>
+                        <dd class="font-medium text-white"><?= htmlspecialchars($document['type_label'], ENT_QUOTES) ?></dd>
+                    </div>
+                    <div class="flex items-baseline justify-between gap-4">
+                        <dt class="text-slate-400">Uploaded</dt>
+                        <dd class="font-medium text-white"><?= htmlspecialchars($document['created_at'], ENT_QUOTES) ?></dd>
+                    </div>
+                    <div class="flex items-baseline justify-between gap-4">
+                        <dt class="text-slate-400">Size</dt>
+                        <dd class="font-medium text-white"><?= htmlspecialchars($document['size'], ENT_QUOTES) ?></dd>
+                    </div>
+                    <div class="flex items-baseline justify-between gap-4">
+                        <dt class="text-slate-400">MIME type</dt>
+                        <dd class="font-medium text-white"><?= htmlspecialchars($document['mime_type'], ENT_QUOTES) ?></dd>
+                    </div>
+                </dl>
+            </article>
+
+            <?php if (!empty($document['download_url'])) : ?>
+                <a href="<?= htmlspecialchars($document['download_url'], ENT_QUOTES) ?>" class="flex items-center justify-center gap-2 rounded-2xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-3 text-sm font-semibold uppercase tracking-wide text-emerald-100 transition hover:border-emerald-300 hover:text-emerald-50">
+                    Download original
+                </a>
+            <?php endif; ?>
+        </div>
+
+        <div class="space-y-6">
+            <article id="formatted-markdown" class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl">
+                <header class="flex flex-col gap-1">
+                    <h3 class="text-lg font-semibold text-white">Formatted view</h3>
+                    <p class="text-sm text-slate-400">Clean CommonMark rendering with unsafe HTML stripped for safety.</p>
+                </header>
+                <div class="prose prose-invert mt-4 max-w-none space-y-4 text-slate-100">
+                    <?= $markdown['html'] ?>
+                </div>
+            </article>
+
+            <article class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl">
+                <header class="flex flex-col gap-1">
+                    <h3 class="text-lg font-semibold text-white">Raw markdown</h3>
+                    <p class="text-sm text-slate-400">Copy and reuse the original text version if you need to edit locally.</p>
+                </header>
+                <pre class="mt-4 max-h-[320px] overflow-auto rounded-xl border border-slate-800/60 bg-slate-950/60 p-4 text-sm leading-relaxed text-slate-200 whitespace-pre-wrap break-words font-mono text-[13px]"><?= htmlspecialchars($markdown['raw'], ENT_QUOTES) ?></pre>
+            </article>
+        </div>
+    </section>
+</div>
+<?php $body = ob_get_clean(); ?>
+<?php include __DIR__ . '/layout.php'; ?>

--- a/resources/views/document-view.php
+++ b/resources/views/document-view.php
@@ -1,5 +1,5 @@
 <?php
-/** @var array{filename: string, created_at: string, size: string, mime_type: string, type_label: string, preview: string, id: int|null, download_url: string|null} $document */
+/** @var array{filename: string, created_at: string, size: string, mime_type: string, type_label: string, preview: string, id: int|null, download_url: string|null, is_markdown: bool, markdown_view_url: string|null} $document */
 /** @var string $title */
 /** @var string $subtitle */
 /** @var array<int, array{href: string, label: string, current: bool}> $navLinks */
@@ -58,18 +58,30 @@
         </div>
 
         <article class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl">
-            <header class="flex items-center justify-between gap-4">
+            <header class="flex flex-wrap items-center justify-between gap-4">
                 <div>
                     <h3 class="text-lg font-semibold text-white">Contents</h3>
                     <p class="text-sm text-slate-400">Plain text preview extracted for quick review.</p>
                 </div>
-                <?php if (!empty($document['download_url'])) : ?>
-                    <a href="<?= htmlspecialchars($document['download_url'], ENT_QUOTES) ?>" class="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-100 transition hover:border-emerald-300 hover:text-emerald-50">
-                        Download original
-                    </a>
-                <?php endif; ?>
+                <div class="flex flex-wrap items-center gap-2">
+                    <?php if (!empty($document['is_markdown']) && !empty($document['markdown_view_url'])) : ?>
+                        <a href="<?= htmlspecialchars($document['markdown_view_url'], ENT_QUOTES) ?>#formatted-markdown" class="inline-flex items-center gap-2 rounded-full border border-sky-400/40 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-sky-100 transition hover:border-sky-300 hover:text-sky-50">
+                            Markdown view
+                        </a>
+                    <?php endif; ?>
+                    <?php if (!empty($document['download_url'])) : ?>
+                        <a href="<?= htmlspecialchars($document['download_url'], ENT_QUOTES) ?>" class="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-100 transition hover:border-emerald-300 hover:text-emerald-50">
+                            Download original
+                        </a>
+                    <?php endif; ?>
+                </div>
             </header>
             <div class="mt-4 max-h-[540px] overflow-auto rounded-xl border border-slate-800/60 bg-slate-950/60 p-4 text-sm leading-relaxed text-slate-200">
+                <?php if (!empty($document['is_markdown']) && !empty($document['markdown_view_url'])) : ?>
+                    <p class="mb-4 rounded-lg border border-sky-400/30 bg-sky-500/10 p-3 text-xs text-sky-100">
+                        Need formatting? Visit the <a href="<?= htmlspecialchars($document['markdown_view_url'], ENT_QUOTES) ?>#formatted-markdown" class="font-semibold underline decoration-dotted">markdown view</a> for headings, lists, and emphasis.
+                    </p>
+                <?php endif; ?>
                 <?php if ($document['preview'] === '') : ?>
                     <p class="text-slate-500">A preview is not available for this file type, but the document remains stored securely.</p>
                 <?php else : ?>

--- a/resources/views/documents.php
+++ b/resources/views/documents.php
@@ -2,8 +2,8 @@
 /** @var string $title */
 /** @var string $subtitle */
 /** @var array<int, array{href: string, label: string, current: bool}> $navLinks */
-/** @var array<int, array{id: int|null, filename: string, created_at: string, size: string, view_url: string|null, download_url: string|null}> $jobDocuments */
-/** @var array<int, array{id: int|null, filename: string, created_at: string, size: string, view_url: string|null, download_url: string|null}> $cvDocuments */
+/** @var array<int, array{id: int|null, filename: string, created_at: string, size: string, view_url: string|null, download_url: string|null, is_markdown: bool, markdown_view_url: string|null}> $jobDocuments */
+/** @var array<int, array{id: int|null, filename: string, created_at: string, size: string, view_url: string|null, download_url: string|null, is_markdown: bool, markdown_view_url: string|null}> $cvDocuments */
 /** @var array<int, array<string, mixed>> $tailoredGenerations */
 /** @var array<int, string> $errors */
 /** @var string|null $status */
@@ -113,6 +113,11 @@
                                                 Download
                                             </a>
                                         <?php endif; ?>
+                                        <?php if (!empty($document['is_markdown']) && !empty($document['markdown_view_url'])) : ?>
+                                            <a href="<?= htmlspecialchars($document['markdown_view_url'], ENT_QUOTES) ?>#formatted-markdown" class="inline-flex items-center gap-2 rounded-full border border-sky-400/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-100 transition hover:border-sky-300 hover:text-sky-50">
+                                                Markdown view
+                                            </a>
+                                        <?php endif; ?>
                                         <?php if (!empty($document['view_url'])) : ?>
                                             <a href="<?= htmlspecialchars($document['view_url'], ENT_QUOTES) ?>" class="inline-flex items-center gap-2 rounded-full border border-indigo-400/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-100 transition hover:border-indigo-300 hover:text-indigo-50">
                                                 View
@@ -157,6 +162,11 @@
                                         <?php if (!empty($document['download_url'])) : ?>
                                             <a href="<?= htmlspecialchars($document['download_url'], ENT_QUOTES) ?>" class="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-100 transition hover:border-emerald-300 hover:text-emerald-50">
                                                 Download
+                                            </a>
+                                        <?php endif; ?>
+                                        <?php if (!empty($document['is_markdown']) && !empty($document['markdown_view_url'])) : ?>
+                                            <a href="<?= htmlspecialchars($document['markdown_view_url'], ENT_QUOTES) ?>#formatted-markdown" class="inline-flex items-center gap-2 rounded-full border border-sky-400/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-100 transition hover:border-sky-300 hover:text-sky-50">
+                                                Markdown view
                                             </a>
                                         <?php endif; ?>
                                         <?php if (!empty($document['view_url'])) : ?>

--- a/src/Documents/MarkdownRenderer.php
+++ b/src/Documents/MarkdownRenderer.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Documents;
+
+use League\CommonMark\CommonMarkConverter;
+
+class MarkdownRenderer
+{
+    /** @var CommonMarkConverter */
+    private $converter;
+
+    /**
+     * Construct the renderer with a CommonMark converter instance.
+     *
+     * Accepting an optional converter keeps the class easy to test while
+     * guaranteeing safe defaults for production rendering.
+     */
+    public function __construct(?CommonMarkConverter $converter = null)
+    {
+        $this->converter = $converter ?? new CommonMarkConverter([
+            'html_input' => 'strip',
+            'allow_unsafe_links' => false,
+        ]);
+    }
+
+    /**
+     * Convert the supplied markdown into sanitized HTML.
+     *
+     * Returning a string keeps the view layer simple while ensuring markdown
+     * documents display with full formatting support.
+     */
+    public function toHtml(string $markdown): string
+    {
+        return $this->converter->convertToHtml($markdown);
+    }
+}

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -59,6 +59,10 @@ class Routes
             return $container->get(DocumentController::class)->show($request, $response, $args);
         });
 
+        $app->get('/documents/{id}/markdown', function (Request $request, Response $response, array $args) use ($container) {
+            return $container->get(DocumentController::class)->showMarkdown($request, $response, $args);
+        });
+
         $app->get('/documents/{id}/download', function (Request $request, Response $response, array $args) use ($container) {
             return $container->get(DocumentController::class)->download($request, $response, $args);
         });


### PR DESCRIPTION
## Summary
- add a dedicated MarkdownRenderer service and route for formatted previews
- update document listings and detail views with Markdown view links and messaging
- build a formatted markdown page that renders CommonMark safely and exposes the raw source

## Testing
- composer test
- php -l src/Controllers/DocumentController.php
- php -l src/Documents/MarkdownRenderer.php

------
https://chatgpt.com/codex/tasks/task_e_68e169f44980832e90d47683052c3cce