### PR TITLE
Add SSE generation stream route

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -11,6 +11,7 @@ use App\Contacts\ContactDetailsService;
 use App\Controllers\DocumentController;
 use App\Controllers\JobApplicationController;
 use App\Controllers\GenerationController;
+use App\Controllers\GenerationStreamController;
 use App\Controllers\GenerationDownloadController;
 use App\Controllers\HomeController;
 use App\Controllers\TailorController;
@@ -204,6 +205,13 @@ $container->set(GenerationController::class, static function (Container $c): Gen
         $c->get(GenerationRepository::class),
         $c->get(DocumentRepository::class)
     );
+});
+
+/**
+ * Register the controller that streams live generation updates to the UI.
+ */
+$container->set(GenerationStreamController::class, static function (): GenerationStreamController {
+    return new GenerationStreamController();
 });
 
 $container->set(RetentionPolicyService::class, static function (Container $c): RetentionPolicyService {

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -8,6 +8,7 @@ use App\Controllers\AuthController;
 use App\Controllers\DocumentController;
 use App\Controllers\GenerationController;
 use App\Controllers\GenerationDownloadController;
+use App\Controllers\GenerationStreamController;
 use App\Controllers\HomeController;
 use App\Controllers\TailorController;
 use App\Controllers\JobApplicationController;
@@ -175,6 +176,11 @@ class Routes
 
         $app->get('/generations/{id}/download', function (Request $request, Response $response, array $args) use ($container) {
             return $container->get(GenerationDownloadController::class)->download($request, $response, $args);
+        });
+
+        // Stream generation progress updates using server-sent events.
+        $app->get('/generations/{id}/stream', function (Request $request, Response $response, array $args) use ($container) {
+            return $container->get(GenerationStreamController::class)($request, $response, $args);
         });
 
         $app->get('/healthz', function (Request $request, Response $response): Response {


### PR DESCRIPTION
## Summary
- register the GenerationStreamController in the container for dependency injection
- expose the /generations/{id}/stream endpoint so the UI can subscribe to generation progress updates

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68e16b65f740832e9d23937ba5693d86