### PR TITLE
Add research insights workflow to applications board

### DIFF
--- a/public/assets/js/applications.js
+++ b/public/assets/js/applications.js
@@ -1,0 +1,666 @@
+(function () {
+    'use strict';
+
+    /**
+     * Read the CSRF token placed within the document head meta tags.
+     *
+     * @returns {string} The token value or an empty string when missing.
+     */
+    const resolveCsrfToken = function () {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+
+        if (!meta) {
+            return '';
+        }
+
+        const value = meta.getAttribute('content');
+
+        return typeof value === 'string' ? value : '';
+    };
+
+    /**
+     * Normalise arbitrary identifiers into a string for DOM queries.
+     *
+     * @param {*} value The raw value sourced from data attributes.
+     * @returns {string} A string identifier or an empty fallback.
+     */
+    const normaliseId = function (value) {
+        if (typeof value === 'string') {
+            return value;
+        }
+
+        if (typeof value === 'number' && isFinite(value)) {
+            return String(value);
+        }
+
+        return '';
+    };
+
+    /**
+     * Toggle the hidden state for an element using the `hidden` attribute.
+     *
+     * @param {HTMLElement|null} element The element to show or hide.
+     * @param {boolean} shouldHide Indicates whether the element should be hidden.
+     * @returns {void}
+     */
+    const setHiddenState = function (element, shouldHide) {
+        if (!element) {
+            return;
+        }
+
+        if (shouldHide) {
+            element.setAttribute('hidden', 'hidden');
+            return;
+        }
+
+        element.removeAttribute('hidden');
+    };
+
+    /**
+     * Collect important child elements from the research panel.
+     *
+     * @param {HTMLElement} panel The container element holding research output.
+     * @returns {{content: HTMLElement|null, loading: HTMLElement|null, error: HTMLElement|null, meta: HTMLElement|null}} Resolved child references.
+     */
+    const locatePanelElements = function (panel) {
+        return {
+            content: panel.querySelector('[data-research-content]'),
+            loading: panel.querySelector('[data-research-loading]'),
+            error: panel.querySelector('[data-research-error]'),
+            meta: panel.querySelector('[data-research-meta]'),
+        };
+    };
+
+    /**
+     * Clear the research content container to prepare for new markup.
+     *
+     * @param {HTMLElement|null} container The container that receives generated markup.
+     * @returns {void}
+     */
+    const resetContent = function (container) {
+        if (!container) {
+            return;
+        }
+
+        while (container.firstChild) {
+            container.removeChild(container.firstChild);
+        }
+    };
+
+    /**
+     * Append a list element with supplied items to the container.
+     *
+     * @param {(HTMLElement|DocumentFragment)} container The container accepting the list.
+     * @param {Array} items The collection of string items.
+     * @returns {boolean} Indicates whether list items were appended.
+     */
+    const appendList = function (container, items) {
+        if (!container || !Array.isArray(items) || items.length === 0) {
+            return false;
+        }
+
+        const list = document.createElement('ul');
+        list.className = 'list-disc space-y-1 pl-5 text-left';
+
+        let appended = false;
+
+        for (let index = 0; index < items.length; index += 1) {
+            const item = items[index];
+
+            if (typeof item !== 'string' || item.trim() === '') {
+                continue;
+            }
+
+            const listItem = document.createElement('li');
+            listItem.textContent = item.trim();
+            list.appendChild(listItem);
+            appended = true;
+        }
+
+        if (!appended) {
+            return false;
+        }
+
+        container.appendChild(list);
+
+        return true;
+    };
+
+    /**
+     * Render markdown-style content into a container with minimal formatting.
+     *
+     * @param {string} markdownText The markdown text returned by the API.
+     * @param {HTMLElement|null} container The container that receives rendered HTML.
+     * @returns {boolean} Indicates whether any markdown content was rendered.
+     */
+    const renderMarkdownContent = function (markdownText, container) {
+        if (!container || typeof markdownText !== 'string' || markdownText.trim() === '') {
+            return false;
+        }
+
+        const text = markdownText.replace(/\r\n/g, '\n');
+        const lines = text.split('\n');
+        const fragment = document.createDocumentFragment();
+
+        let paragraphBuffer = [];
+        let hasRendered = false;
+
+        /**
+         * Flush the buffered paragraph lines into a paragraph element.
+         *
+         * @returns {void}
+         */
+        const flushParagraph = function () {
+            if (paragraphBuffer.length === 0) {
+                return;
+            }
+
+            const paragraph = document.createElement('p');
+            paragraph.textContent = paragraphBuffer.join(' ');
+            fragment.appendChild(paragraph);
+            paragraphBuffer = [];
+            hasRendered = true;
+        };
+
+        let activeList = null;
+
+        for (let index = 0; index < lines.length; index += 1) {
+            const rawLine = lines[index];
+            const line = typeof rawLine === 'string' ? rawLine.trim() : '';
+
+            if (line === '') {
+                flushParagraph();
+                activeList = null;
+                continue;
+            }
+
+            if (line.charAt(0) === '-' || line.charAt(0) === '*') {
+                const cleaned = line.replace(/^[-*]\s*/, '');
+
+                flushParagraph();
+
+                if (!activeList) {
+                    activeList = document.createElement('ul');
+                    activeList.className = 'list-disc space-y-1 pl-5 text-left';
+                    fragment.appendChild(activeList);
+                }
+
+                const listItem = document.createElement('li');
+                listItem.textContent = cleaned;
+                activeList.appendChild(listItem);
+                hasRendered = true;
+                continue;
+            }
+
+            if (line.charAt(0) === '#') {
+                const levelMatch = line.match(/^(#+)\s*(.*)$/);
+                const headingText = levelMatch && levelMatch[2] ? levelMatch[2].trim() : line.replace(/^#+\s*/, '').trim();
+
+                flushParagraph();
+                activeList = null;
+
+                if (headingText !== '') {
+                    const heading = document.createElement('h3');
+                    heading.className = 'text-sm font-semibold text-indigo-200 theme-light:text-indigo-600';
+                    heading.textContent = headingText;
+                    fragment.appendChild(heading);
+                    hasRendered = true;
+                }
+
+                continue;
+            }
+
+            activeList = null;
+            paragraphBuffer.push(line);
+        }
+
+        flushParagraph();
+
+        if (!hasRendered) {
+            return false;
+        }
+
+        resetContent(container);
+        container.appendChild(fragment);
+
+        return true;
+    };
+
+    /**
+     * Render structured sections or highlight lists when provided.
+     *
+     * @param {object} payload The payload returned from the API.
+     * @param {HTMLElement|null} container The container that receives rendered HTML.
+     * @returns {boolean} Indicates whether any structured content was rendered.
+     */
+    const renderStructuredContent = function (payload, container) {
+        if (!container || !payload || typeof payload !== 'object') {
+            return false;
+        }
+
+        const fragment = document.createDocumentFragment();
+        let hasRendered = false;
+
+        if (Array.isArray(payload.sections) && payload.sections.length > 0) {
+            for (let index = 0; index < payload.sections.length; index += 1) {
+                const section = payload.sections[index];
+
+                if (!section || typeof section !== 'object') {
+                    continue;
+                }
+
+                const title = typeof section.title === 'string' ? section.title.trim() : '';
+                const points = Array.isArray(section.points) ? section.points : section.items;
+
+                if (title !== '') {
+                    const heading = document.createElement('h3');
+                    heading.className = 'text-sm font-semibold text-indigo-200 theme-light:text-indigo-600';
+                    heading.textContent = title;
+                    fragment.appendChild(heading);
+                    hasRendered = true;
+                }
+
+                if (Array.isArray(points) && points.length > 0) {
+                    const list = document.createElement('ul');
+                    list.className = 'list-disc space-y-1 pl-5 text-left';
+
+                    for (let pointIndex = 0; pointIndex < points.length; pointIndex += 1) {
+                        const value = points[pointIndex];
+
+                        if (typeof value !== 'string' || value.trim() === '') {
+                            continue;
+                        }
+
+                        const listItem = document.createElement('li');
+                        listItem.textContent = value.trim();
+                        list.appendChild(listItem);
+                    }
+
+                    if (list.childNodes.length > 0) {
+                        fragment.appendChild(list);
+                        hasRendered = true;
+                    }
+                }
+            }
+        }
+
+        if (!hasRendered) {
+            const highlights = Array.isArray(payload.highlights)
+                ? payload.highlights
+                : (Array.isArray(payload.points) ? payload.points : null);
+
+            if (Array.isArray(highlights) && highlights.length > 0) {
+                hasRendered = appendList(fragment, highlights);
+            }
+        }
+
+        if (!hasRendered) {
+            return false;
+        }
+
+        resetContent(container);
+        container.appendChild(fragment);
+
+        return true;
+    };
+
+    /**
+     * Resolve the primary payload object from the API response.
+     *
+     * @param {*} response The decoded JSON response.
+     * @returns {object|null} The payload object or null when absent.
+     */
+    const resolvePayload = function (response) {
+        if (!response || typeof response !== 'object') {
+            return null;
+        }
+
+        if (response.data && typeof response.data === 'object') {
+            return response.data;
+        }
+
+        if (response.result && typeof response.result === 'object') {
+            return response.result;
+        }
+
+        return response;
+    };
+
+    /**
+     * Derive a readable timestamp description for screen readers.
+     *
+     * @param {object} payload The payload containing optional timestamp metadata.
+     * @returns {{message: string, raw: string}|null} A prepared timestamp description or null when unavailable.
+     */
+    const resolveTimestamp = function (payload) {
+        if (!payload || typeof payload !== 'object') {
+            return null;
+        }
+
+        const candidates = [
+            payload.generated_at,
+            payload.generatedAt,
+            payload.cached_at,
+            payload.cachedAt,
+            payload.updated_at,
+            payload.updatedAt,
+        ];
+
+        let timestamp = '';
+
+        for (let index = 0; index < candidates.length; index += 1) {
+            const value = candidates[index];
+
+            if (typeof value === 'string' && value.trim() !== '') {
+                timestamp = value.trim();
+                break;
+            }
+        }
+
+        if (timestamp === '') {
+            return null;
+        }
+
+        const prefixSources = [payload.cached, payload.fromCache, payload.is_cached, payload.cachedResult];
+        let prefix = 'Generated';
+
+        for (let index = 0; index < prefixSources.length; index += 1) {
+            const value = prefixSources[index];
+
+            if (value === true || value === 'true') {
+                prefix = 'Cached result';
+                break;
+            }
+        }
+
+        const parsed = new Date(timestamp);
+        let readable = timestamp;
+
+        if (!isNaN(parsed.getTime()) && typeof parsed.toLocaleString === 'function') {
+            readable = parsed.toLocaleString(undefined, {
+                dateStyle: 'medium',
+                timeStyle: 'short',
+            });
+        }
+
+        return {
+            message: prefix + ' ' + readable + '.',
+            raw: timestamp,
+        };
+    };
+
+    /**
+     * Display the loading state for the research panel.
+     *
+     * @param {HTMLElement} panel The container element that reports busy state.
+     * @param {{loading: HTMLElement|null, content: HTMLElement|null, error: HTMLElement|null, meta: HTMLElement|null}} elements The resolved child references.
+     * @returns {void}
+     */
+    const presentLoadingState = function (panel, elements) {
+        panel.setAttribute('aria-busy', 'true');
+        panel.dataset.researchLoading = 'true';
+
+        setHiddenState(elements.loading, false);
+        setHiddenState(elements.content, true);
+        setHiddenState(elements.error, true);
+
+        if (elements.meta) {
+            elements.meta.textContent = '';
+            setHiddenState(elements.meta, true);
+        }
+    };
+
+    /**
+     * Present an error message to the user when the request fails.
+     *
+     * @param {HTMLElement} panel The container element that reports busy state.
+     * @param {{loading: HTMLElement|null, content: HTMLElement|null, error: HTMLElement|null, meta: HTMLElement|null}} elements The resolved child references.
+     * @param {string} message The error message to display.
+     * @returns {void}
+     */
+    const presentErrorState = function (panel, elements, message) {
+        panel.setAttribute('aria-busy', 'false');
+        panel.dataset.researchLoading = 'false';
+
+        setHiddenState(elements.loading, true);
+        setHiddenState(elements.content, true);
+
+        if (elements.error) {
+            const heading = elements.error.querySelector('[data-research-error-heading]');
+            const body = elements.error.querySelector('[data-research-error-body]');
+
+            if (heading) {
+                heading.textContent = message;
+            } else {
+                const fallbackHeading = document.createElement('p');
+                fallbackHeading.textContent = message;
+                elements.error.appendChild(fallbackHeading);
+            }
+
+            if (body) {
+                body.textContent = 'Please try again in a moment.';
+            }
+
+            setHiddenState(elements.error, false);
+        }
+
+        if (elements.meta) {
+            elements.meta.textContent = '';
+            setHiddenState(elements.meta, true);
+        }
+    };
+
+    /**
+     * Present the rendered research content to the user.
+     *
+     * @param {HTMLElement} panel The container element that reports busy state.
+     * @param {{loading: HTMLElement|null, content: HTMLElement|null, error: HTMLElement|null, meta: HTMLElement|null}} elements The resolved child references.
+     * @param {object|null} payload The payload returned from the API.
+     * @returns {boolean} Indicates whether content was successfully rendered.
+     */
+    const presentContentState = function (panel, elements, payload) {
+        panel.setAttribute('aria-busy', 'false');
+        panel.dataset.researchLoading = 'false';
+
+        setHiddenState(elements.loading, true);
+        setHiddenState(elements.error, true);
+
+        let rendered = false;
+
+        if (payload) {
+            if (!rendered && typeof payload.markdown === 'string') {
+                rendered = renderMarkdownContent(payload.markdown, elements.content);
+            }
+
+            if (!rendered && typeof payload.content === 'string') {
+                rendered = renderMarkdownContent(payload.content, elements.content);
+            }
+
+            if (!rendered) {
+                rendered = renderStructuredContent(payload, elements.content);
+            }
+        }
+
+        if (!rendered && elements.content) {
+            resetContent(elements.content);
+            const paragraph = document.createElement('p');
+            paragraph.textContent = 'No research notes were returned for this application.';
+            elements.content.appendChild(paragraph);
+            rendered = true;
+        }
+
+        if (elements.content) {
+            setHiddenState(elements.content, !rendered);
+        }
+
+        if (elements.meta) {
+            const timestamp = resolveTimestamp(payload || {});
+
+            if (timestamp) {
+                elements.meta.textContent = timestamp.message;
+                elements.meta.setAttribute('data-timestamp', timestamp.raw);
+                setHiddenState(elements.meta, false);
+            } else {
+                elements.meta.textContent = '';
+                setHiddenState(elements.meta, true);
+            }
+        }
+
+        return rendered;
+    };
+
+    /**
+     * Perform the POST request that retrieves company research insights.
+     *
+     * @param {HTMLButtonElement} button The trigger that initiated the request.
+     * @param {HTMLElement} panel The container element that displays responses.
+     * @param {{loading: HTMLElement|null, content: HTMLElement|null, error: HTMLElement|null, meta: HTMLElement|null}} elements The resolved child references.
+     * @param {string} csrfToken The CSRF token applied to the request headers.
+     * @returns {void}
+     */
+    const requestResearch = function (button, panel, elements, csrfToken) {
+        if (!button || !panel) {
+            return;
+        }
+
+        const identifier = normaliseId(button.getAttribute('data-application-id'));
+
+        if (identifier === '') {
+            presentErrorState(panel, elements, 'Missing application identifier.');
+            return;
+        }
+
+        const title = button.getAttribute('data-application-title') || '';
+        const endpoint = '/applications/' + encodeURIComponent(identifier) + '/research';
+
+        presentLoadingState(panel, elements);
+
+        const headers = {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+        };
+
+        if (csrfToken !== '') {
+            headers['X-CSRF-TOKEN'] = csrfToken;
+        }
+
+        fetch(endpoint, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: headers,
+            body: JSON.stringify({
+                title: title,
+            }),
+        })
+            .then(function (response) {
+                if (!response.ok) {
+                    throw new Error('Unable to fetch research details at this time.');
+                }
+
+                return response.json();
+            })
+            .then(function (json) {
+                const payload = resolvePayload(json);
+
+                if (json && json.success === false) {
+                    const message = typeof json.message === 'string' && json.message !== ''
+                        ? json.message
+                        : 'The research endpoint reported an error.';
+                    throw new Error(message);
+                }
+
+                presentContentState(panel, elements, payload);
+                panel.dataset.researchLoaded = 'true';
+            })
+            .catch(function (error) {
+                presentErrorState(panel, elements, error.message || 'Unable to fetch research details at this time.');
+            });
+    };
+
+    /**
+     * Show the research panel and optionally toggle it closed when already visible.
+     *
+     * @param {HTMLButtonElement} button The button that toggles the panel.
+     * @param {HTMLElement} panel The panel element to toggle.
+     * @returns {boolean} Indicates whether the panel remains visible after toggling.
+     */
+    const togglePanelVisibility = function (button, panel) {
+        const classList = panel.classList;
+        const isHidden = classList.contains('hidden');
+
+        if (isHidden) {
+            classList.remove('hidden');
+            panel.setAttribute('aria-hidden', 'false');
+
+            if (typeof panel.focus === 'function') {
+                panel.focus();
+            }
+
+            button.setAttribute('aria-expanded', 'true');
+            return true;
+        }
+
+        classList.add('hidden');
+        panel.setAttribute('aria-hidden', 'true');
+        button.setAttribute('aria-expanded', 'false');
+
+        return false;
+    };
+
+    const csrfToken = resolveCsrfToken();
+    const triggers = document.querySelectorAll('[data-research-trigger]');
+
+    for (let index = 0; index < triggers.length; index += 1) {
+        const trigger = triggers[index];
+
+        trigger.addEventListener('click', function (event) {
+            event.preventDefault();
+
+            const button = event.currentTarget;
+            const targetId = button.getAttribute('aria-controls');
+            const panelId = normaliseId(targetId);
+
+            if (panelId === '') {
+                return;
+            }
+
+            const panel = document.getElementById(panelId);
+
+            if (!panel) {
+                return;
+            }
+
+            const isVisible = togglePanelVisibility(button, panel);
+
+            if (!isVisible) {
+                return;
+            }
+
+            const elements = locatePanelElements(panel);
+
+            if (panel.dataset.researchLoading === 'true') {
+                presentLoadingState(panel, elements);
+                return;
+            }
+
+            if (panel.dataset.researchLoaded === 'true') {
+                panel.setAttribute('aria-busy', 'false');
+                panel.dataset.researchLoading = 'false';
+                setHiddenState(elements.loading, true);
+                setHiddenState(elements.error, true);
+
+                if (elements.content) {
+                    setHiddenState(elements.content, false);
+                }
+
+                if (elements.meta && elements.meta.textContent && elements.meta.textContent.trim() !== '') {
+                    setHiddenState(elements.meta, false);
+                }
+
+                return;
+            }
+
+            requestResearch(button, panel, elements, csrfToken);
+        });
+    }
+})();

--- a/resources/views/applications.php
+++ b/resources/views/applications.php
@@ -10,6 +10,9 @@
 /** @var array<string, string> $failureReasons */
 /** @var string|null $csrfToken */
 ?>
+<?php
+$additionalHead = '<script src="/assets/js/applications.js" defer></script>';
+?>
 <?php ob_start(); ?>
 <div class="space-y-8">
     <header class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
@@ -112,6 +115,13 @@
                                     $generation = isset($kanbanItem['generation']) && is_array($kanbanItem['generation'])
                                         ? $kanbanItem['generation']
                                         : null;
+                                    $applicationIdValue = isset($kanbanItem['id']) ? (string) $kanbanItem['id'] : '';
+                                    $researchPanelId = 'application_research_' . ($applicationIdValue !== ''
+                                        ? preg_replace('/[^a-zA-Z0-9_-]/', '_', $applicationIdValue)
+                                        : uniqid('app_', false));
+                                    $applicationTitleValue = isset($kanbanItem['title']) && is_string($kanbanItem['title'])
+                                        ? $kanbanItem['title']
+                                        : 'Untitled role';
                                     $submittedAt = isset($kanbanItem['applied_at']) && $kanbanItem['applied_at'] !== null && $kanbanItem['applied_at'] !== ''
                                         ? 'Submitted ' . $kanbanItem['applied_at']
                                         : 'Not submitted yet';
@@ -120,9 +130,24 @@
                                         <div class="flex flex-col gap-3">
                                             <div class="flex items-start justify-between gap-3">
                                                 <h5 class="text-sm font-semibold text-white theme-light:text-slate-900">
-                                                    <?= htmlspecialchars($kanbanItem['title'] ?? 'Untitled role', ENT_QUOTES) ?>
+                                                    <?= htmlspecialchars($applicationTitleValue, ENT_QUOTES) ?>
                                                 </h5>
-                                                <div class="flex items-center gap-2">
+                                                <div class="flex flex-wrap items-center justify-end gap-2">
+                                                    <button
+                                                        type="button"
+                                                        class="inline-flex items-center gap-2 rounded-full border border-indigo-400/40 bg-indigo-500/10 px-3 py-1 text-[0.68rem] font-semibold uppercase tracking-wide text-indigo-100 transition hover:border-indigo-300 hover:text-indigo-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400 theme-light:border-indigo-200 theme-light:bg-indigo-50 theme-light:text-indigo-600 theme-light:hover:border-indigo-300 theme-light:hover:text-indigo-700"
+                                                        data-research-trigger
+                                                        data-application-id="<?= htmlspecialchars($applicationIdValue, ENT_QUOTES) ?>"
+                                                        data-application-title="<?= htmlspecialchars($applicationTitleValue, ENT_QUOTES) ?>"
+                                                        aria-controls="<?= htmlspecialchars($researchPanelId, ENT_QUOTES) ?>"
+                                                        aria-expanded="false"
+                                                    >
+                                                        <svg aria-hidden="true" class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                                                            <path d="M21 21l-4.35-4.35"></path>
+                                                            <circle cx="10.5" cy="10.5" r="6.5"></circle>
+                                                        </svg>
+                                                        <span>Research company</span>
+                                                    </button>
                                                     <?php if ($generation !== null) : ?>
                                                         <a
                                                             href="/generations/<?= urlencode((string) ($generation['id'] ?? '')) ?>/download?artifact=cv&amp;format=pdf"
@@ -159,6 +184,32 @@
                                                         </span>
                                                     <?php endif; ?>
                                                 </div>
+                                            </div>
+                                            <div
+                                                id="<?= htmlspecialchars($researchPanelId, ENT_QUOTES) ?>"
+                                                class="hidden rounded-xl border border-indigo-400/30 bg-slate-950/80 p-3 text-left text-[0.72rem] text-slate-200 shadow-inner shadow-indigo-900/20 focus:outline-none theme-light:border-indigo-200 theme-light:bg-indigo-50 theme-light:text-slate-700"
+                                                data-research-output
+                                                data-application-id="<?= htmlspecialchars($applicationIdValue, ENT_QUOTES) ?>"
+                                                role="region"
+                                                aria-label="Research insights for <?= htmlspecialchars($applicationTitleValue, ENT_QUOTES) ?>"
+                                                aria-live="polite"
+                                                aria-busy="false"
+                                                aria-hidden="true"
+                                                tabindex="-1"
+                                            >
+                                                <div class="flex items-center gap-2 text-indigo-200 theme-light:text-indigo-600" data-research-loading hidden role="status" aria-live="polite">
+                                                    <svg aria-hidden="true" class="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                                                        <circle cx="12" cy="12" r="9" opacity="0.25"></circle>
+                                                        <path d="M21 12a9 9 0 01-9 9" stroke-linecap="round"></path>
+                                                    </svg>
+                                                    <span class="font-medium">Gathering company research…</span>
+                                                </div>
+                                                <div class="prose prose-invert max-w-none text-left text-sm leading-relaxed theme-light:prose-slate" data-research-content hidden></div>
+                                                <div class="space-y-1" data-research-error hidden role="alert">
+                                                    <p class="text-sm font-semibold text-rose-200 theme-light:text-rose-600" data-research-error-heading>Unable to load insights.</p>
+                                                    <p class="text-xs text-rose-200/80 theme-light:text-rose-600/80" data-research-error-body>Please try again in a moment.</p>
+                                                </div>
+                                                <p class="mt-3 text-[0.65rem] text-slate-400 theme-light:text-slate-600" data-research-meta hidden></p>
                                             </div>
                                             <div class="flex flex-col gap-2 text-[0.7rem] text-slate-400 theme-light:text-slate-600">
                                                 <?php if (!empty($kanbanItem['source_url'])) : ?>


### PR DESCRIPTION
## Summary
- load a dedicated applications.js bundle on the applications view and extend each kanban card with a research action and live region for results
- build an accessible research panel template with loading, error, and metadata slots for AI-provided insights
- implement applications.js to fetch research data with CSRF protection, render markdown or structured lists, and manage cached states without duplicate requests

## Testing
- php -l resources/views/applications.php

------
https://chatgpt.com/codex/tasks/task_e_68e4f20eb46c832e984b993331de7f66