### PR TITLE
Add candidate voice constraints to tailoring prompt

### DIFF
--- a/prompts/tailor.txt
+++ b/prompts/tailor.txt
@@ -1,3 +1,10 @@
+No meta-text, no commentary, no “you should/consider/add/include,” no apologies, no notes, no lists of suggestions, no “as an AI”.
+No second-person voice; write as the candidate (“Led…”, not “You led…”).
+No fabrication. If a detail is absent in the CV, omit it; do not infer figures, employers, dates, or certifications.
+May reorder, tighten, and mirror JD terminology; may rephrase bullets; may merge duplicates; may quantify only where numbers already exist.
+Keep contact details, dates, employers, and education accurate.
+Keep to UK spelling and professional tone. No emojis, no headers like “Tailored CV”.
+
 Inputs you receive:
 - Job title: {{title}}
 - Hiring company: {{company}}


### PR DESCRIPTION
## Summary
- add explicit instructions to the tailoring prompt requiring first-person candidate voice and prohibiting meta commentary
- reinforce existing guidance around factual accuracy, UK spelling, and respectful tone at the top of the prompt

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e16d838b40832e86b006f103c2668f