### PR TITLE
Add company research workflow with caching

### DIFF
--- a/database/migrations/20241001000000_create_job_application_research.php
+++ b/database/migrations/20241001000000_create_job_application_research.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'id' => '20241001000000_create_job_application_research',
+    'up' => [
+        <<<SQL
+        CREATE TABLE IF NOT EXISTS job_application_research (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            user_id BIGINT UNSIGNED NOT NULL,
+            job_application_id BIGINT UNSIGNED NOT NULL,
+            query VARCHAR(512) NOT NULL,
+            summary LONGTEXT NOT NULL,
+            search_results LONGTEXT NOT NULL,
+            generated_at DATETIME NOT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            CONSTRAINT fk_job_application_research_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+            CONSTRAINT fk_job_application_research_application FOREIGN KEY (job_application_id) REFERENCES job_applications(id) ON DELETE CASCADE,
+            UNIQUE KEY uniq_job_application_research_application (user_id, job_application_id),
+            INDEX idx_job_application_research_generated (generated_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        SQL,
+    ],
+    'down' => [
+        'DROP TABLE IF EXISTS job_application_research',
+    ],
+];

--- a/src/Applications/JobApplicationRepository.php
+++ b/src/Applications/JobApplicationRepository.php
@@ -4,10 +4,17 @@ declare(strict_types=1);
 
 namespace App\Applications;
 
+use DateInterval;
 use DateTimeImmutable;
+use JsonException;
 use PDO;
 use PDOException;
 use RuntimeException;
+
+use function error_log;
+use function is_array;
+use function json_decode;
+use function json_encode;
 
 class JobApplicationRepository
 {
@@ -229,12 +236,144 @@ class JobApplicationRepository
     }
 
     /**
+     * Retrieve the most recent cached research result for the given user.
+     *
+     * Returning hydrated arrays keeps the service layer agnostic of storage
+     * details while still enforcing freshness windows to control spend.
+     *
+     * @return array{
+     *     query: string,
+     *     summary: string,
+     *     search_results: array<int, array{title: string, url: string, snippet: string}>,
+     *     generated_at: DateTimeImmutable
+     * }|null
+     */
+    public function findRecentResearch(int $userId, int $applicationId, int $maxAgeMinutes): ?array
+    {
+        $statement = $this->pdo->prepare(
+            'SELECT query, summary, search_results, generated_at FROM job_application_research '
+            . 'WHERE user_id = :user_id AND job_application_id = :application_id LIMIT 1'
+        );
+
+        $statement->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        $statement->bindValue(':application_id', $applicationId, PDO::PARAM_INT);
+        $statement->execute();
+
+        $row = $statement->fetch();
+
+        if ($row === false) {
+            return null;
+        }
+
+        $generatedAt = new DateTimeImmutable((string) $row['generated_at']);
+        $now = new DateTimeImmutable('now');
+
+        if ($maxAgeMinutes > 0) {
+            $threshold = $now->sub(new DateInterval('PT' . $maxAgeMinutes . 'M'));
+
+            if ($generatedAt < $threshold) {
+                return null;
+            }
+        }
+
+        try {
+            $results = json_decode((string) $row['search_results'], true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            error_log('Failed to decode cached research search results: ' . $exception->getMessage());
+
+            return null;
+        }
+
+        if (!is_array($results)) {
+            return null;
+        }
+
+        return [
+            'query' => (string) $row['query'],
+            'summary' => (string) $row['summary'],
+            'search_results' => $results,
+            'generated_at' => $generatedAt,
+        ];
+    }
+
+    /**
+     * Persist a freshly generated research artefact for future reuse.
+     *
+     * The helper centralises the upsert logic to ensure both MySQL and SQLite
+     * environments maintain a single cached row per application and user.
+     *
+     * @param array<int, array{title: string, url: string, snippet: string}> $searchResults
+     */
+    public function saveResearchResult(
+        int $userId,
+        int $applicationId,
+        string $query,
+        string $summary,
+        array $searchResults,
+        DateTimeImmutable $generatedAt
+    ): void {
+        try {
+            $encodedResults = json_encode($searchResults, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new RuntimeException('Unable to encode research search results for storage.', 0, $exception);
+        }
+
+        $timestamp = $generatedAt->format('Y-m-d H:i:s');
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'mysql') {
+            $sql = <<<SQL
+                INSERT INTO job_application_research
+                    (user_id, job_application_id, query, summary, search_results, generated_at, created_at, updated_at)
+                VALUES
+                    (:user_id, :application_id, :query, :summary, :results, :generated_at, :generated_at, :generated_at)
+                ON DUPLICATE KEY UPDATE
+                    query = VALUES(query),
+                    summary = VALUES(summary),
+                    search_results = VALUES(search_results),
+                    generated_at = VALUES(generated_at),
+                    updated_at = VALUES(updated_at)
+            SQL;
+        } else {
+            $sql = <<<SQL
+                INSERT INTO job_application_research
+                    (user_id, job_application_id, query, summary, search_results, generated_at, created_at, updated_at)
+                VALUES
+                    (:user_id, :application_id, :query, :summary, :results, :generated_at, :generated_at, :generated_at)
+                ON CONFLICT(user_id, job_application_id) DO UPDATE SET
+                    query = excluded.query,
+                    summary = excluded.summary,
+                    search_results = excluded.search_results,
+                    generated_at = excluded.generated_at,
+                    updated_at = excluded.updated_at
+            SQL;
+        }
+
+        $statement = $this->pdo->prepare($sql);
+        $statement->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        $statement->bindValue(':application_id', $applicationId, PDO::PARAM_INT);
+        $statement->bindValue(':query', $query);
+        $statement->bindValue(':summary', $summary);
+        $statement->bindValue(':results', $encodedResults);
+        $statement->bindValue(':generated_at', $timestamp);
+
+        $statement->execute();
+    }
+
+    /**
      * Handle the delete for user operation.
      *
      * The helper keeps deletion logic consistent across the service layer.
      */
     public function deleteForUser(int $userId, int $applicationId): bool
     {
+        $cleanup = $this->pdo->prepare(
+            'DELETE FROM job_application_research WHERE job_application_id = :application_id AND user_id = :user_id'
+        );
+        $cleanup->bindValue(':application_id', $applicationId, PDO::PARAM_INT);
+        $cleanup->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        $cleanup->execute();
+
         $statement = $this->pdo->prepare('DELETE FROM job_applications WHERE id = :id AND user_id = :user_id');
         $statement->bindValue(':id', $applicationId, PDO::PARAM_INT);
         $statement->bindValue(':user_id', $userId, PDO::PARAM_INT);
@@ -278,6 +417,7 @@ class JobApplicationRepository
 
             $this->ensureReasonCodeColumn();
             $this->ensureGenerationIdColumn();
+            $this->ensureResearchTable();
 
             return;
         }
@@ -304,7 +444,58 @@ class JobApplicationRepository
         $this->pdo->exec('CREATE INDEX IF NOT EXISTS idx_job_applications_user_created ON job_applications (user_id, created_at)');
         $this->ensureReasonCodeColumn();
         $this->ensureGenerationIdColumn();
+        $this->ensureResearchTable();
 
+    }
+
+    /**
+     * Ensure the research cache table exists for environments without migrations.
+     */
+    private function ensureResearchTable(): void
+    {
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'mysql') {
+            $sql = <<<SQL
+            CREATE TABLE IF NOT EXISTS job_application_research (
+                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                user_id BIGINT UNSIGNED NOT NULL,
+                job_application_id BIGINT UNSIGNED NOT NULL,
+                query VARCHAR(512) NOT NULL,
+                summary LONGTEXT NOT NULL,
+                search_results LONGTEXT NOT NULL,
+                generated_at DATETIME NOT NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                CONSTRAINT fk_job_application_research_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+                CONSTRAINT fk_job_application_research_application FOREIGN KEY (job_application_id) REFERENCES job_applications(id) ON DELETE CASCADE,
+                UNIQUE KEY uniq_job_application_research_application (user_id, job_application_id),
+                INDEX idx_job_application_research_generated (generated_at)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+            SQL;
+
+            $this->pdo->exec($sql);
+
+            return;
+        }
+
+        $sql = <<<SQL
+        CREATE TABLE IF NOT EXISTS job_application_research (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            job_application_id INTEGER NOT NULL,
+            query TEXT NOT NULL,
+            summary TEXT NOT NULL,
+            search_results TEXT NOT NULL,
+            generated_at TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        SQL;
+
+        $this->pdo->exec($sql);
+        $this->pdo->exec('CREATE UNIQUE INDEX IF NOT EXISTS uniq_job_application_research_application ON job_application_research (user_id, job_application_id)');
+        $this->pdo->exec('CREATE INDEX IF NOT EXISTS idx_job_application_research_generated ON job_application_research (generated_at)');
     }
 
     /**

--- a/src/Research/CompanyResearchService.php
+++ b/src/Research/CompanyResearchService.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Research;
+
+use App\AI\OpenAIProvider;
+use App\Applications\JobApplication;
+use App\Applications\JobApplicationRepository;
+use GuzzleHttp\Exception\RequestException;
+use DateTimeImmutable;
+use DateTimeInterface;
+use RuntimeException;
+
+use function implode;
+use function parse_url;
+use function preg_match;
+use function strtolower;
+use function trim;
+
+final class CompanyResearchService
+{
+    private const CACHE_TTL_MINUTES = 360;
+    private const SEARCH_RESULT_LIMIT = 5;
+
+    /** @var JobApplicationRepository */
+    private $repository;
+
+    /** @var WebSearchClient */
+    private $searchClient;
+
+    /** @var OpenAIProvider */
+    private $openAiProvider;
+
+    /**
+     * Construct the object with its required dependencies.
+     *
+     * This ensures collaborating services are available for subsequent method calls.
+     */
+    public function __construct(
+        JobApplicationRepository $repository,
+        WebSearchClient $searchClient,
+        OpenAIProvider $openAiProvider
+    ) {
+        $this->repository = $repository;
+        $this->searchClient = $searchClient;
+        $this->openAiProvider = $openAiProvider;
+    }
+
+    /**
+     * Generate or retrieve cached research insights for a job application.
+     *
+     * The helper orchestrates repository lookups, web search enrichment, and
+     * OpenAI summarisation while enforcing caching rules to limit token spend.
+     *
+     * @return array{
+     *     status: 'cached'|'generated',
+     *     query: string,
+     *     generated_at: string,
+     *     summary: string,
+     *     search_results: array<int, array{title: string, url: string, snippet: string}>
+     * }
+     */
+    public function research(int $userId, int $applicationId): array
+    {
+        $application = $this->repository->findForUser($userId, $applicationId);
+
+        if ($application === null) {
+            throw new RuntimeException('Job application not found.', 404);
+        }
+
+        $cached = $this->repository->findRecentResearch($userId, $applicationId, self::CACHE_TTL_MINUTES);
+
+        if ($cached !== null) {
+            return [
+                'status' => 'cached',
+                'query' => $cached['query'],
+                'generated_at' => $cached['generated_at']->format(DateTimeInterface::ATOM),
+                'summary' => $cached['summary'],
+                'search_results' => $cached['search_results'],
+            ];
+        }
+
+        $query = $this->buildQuery($application);
+        $results = $this->performSearch($query);
+        $summary = $this->summarise($userId, $application, $results);
+        $generatedAt = new DateTimeImmutable('now');
+
+        $this->repository->saveResearchResult($userId, $applicationId, $query, $summary, $results, $generatedAt);
+
+        return [
+            'status' => 'generated',
+            'query' => $query,
+            'generated_at' => $generatedAt->format(DateTimeInterface::ATOM),
+            'summary' => $summary,
+            'search_results' => $results,
+        ];
+    }
+
+    /**
+     * Derive a sensible default search query from the application context.
+     *
+     * The helper combines the job title with any detected domain keywords to
+     * improve search quality without requiring user-provided queries.
+     */
+    private function buildQuery(JobApplication $application): string
+    {
+        $parts = [];
+        $title = trim($application->title());
+
+        if ($title !== '') {
+            $parts[] = $title;
+        }
+
+        $sourceUrl = $application->sourceUrl();
+
+        if ($sourceUrl !== null) {
+            $domain = $this->extractDomain($sourceUrl);
+
+            if ($domain !== null) {
+                $parts[] = $domain;
+            }
+        }
+
+        if ($parts === []) {
+            $parts[] = 'company research';
+        }
+
+        return implode(' ', $parts);
+    }
+
+    /**
+     * Extract a domain name from a source URL when available.
+     *
+     * Restricting the domain to alphanumeric and hyphen characters avoids
+     * accidentally feeding path segments into the search query.
+     */
+    private function extractDomain(string $sourceUrl): ?string
+    {
+        $host = parse_url($sourceUrl, PHP_URL_HOST);
+
+        if (!is_string($host)) {
+            return null;
+        }
+
+        $host = strtolower(trim($host));
+
+        if ($host === '') {
+            return null;
+        }
+
+        if (!preg_match('/^[a-z0-9.-]+$/', $host)) {
+            return null;
+        }
+
+        return $host;
+    }
+
+    /**
+     * Perform the outbound web search call and map failures into domain errors.
+     *
+     * Catching upstream exceptions here ensures the controller can surface a
+     * predictable message and status code to the caller.
+     *
+     * @return array<int, array{title: string, url: string, snippet: string}>
+     */
+    private function performSearch(string $query): array
+    {
+        try {
+            return $this->searchClient->search($query, self::SEARCH_RESULT_LIMIT);
+        } catch (RuntimeException $exception) {
+            if ($exception->getCode() === 429) {
+                throw new RuntimeException('Search provider rate limit reached.', 429, $exception);
+            }
+
+            throw new RuntimeException('Unable to contact the search provider.', 0, $exception);
+        }
+    }
+
+    /**
+     * Request an OpenAI-backed cheat sheet that fuses job and company details.
+     *
+     * @param array<int, array{title: string, url: string, snippet: string}> $results
+     */
+    private function summarise(int $userId, JobApplication $application, array $results): string
+    {
+        $provider = $this->openAiProvider->forUser($userId);
+
+        try {
+            return $provider->cheatSheet($application->description(), $results);
+        } catch (RuntimeException $exception) {
+            $statusCode = $this->resolveStatusCode($exception);
+
+            if ($statusCode === 429) {
+                throw new RuntimeException('OpenAI rate limit reached.', 429, $exception);
+            }
+
+            throw new RuntimeException('Unable to generate research summary.', 0, $exception);
+        }
+    }
+
+    /**
+     * Resolve an HTTP status code from a nested runtime exception hierarchy.
+     */
+    private function resolveStatusCode(RuntimeException $exception): ?int
+    {
+        $previous = $exception->getPrevious();
+
+        if ($previous instanceof RuntimeException) {
+            $code = $previous->getCode();
+
+            if ($code !== 0) {
+                return $code;
+            }
+        }
+
+        if ($previous instanceof RequestException) {
+            $response = $previous->getResponse();
+
+            if ($response !== null) {
+                return $response->getStatusCode();
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Research/WebSearchClient.php
+++ b/src/Research/WebSearchClient.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Research;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\RequestException;
+use JsonException;
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
+
+use function array_map;
+use function array_values;
+use function count;
+use function getenv;
+use function is_array;
+use function is_string;
+use function json_decode;
+use function rtrim;
+use function sprintf;
+use function trim;
+
+final class WebSearchClient
+{
+    private const DEFAULT_BASE_URL = 'https://api.search.local/v1';
+    private const DEFAULT_ENDPOINT = 'search';
+
+    /** @var ClientInterface */
+    private $client;
+
+    /** @var string */
+    private $apiKey;
+
+    /** @var string */
+    private $endpoint;
+
+    /**
+     * Construct the object with its required dependencies.
+     *
+     * This ensures collaborating services are available for subsequent method calls.
+     */
+    public function __construct(?ClientInterface $client = null)
+    {
+        $this->apiKey = $this->requireEnv('SEARCH_API_KEY');
+        $baseUrl = $this->env('SEARCH_API_BASE_URL') ?? self::DEFAULT_BASE_URL;
+        $endpoint = $this->env('SEARCH_API_ENDPOINT') ?? self::DEFAULT_ENDPOINT;
+        $this->endpoint = trim($endpoint, '/');
+        $baseUri = rtrim($baseUrl, '/') . '/';
+
+        $this->client = $client ?? new Client([
+            'base_uri' => $baseUri,
+            'timeout' => 20,
+        ]);
+    }
+
+    /**
+     * Execute a search query and normalise the response payload.
+     *
+     * The helper translates diverse search provider schemas into a predictable
+     * tuple list containing title, url, and snippet keys for downstream use.
+     *
+     * @return array<int, array{title: string, url: string, snippet: string}>
+     */
+    public function search(string $query, int $limit = 5): array
+    {
+        $parameters = [
+            'query' => [
+                'q' => $query,
+                'count' => $limit,
+            ],
+            'headers' => [
+                'Authorization' => 'Bearer ' . $this->apiKey,
+                'Accept' => 'application/json',
+            ],
+        ];
+
+        try {
+            $response = $this->client->request('GET', $this->endpoint, $parameters);
+        } catch (RequestException $exception) {
+            $statusCode = null;
+            $response = $exception->getResponse();
+
+            if ($response !== null) {
+                $statusCode = $response->getStatusCode();
+            }
+
+            $message = $statusCode === 429
+                ? 'Search provider rate limit exceeded.'
+                : 'Search provider request failed.';
+
+            throw new RuntimeException($message, (int) ($statusCode ?? 0), $exception);
+        }
+
+        $payload = $this->decodeResponse($response);
+        $items = $this->extractItems($payload);
+
+        $normalised = array_values(array_map(function ($item) {
+            $title = isset($item['title']) && is_string($item['title']) ? trim($item['title']) : '';
+            $url = isset($item['url']) && is_string($item['url']) ? trim($item['url']) : '';
+            $snippet = isset($item['snippet']) && is_string($item['snippet']) ? trim($item['snippet']) : '';
+
+            if ($title === '' && isset($item['name']) && is_string($item['name'])) {
+                $title = trim($item['name']);
+            }
+
+            if ($url === '' && isset($item['link']) && is_string($item['link'])) {
+                $url = trim($item['link']);
+            }
+
+            if ($snippet === '' && isset($item['description']) && is_string($item['description'])) {
+                $snippet = trim($item['description']);
+            }
+
+            if ($snippet === '' && isset($item['summary']) && is_string($item['summary'])) {
+                $snippet = trim($item['summary']);
+            }
+
+            return [
+                'title' => $title,
+                'url' => $url,
+                'snippet' => $snippet,
+            ];
+        }, $items));
+
+        $filtered = [];
+
+        foreach ($normalised as $entry) {
+            if ($entry['title'] === '' || $entry['url'] === '') {
+                continue;
+            }
+
+            $filtered[] = $entry;
+
+            if (count($filtered) >= $limit) {
+                break;
+            }
+        }
+
+        return $filtered;
+    }
+
+    /**
+     * Decode a JSON response payload into a PHP array.
+     *
+     * Wrapping json_decode with error handling keeps failure messaging tidy.
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeResponse(ResponseInterface $response): array
+    {
+        $body = (string) $response->getBody();
+
+        try {
+            $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new RuntimeException('Search provider returned malformed JSON.', 0, $exception);
+        }
+
+        if (!is_array($decoded)) {
+            throw new RuntimeException('Search provider responded with an unexpected payload.');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * Extract the candidate result entries from the provider-specific schema.
+     *
+     * Supporting a variety of property names keeps the client portable across
+     * common search APIs without leaking provider-specific logic elsewhere.
+     *
+     * @param array<string, mixed> $payload
+     * @return array<int, array<string, mixed>>
+     */
+    private function extractItems(array $payload): array
+    {
+        if (isset($payload['items']) && is_array($payload['items'])) {
+            return $payload['items'];
+        }
+
+        if (isset($payload['results']) && is_array($payload['results'])) {
+            return $payload['results'];
+        }
+
+        if (isset($payload['data']) && is_array($payload['data'])) {
+            return $payload['data'];
+        }
+
+        return [];
+    }
+
+    /**
+     * Fetch an environment variable while permitting empty strings.
+     */
+    private function env(string $key): ?string
+    {
+        $value = getenv($key);
+
+        if ($value === false) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    /**
+     * Fetch an environment variable, throwing if it is missing.
+     */
+    private function requireEnv(string $key): string
+    {
+        $value = $this->env($key);
+
+        if ($value === null) {
+            throw new RuntimeException(sprintf('%s environment variable must be configured for search access.', $key));
+        }
+
+        return $value;
+    }
+}

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -112,6 +112,10 @@ class Routes
             return $container->get(JobApplicationController::class)->updateGeneration($request, $response, $args);
         });
 
+        $app->post('/applications/{id}/research', function (Request $request, Response $response, array $args) use ($container) {
+            return $container->get(JobApplicationController::class)->research($request, $response, $args);
+        });
+
         $app->post('/applications/{id}/delete', function (Request $request, Response $response, array $args) use ($container) {
             return $container->get(JobApplicationController::class)->delete($request, $response, $args);
         });


### PR DESCRIPTION
## Summary
- add a reusable web search client and company research service that combine job data, cached results, and OpenAI cheat sheets
- extend the job application repository and schema to cache research outputs and surface cached versus freshly generated insights
- expose the research endpoint via the controller, dependency container, and routing so authenticated clients can request summaries

## Testing
- php -l src/Research/WebSearchClient.php
- php -l src/Research/CompanyResearchService.php
- php -l src/Controllers/JobApplicationController.php
- php -l src/AI/OpenAIProvider.php
- php -l src/Applications/JobApplicationRepository.php
- php -l public/index.php
- php -l src/Routes.php

------
https://chatgpt.com/codex/tasks/task_e_68e4f20d142c832ea48a3f592268f1b5