### PR TITLE
Split job applications views into dedicated flow

### DIFF
--- a/resources/views/applications-edit.php
+++ b/resources/views/applications-edit.php
@@ -7,6 +7,8 @@
 /** @var array<string, array{label: string, description: string}> $statusOptions */
 /** @var array<string, string> $failureReasons */
 /** @var array<string, mixed> $application */
+/** @var array<int, array{id: int, label: string}> $generationOptions */
+/** @var array<string, mixed>|null $linkedGeneration */
 /** @var string|null $status */
 /** @var string|null $csrfToken */
 ?>
@@ -136,35 +138,105 @@
             </button>
         </form>
 
-        <aside class="space-y-4 rounded-2xl border border-slate-800/80 bg-slate-900/60 p-6 shadow-xl">
-            <h3 class="text-lg font-semibold text-white">Timeline &amp; context</h3>
-            <p class="text-sm text-slate-400">
-                Use these timestamps to gauge momentum and plan follow-ups. Keeping them accurate ensures reminders and reports stay relevant.
-            </p>
-            <dl class="space-y-3 text-sm text-slate-300">
-                <div class="flex items-center justify-between">
-                    <dt class="text-slate-400">Created</dt>
-                    <dd><?= htmlspecialchars((string) ($application['created_at'] ?? ''), ENT_QUOTES) ?></dd>
-                </div>
-                <div class="flex items-center justify-between">
-                    <dt class="text-slate-400">Last updated</dt>
-                    <dd><?= htmlspecialchars((string) ($application['updated_at'] ?? ''), ENT_QUOTES) ?></dd>
-                </div>
-                <div class="flex items-center justify-between">
-                    <dt class="text-slate-400">Submitted</dt>
-                    <dd>
-                        <?php if (!empty($application['applied_at'])) : ?>
-                            <?= htmlspecialchars((string) $application['applied_at'], ENT_QUOTES) ?>
-                        <?php else : ?>
-                            <span class="text-slate-500">Not submitted</span>
+        <aside class="space-y-5 rounded-2xl border border-slate-800/80 bg-slate-900/60 p-6 shadow-xl">
+            <section class="space-y-3">
+                <h3 class="text-lg font-semibold text-white">Timeline &amp; context</h3>
+                <p class="text-sm text-slate-400">
+                    Use these timestamps to gauge momentum and plan follow-ups. Keeping them accurate ensures reminders and reports stay relevant.
+                </p>
+                <dl class="space-y-3 text-sm text-slate-300">
+                    <div class="flex items-center justify-between">
+                        <dt class="text-slate-400">Created</dt>
+                        <dd><?= htmlspecialchars((string) ($application['created_at'] ?? ''), ENT_QUOTES) ?></dd>
+                    </div>
+                    <div class="flex items-center justify-between">
+                        <dt class="text-slate-400">Last updated</dt>
+                        <dd><?= htmlspecialchars((string) ($application['updated_at'] ?? ''), ENT_QUOTES) ?></dd>
+                    </div>
+                    <div class="flex items-center justify-between">
+                        <dt class="text-slate-400">Submitted</dt>
+                        <dd>
+                            <?php if (!empty($application['applied_at'])) : ?>
+                                <?= htmlspecialchars((string) $application['applied_at'], ENT_QUOTES) ?>
+                            <?php else : ?>
+                                <span class="text-slate-500">Not submitted</span>
+                            <?php endif; ?>
+                        </dd>
+                    </div>
+                </dl>
+            </section>
+
+            <section class="space-y-3 rounded-2xl border border-slate-800/70 bg-slate-950/70 p-4 text-sm text-slate-200 theme-light:border-slate-200 theme-light:bg-white theme-light:text-slate-700">
+                <header class="space-y-1">
+                    <h4 class="text-base font-semibold text-white theme-light:text-slate-900">Tailored CV link</h4>
+                    <p class="text-xs text-slate-400 theme-light:text-slate-500">Attach a generated CV so downloads stay one click away.</p>
+                </header>
+                <?php if (!empty($linkedGeneration)) : ?>
+                    <div class="space-y-1 rounded-xl border border-indigo-400/30 bg-indigo-500/10 p-3 text-xs text-indigo-100 theme-light:border-indigo-200 theme-light:bg-indigo-50 theme-light:text-indigo-600">
+                        <p class="font-semibold uppercase tracking-wide">Currently linked</p>
+                        <p class="flex flex-wrap items-center gap-2">
+                            <span class="inline-flex items-center gap-2 rounded-md bg-slate-900/60 px-2 py-1 text-[0.7rem] font-medium text-indigo-100 theme-light:bg-white theme-light:text-indigo-600">
+                                <svg aria-hidden="true" class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                                    <path d="M7 3h10l4 4v12a2 2 0 01-2 2H7a2 2 0 01-2-2V5a2 2 0 012-2z" stroke-linecap="round" stroke-linejoin="round"></path>
+                                </svg>
+                                <?= htmlspecialchars((string) ($linkedGeneration['cv_filename'] ?? 'CV draft'), ENT_QUOTES) ?>
+                            </span>
+                            <span class="text-indigo-200/70 theme-light:text-indigo-500">tailored for</span>
+                            <span class="inline-flex items-center gap-2 rounded-md bg-slate-900/60 px-2 py-1 text-[0.7rem] font-medium text-indigo-100 theme-light:bg-white theme-light:text-indigo-600">
+                                <svg aria-hidden="true" class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                                    <path d="M3 7h18M3 12h18M3 17h18" stroke-linecap="round" stroke-linejoin="round"></path>
+                                </svg>
+                                <?= htmlspecialchars((string) ($linkedGeneration['job_filename'] ?? 'Job description'), ENT_QUOTES) ?>
+                            </span>
+                        </p>
+                        <?php if (!empty($linkedGeneration['created_at'])) : ?>
+                            <p class="text-[0.65rem] text-indigo-200/80 theme-light:text-indigo-500/80">Generated <?= htmlspecialchars((string) $linkedGeneration['created_at'], ENT_QUOTES) ?></p>
                         <?php endif; ?>
-                    </dd>
-                </div>
-            </dl>
-            <div class="rounded-xl border border-indigo-500/40 bg-indigo-500/10 p-4 text-xs text-indigo-100">
+                    </div>
+                <?php else : ?>
+                    <p class="text-xs text-slate-400 theme-light:text-slate-500">No tailored CV linked yet. Choose one to unlock quick downloads from the kanban board.</p>
+                <?php endif; ?>
+                <form method="post" action="/applications/<?= urlencode((string) ($application['id'] ?? '')) ?>/generation" class="space-y-2">
+                    <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                    <label for="generation_id" class="text-xs font-semibold uppercase tracking-wide text-slate-400 theme-light:text-slate-600">Select tailored document</label>
+                    <select
+                        id="generation_id"
+                        name="generation_id"
+                        class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400 theme-light:border-slate-300 theme-light:bg-white theme-light:text-slate-700"
+                    >
+                        <option value="">No tailored CV linked</option>
+                        <?php foreach ($generationOptions as $option) : ?>
+                            <option value="<?= htmlspecialchars((string) $option['id'], ENT_QUOTES) ?>" <?= (string) ($application['generation_id'] ?? '') === (string) $option['id'] ? 'selected' : '' ?>>
+                                <?= htmlspecialchars($option['label'], ENT_QUOTES) ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                    <button type="submit" class="w-full rounded-lg bg-indigo-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400">
+                        Update link
+                    </button>
+                </form>
+                <?php if (empty($generationOptions)) : ?>
+                    <p class="text-xs text-slate-500 theme-light:text-slate-500">Generate tailored documents from the Tailor page to link them here.</p>
+                <?php endif; ?>
+            </section>
+
+            <section class="space-y-3 rounded-2xl border border-rose-500/40 bg-rose-500/10 p-4 text-xs text-rose-100 theme-light:border-rose-200 theme-light:bg-rose-50 theme-light:text-rose-600">
+                <header class="space-y-1">
+                    <h4 class="text-base font-semibold">Delete application</h4>
+                    <p class="text-[0.75rem]">Removing the record also clears linked tailored documents and status history.</p>
+                </header>
+                <form method="post" action="/applications/<?= urlencode((string) ($application['id'] ?? '')) ?>/delete" class="space-y-2">
+                    <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                    <button type="submit" class="w-full rounded-lg border border-rose-400/50 bg-rose-500/20 px-4 py-2 text-sm font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-300 hover:bg-rose-500/30 hover:text-rose-50 theme-light:border-rose-300 theme-light:text-rose-700 theme-light:hover:border-rose-400 theme-light:hover:text-rose-800">
+                        Delete this application
+                    </button>
+                </form>
+            </section>
+
+            <div class="rounded-xl border border-indigo-500/40 bg-indigo-500/10 p-4 text-xs text-indigo-100 theme-light:border-indigo-200 theme-light:bg-indigo-50 theme-light:text-indigo-600">
                 <p class="font-semibold uppercase tracking-wide">Tip</p>
                 <p class="mt-1">
-                    After saving, revisit the kanban board to drag insight from the new status or generate fresh tailored documents.
+                    After saving, return to the kanban board to review the updated column placement or trigger fresh company research.
                 </p>
             </div>
         </aside>

--- a/resources/views/applications.php
+++ b/resources/views/applications.php
@@ -5,10 +5,7 @@
 /** @var array<int, array<string, mixed>> $outstanding */
 /** @var array<int, array<string, mixed>> $applied */
 /** @var array<int, array<string, mixed>> $failed */
-/** @var array<int, array{id: int, label: string}> $generationOptions */
 /** @var string|null $status */
-/** @var array<string, string> $failureReasons */
-/** @var string|null $csrfToken */
 ?>
 <?php
 $additionalHead = '<script src="/assets/js/applications.js" defer></script>';
@@ -245,399 +242,39 @@ $additionalHead = '<script src="/assets/js/applications.js" defer></script>';
         </div>
     </section>
 
+
     <?php if (!empty($status)) : ?>
         <div class="rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100 theme-light:border-emerald-200 theme-light:bg-emerald-50 theme-light:text-emerald-700">
             <?= htmlspecialchars($status, ENT_QUOTES) ?>
         </div>
     <?php endif; ?>
 
-    <section class="space-y-6">
-        <section class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl theme-light:border-slate-200 theme-light:bg-white/90 theme-light:shadow-soft">
-                <header class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                    <div>
-                        <h3 class="text-lg font-semibold text-white theme-light:text-slate-900">Outstanding opportunities</h3>
-                        <p class="text-sm text-slate-400 theme-light:text-slate-600">Everything you still plan to apply for appears here.</p>
-                    </div>
-                    <span class="rounded-full border border-amber-400/40 bg-amber-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-200 theme-light:border-amber-200 theme-light:bg-amber-50 theme-light:text-amber-600">
-                        <?= count($outstanding) ?> queued
-                    </span>
-                </header>
-                <div class="mt-4 space-y-4">
-                    <?php if (empty($outstanding)) : ?>
-                        <p class="rounded-xl border border-slate-800 bg-slate-900/70 px-4 py-6 text-sm text-slate-400 theme-light:border-slate-200 theme-light:bg-slate-50/80 theme-light:text-slate-600">
-                            Nothing queued yet. Paste the next role you are targeting to get started.
-                        </p>
-                    <?php else : ?>
-                        <?php foreach ($outstanding as $item) : ?>
-                            <article class="rounded-xl border border-slate-800 bg-slate-950/80 p-4 text-sm text-slate-200 shadow-inner theme-light:border-slate-200 theme-light:bg-white theme-light:text-slate-700 theme-light:shadow-soft">
-                                <header class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                                    <div>
-                                        <h4 class="text-base font-semibold text-white theme-light:text-slate-900">
-                                            <?= htmlspecialchars($item['title'] ?? 'Untitled application', ENT_QUOTES) ?>
-                                        </h4>
-                                        <p class="text-xs text-slate-500 theme-light:text-slate-500">Added <?= htmlspecialchars($item['created_at'], ENT_QUOTES) ?></p>
-                                    </div>
-                                    <div class="flex flex-col gap-2 sm:items-end">
-                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="self-start sm:self-auto">
-                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                            <input type="hidden" name="status" value="applied">
-                                            <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-200 transition hover:border-emerald-300 hover:text-emerald-100 theme-light:border-emerald-200 theme-light:bg-emerald-50 theme-light:text-emerald-600 theme-light:hover:border-emerald-300 theme-light:hover:text-emerald-700">
-                                                Mark applied
-                                            </button>
-                                        </form>
-                                        <?php $reasonFieldId = 'failure_reason_' . ($item['id'] ?? '0') . '_outstanding'; ?>
-                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="flex flex-col gap-2 rounded-xl border border-rose-500/40 bg-rose-500/10 p-3 text-xs text-rose-100 sm:flex-row sm:items-center sm:gap-3 theme-light:border-rose-200 theme-light:bg-rose-50 theme-light:text-rose-600">
-                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                            <input type="hidden" name="status" value="failed">
-                                            <label for="<?= htmlspecialchars($reasonFieldId, ENT_QUOTES) ?>" class="font-medium text-rose-100 theme-light:text-rose-700">Rejection reason</label>
-                                            <select
-                                                id="<?= htmlspecialchars($reasonFieldId, ENT_QUOTES) ?>"
-                                                name="reason_code"
-                                                required
-                                                class="w-full rounded-lg border border-rose-400/40 bg-rose-500/10 px-2 py-1 text-rose-100 focus:border-rose-200 focus:outline-none focus:ring-rose-200 sm:max-w-xs theme-light:border-rose-200 theme-light:bg-white theme-light:text-rose-700 theme-light:focus:border-rose-300 theme-light:focus:ring-rose-200"
-                                            >
-                                                <option value="" disabled selected>Select reason</option>
-                                                <?php foreach ($failureReasons as $code => $label) : ?>
-                                                    <option value="<?= htmlspecialchars($code, ENT_QUOTES) ?>">
-                                                        <?= htmlspecialchars($label, ENT_QUOTES) ?>
-                                                    </option>
-                                                <?php endforeach; ?>
-                                            </select>
-                                            <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-full border border-rose-400/40 bg-rose-500/30 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-200 hover:text-rose-50 theme-light:border-rose-200 theme-light:bg-rose-100 theme-light:text-rose-700 theme-light:hover:border-rose-300 theme-light:hover:text-rose-800">
-                                                Mark failed
-                                            </button>
-                                        </form>
-                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/delete" class="self-start sm:self-auto">
-                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                            <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-rose-500/60 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-300 hover:text-rose-50 theme-light:border-rose-300 theme-light:text-rose-700 theme-light:hover:border-rose-400 theme-light:hover:text-rose-800">
-                                                Delete
-                                            </button>
-                                        </form>
-                                    </div>
-                                </header>
-                                <?php $generationFieldId = 'generation_' . ($item['id'] ?? '0') . '_outstanding'; ?>
-                                <div class="mt-3 rounded-xl border border-slate-800 bg-slate-900/60 p-4 theme-light:border-slate-200 theme-light:bg-slate-50/80">
-                                    <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-                                        <div class="space-y-1">
-                                            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500 theme-light:text-slate-600">Tailored CV link</p>
-                                            <?php if (!empty($item['generation'])) : ?>
-                                                <p class="text-sm text-slate-200 theme-light:text-slate-700">
-                                                    <?= htmlspecialchars($item['generation']['cv_filename'] ?? 'CV draft', ENT_QUOTES) ?>
-                                                    <span class="text-slate-500">→</span>
-                                                    <?= htmlspecialchars($item['generation']['job_filename'] ?? 'Job description', ENT_QUOTES) ?>
-                                                </p>
-                                                <?php if (!empty($item['generation']['created_at'])) : ?>
-                                                    <p class="text-xs text-slate-500 theme-light:text-slate-500">
-                                                        Generated <?= htmlspecialchars($item['generation']['created_at'], ENT_QUOTES) ?>
-                                                    </p>
-                                                <?php endif; ?>
-                                            <?php else : ?>
-                                                <p class="text-sm text-slate-400 theme-light:text-slate-600">No tailored CV linked yet.</p>
-                                            <?php endif; ?>
-                                        </div>
-                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/generation" class="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
-                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                            <label for="<?= htmlspecialchars($generationFieldId, ENT_QUOTES) ?>" class="sr-only">Select tailored CV</label>
-                                            <select
-                                                id="<?= htmlspecialchars($generationFieldId, ENT_QUOTES) ?>"
-                                                name="generation_id"
-                                                class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400 md:min-w-[220px] theme-light:border-slate-300 theme-light:bg-white theme-light:text-slate-700 theme-light:focus:border-indigo-400 theme-light:focus:ring-indigo-200"
-                                            >
-                                                <option value="">No tailored CV</option>
-                                                <?php foreach ($generationOptions as $option) : ?>
-                                                    <?php $optionId = (int) $option['id']; ?>
-                                                    <option value="<?= htmlspecialchars((string) $optionId, ENT_QUOTES) ?>" <?= (isset($item['generation_id']) && (int) $item['generation_id'] === $optionId) ? 'selected' : '' ?>>
-                                                        <?= htmlspecialchars($option['label'], ENT_QUOTES) ?>
-                                                    </option>
-                                                <?php endforeach; ?>
-                                            </select>
-                                            <button type="submit" class="inline-flex items-center justify-center rounded-lg bg-slate-800 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:bg-slate-700 theme-light:bg-slate-900/10 theme-light:text-slate-700 theme-light:hover:bg-slate-200">
-                                                Update link
-                                            </button>
-                                        </form>
-                                    </div>
-                                    <?php if (empty($generationOptions)) : ?>
-                                        <p class="mt-3 text-xs text-slate-500 theme-light:text-slate-500">
-                                            Generate a tailored CV from the Tailor page to link it with this application.
-                                        </p>
-                                    <?php endif; ?>
-                                </div>
-                                <?php if (!empty($item['source_url'])) : ?>
-                                    <a href="<?= htmlspecialchars($item['source_url'], ENT_QUOTES) ?>" target="_blank" rel="noopener" class="mt-2 inline-flex items-center gap-2 text-xs text-indigo-300 hover:text-indigo-200 theme-light:text-indigo-600 theme-light:hover:text-indigo-500">
-                                        View listing
-                                        <svg aria-hidden="true" class="h-3 w-3" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                                            <path d="M7 17L17 7M7 7h10v10" stroke-linecap="round" stroke-linejoin="round"></path>
-                                        </svg>
-                                    </a>
-                                <?php endif; ?>
-                                <p class="mt-3 text-sm text-slate-300 theme-light:text-slate-600">
-                                    <?= nl2br(htmlspecialchars($item['description_preview'], ENT_QUOTES)) ?>
-                                </p>
-                            </article>
-                        <?php endforeach; ?>
-                    <?php endif; ?>
-                </div>
-        </section>
-
-        <section class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl theme-light:border-slate-200 theme-light:bg-white/90 theme-light:shadow-soft">
-                <header class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                    <div>
-                        <h3 class="text-lg font-semibold text-white theme-light:text-slate-900">Submitted applications</h3>
-                        <p class="text-sm text-slate-400 theme-light:text-slate-600">Keep a record of where you have already applied.</p>
-                    </div>
-                    <span class="rounded-full border border-indigo-400/40 bg-indigo-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-200 theme-light:border-indigo-200 theme-light:bg-indigo-50 theme-light:text-indigo-600">
-                        <?= count($applied) ?> sent
-                    </span>
-                </header>
-                <div class="mt-4 space-y-4">
-                    <?php if (empty($applied)) : ?>
-                        <p class="rounded-xl border border-slate-800 bg-slate-900/70 px-4 py-6 text-sm text-slate-400 theme-light:border-slate-200 theme-light:bg-slate-50/80 theme-light:text-slate-600">
-                            Once you submit an application it will be archived here for quick reference.
-                        </p>
-                    <?php else : ?>
-                        <?php foreach ($applied as $item) : ?>
-                            <article class="rounded-xl border border-slate-800/80 bg-slate-950/70 p-3 text-sm text-slate-200 shadow-inner sm:p-4 theme-light:border-slate-200 theme-light:bg-white theme-light:text-slate-700 theme-light:shadow-soft">
-                                <header class="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
-                                    <div class="space-y-1">
-                                        <h4 class="text-base font-semibold text-white theme-light:text-slate-900">
-                                            <?= htmlspecialchars($item['title'] ?? 'Untitled application', ENT_QUOTES) ?>
-                                        </h4>
-                                        <p class="flex flex-wrap items-center gap-2 text-xs text-slate-500">
-                                            <span class="font-medium text-slate-300 theme-light:text-slate-600">Applied</span>
-                                            <span><?= htmlspecialchars($item['applied_at'] ?? $item['created_at'], ENT_QUOTES) ?></span>
-                                        </p>
-                                    </div>
-                                    <div class="flex flex-wrap items-center justify-end gap-2">
-                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="inline-flex">
-                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                            <input type="hidden" name="status" value="outstanding">
-                                            <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-300 transition hover:border-slate-500 hover:text-slate-100 theme-light:border-slate-300 theme-light:text-slate-600 theme-light:hover:border-slate-400 theme-light:hover:text-slate-700">
-                                                Move back
-                                            </button>
-                                        </form>
-                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/delete" class="inline-flex">
-                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                            <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-rose-500/60 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-300 hover:text-rose-50 theme-light:border-rose-300 theme-light:text-rose-700 theme-light:hover:border-rose-400 theme-light:hover:text-rose-800">
-                                                Delete
-                                            </button>
-                                        </form>
-                                    </div>
-                                </header>
-                                <?php $appliedReasonFieldId = 'failure_reason_' . ($item['id'] ?? '0') . '_applied'; ?>
-                                <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="mt-3 flex flex-wrap items-center gap-2 rounded-lg border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-100 sm:gap-3 theme-light:border-rose-200 theme-light:bg-rose-50 theme-light:text-rose-600">
-                                    <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                    <input type="hidden" name="status" value="failed">
-                                    <label for="<?= htmlspecialchars($appliedReasonFieldId, ENT_QUOTES) ?>" class="font-medium text-rose-100 theme-light:text-rose-700">Rejection reason</label>
-                                    <select
-                                        id="<?= htmlspecialchars($appliedReasonFieldId, ENT_QUOTES) ?>"
-                                        name="reason_code"
-                                        required
-                                        class="w-full rounded-lg border border-rose-400/40 bg-rose-500/10 px-2 py-1 text-rose-100 focus:border-rose-200 focus:outline-none focus:ring-rose-200 sm:max-w-xs theme-light:border-rose-200 theme-light:bg-white theme-light:text-rose-700 theme-light:focus:border-rose-300 theme-light:focus:ring-rose-200"
-                                    >
-                                        <option value="" disabled selected>Select reason</option>
-                                        <?php foreach ($failureReasons as $code => $label) : ?>
-                                            <option value="<?= htmlspecialchars($code, ENT_QUOTES) ?>">
-                                                <?= htmlspecialchars($label, ENT_QUOTES) ?>
-                                            </option>
-                                        <?php endforeach; ?>
-                                    </select>
-                                    <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-full border border-rose-400/40 bg-rose-500/30 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-200 hover:text-rose-50 theme-light:border-rose-200 theme-light:bg-rose-100 theme-light:text-rose-700 theme-light:hover:border-rose-300 theme-light:hover:text-rose-800">
-                                        Mark failed
-                                    </button>
-                                </form>
-                                <?php $appliedGenerationFieldId = 'generation_' . ($item['id'] ?? '0') . '_applied'; ?>
-                                <div class="mt-3 rounded-2xl border border-indigo-500/30 bg-slate-900/70 p-4 shadow-inner shadow-indigo-900/20">
-                                    <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-                                        <div class="flex flex-col gap-3">
-                                            <div class="flex items-start gap-3">
-                                                <span class="flex h-11 w-11 items-center justify-center rounded-xl border border-indigo-400/40 bg-indigo-500/10 text-indigo-200">
-                                                    <svg aria-hidden="true" class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                                                        <path d="M9 12h6m-6 4h6M9 8h6m3-5H6a2 2 0 00-2 2v14a2 2 0 002 2h12a2 2 0 002-2V7l-5-5z" stroke-linecap="round" stroke-linejoin="round"></path>
-                                                    </svg>
-                                                </span>
-                                                <div class="space-y-1">
-                                                    <p class="text-xs font-semibold uppercase tracking-wide text-indigo-200/80">Tailored CV link</p>
-                                                    <p class="text-sm text-slate-300">Connect this application with the right generated materials for quick downloads.</p>
-                                                </div>
-                                            </div>
-                                            <?php if (!empty($item['generation'])) : ?>
-                                                <div class="flex flex-wrap items-center gap-2 rounded-lg border border-indigo-400/30 bg-indigo-500/10 px-3 py-2 text-xs text-indigo-100">
-                                                    <span class="inline-flex items-center gap-2 rounded-md bg-slate-900/60 px-2 py-1 text-[0.7rem] font-medium text-indigo-100">
-                                                        <svg aria-hidden="true" class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                                                            <path d="M7 3h10l4 4v12a2 2 0 01-2 2H7a2 2 0 01-2-2V5a2 2 0 012-2z" stroke-linecap="round" stroke-linejoin="round"></path>
-                                                        </svg>
-                                                        <?= htmlspecialchars($item['generation']['cv_filename'] ?? 'CV draft', ENT_QUOTES) ?>
-                                                    </span>
-                                                    <span class="text-indigo-200/70">tailored for</span>
-                                                    <span class="inline-flex items-center gap-2 rounded-md bg-slate-900/60 px-2 py-1 text-[0.7rem] font-medium text-indigo-100">
-                                                        <svg aria-hidden="true" class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                                                            <path d="M3 7h18M3 12h18M3 17h18" stroke-linecap="round" stroke-linejoin="round"></path>
-                                                        </svg>
-                                                        <?= htmlspecialchars($item['generation']['job_filename'] ?? 'Job description', ENT_QUOTES) ?>
-                                                    </span>
-                                                </div>
-                                                <?php if (!empty($item['generation']['created_at'])) : ?>
-                                                    <p class="text-xs text-slate-500">Generated <?= htmlspecialchars($item['generation']['created_at'], ENT_QUOTES) ?></p>
-                                                <?php endif; ?>
-                                            <?php else : ?>
-                                                <p class="text-sm text-slate-400">No tailored CV linked yet—select one to keep everything aligned.</p>
-                                            <?php endif; ?>
-                                        </div>
-                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/generation" class="flex flex-col gap-2 rounded-xl border border-slate-800/60 bg-slate-950/80 p-3 text-sm text-slate-200 lg:min-w-[320px]">
-                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                            <label for="<?= htmlspecialchars($appliedGenerationFieldId, ENT_QUOTES) ?>" class="text-xs font-semibold uppercase tracking-wide text-slate-400">Select tailored CV</label>
-                                            <select
-                                                id="<?= htmlspecialchars($appliedGenerationFieldId, ENT_QUOTES) ?>"
-                                                name="generation_id"
-                                                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400"
-                                            >
-                                                <option value="">No tailored CV</option>
-                                                <?php foreach ($generationOptions as $option) : ?>
-                                                    <?php $optionId = (int) $option['id']; ?>
-                                                    <option value="<?= htmlspecialchars((string) $optionId, ENT_QUOTES) ?>" <?= (isset($item['generation_id']) && (int) $item['generation_id'] === $optionId) ? 'selected' : '' ?>>
-                                                        <?= htmlspecialchars($option['label'], ENT_QUOTES) ?>
-                                                    </option>
-                                                <?php endforeach; ?>
-                                            </select>
-                                            <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-lg bg-indigo-500 px-3 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400">
-                                                <svg aria-hidden="true" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                                                    <path d="M12 5v14m7-7H5" stroke-linecap="round" stroke-linejoin="round"></path>
-                                                </svg>
-                                                Update link
-                                            </button>
-                                        </form>
-                                    </div>
-                                    <?php if (empty($generationOptions)) : ?>
-                                        <p class="mt-3 text-xs text-slate-500">Generate a tailored CV from the Tailor page to link it with this application.</p>
-                                    <?php endif; ?>
-                                </div>
-                                <?php if (!empty($item['source_url'])) : ?>
-                                    <a href="<?= htmlspecialchars($item['source_url'], ENT_QUOTES) ?>" target="_blank" rel="noopener" class="mt-2 inline-flex items-center gap-2 text-xs text-indigo-300 hover:text-indigo-200 theme-light:text-indigo-600 theme-light:hover:text-indigo-500">
-                                        View listing
-                                        <svg aria-hidden="true" class="h-3 w-3" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                                            <path d="M7 17L17 7M7 7h10v10" stroke-linecap="round" stroke-linejoin="round"></path>
-                                        </svg>
-                                    </a>
-                                <?php endif; ?>
-                                <p class="mt-2 text-xs leading-relaxed text-slate-400 sm:text-sm theme-light:text-slate-600">
-                                    <?= nl2br(htmlspecialchars($item['description_preview'], ENT_QUOTES)) ?>
-                                </p>
-                            </article>
-                        <?php endforeach; ?>
-                    <?php endif; ?>
-                </div>
-        </section>
-
-        <section class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl theme-light:border-slate-200 theme-light:bg-white/90 theme-light:shadow-soft">
-                <header class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                    <div>
-                        <h3 class="text-lg font-semibold text-white theme-light:text-slate-900">Rejected applications</h3>
-                        <p class="text-sm text-slate-400 theme-light:text-slate-600">Log outcomes and learn from every response.</p>
-                    </div>
-                    <span class="rounded-full border border-rose-400/40 bg-rose-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 theme-light:border-rose-200 theme-light:bg-rose-50 theme-light:text-rose-700">
-                        <?= count($failed) ?> recorded
-                    </span>
-                </header>
-                <div class="mt-4 space-y-4">
-                    <?php if (empty($failed)) : ?>
-                        <p class="rounded-xl border border-slate-800 bg-slate-900/70 px-4 py-6 text-sm text-slate-400 theme-light:border-slate-200 theme-light:bg-slate-50/80 theme-light:text-slate-600">
-                            When you capture rejection reasons they will surface here, giving you insight into where to refine your search.
-                        </p>
-                    <?php else : ?>
-                        <?php foreach ($failed as $item) : ?>
-                            <?php $failureLabel = $failureReasons[$item['reason_code'] ?? ''] ?? 'Unknown reason'; ?>
-                            <article class="rounded-xl border border-slate-800 bg-slate-950/80 p-4 text-sm text-slate-200 shadow-inner theme-light:border-slate-200 theme-light:bg-white theme-light:text-slate-700 theme-light:shadow-soft">
-                                <header class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                                    <div class="space-y-2">
-                                        <h4 class="text-base font-semibold text-white theme-light:text-slate-900">
-                                            <?= htmlspecialchars($item['title'] ?? 'Untitled application', ENT_QUOTES) ?>
-                                        </h4>
-                                        <p class="text-xs text-slate-500 theme-light:text-slate-500">
-                                            Failed <?= htmlspecialchars($item['updated_at'] ?? $item['created_at'], ENT_QUOTES) ?>
-                                        </p>
-                                        <span class="inline-flex w-fit items-center gap-2 rounded-full border border-rose-400/40 bg-rose-500/10 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-wide text-rose-100 theme-light:border-rose-200 theme-light:bg-rose-50 theme-light:text-rose-700">
-                                            <?= htmlspecialchars($failureLabel, ENT_QUOTES) ?>
-                                        </span>
-                                    </div>
-                                    <div class="flex flex-col gap-2 sm:items-end">
-                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/status" class="self-start sm:self-auto">
-                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                            <input type="hidden" name="status" value="outstanding">
-                                            <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-300 transition hover:border-slate-500 hover:text-slate-100 theme-light:border-slate-300 theme-light:text-slate-600 theme-light:hover:border-slate-400 theme-light:hover:text-slate-700">
-                                                Reopen opportunity
-                                            </button>
-                                        </form>
-                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/delete" class="self-start sm:self-auto">
-                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                            <button type="submit" class="inline-flex items-center gap-2 rounded-full border border-rose-500/60 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-100 transition hover:border-rose-300 hover:text-rose-50 theme-light:border-rose-300 theme-light:text-rose-700 theme-light:hover:border-rose-400 theme-light:hover:text-rose-800">
-                                                Delete
-                                            </button>
-                                        </form>
-                                    </div>
-                                </header>
-                                <?php $failedGenerationFieldId = 'generation_' . ($item['id'] ?? '0') . '_failed'; ?>
-                                <div class="mt-3 rounded-xl border border-slate-800 bg-slate-900/60 p-4 theme-light:border-slate-200 theme-light:bg-slate-50/80">
-                                    <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-                                        <div class="space-y-1">
-                                            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500 theme-light:text-slate-600">Tailored CV link</p>
-                                            <?php if (!empty($item['generation'])) : ?>
-                                                <p class="text-sm text-slate-200 theme-light:text-slate-700">
-                                                    <?= htmlspecialchars($item['generation']['cv_filename'] ?? 'CV draft', ENT_QUOTES) ?>
-                                                    <span class="text-slate-500">→</span>
-                                                    <?= htmlspecialchars($item['generation']['job_filename'] ?? 'Job description', ENT_QUOTES) ?>
-                                                </p>
-                                                <?php if (!empty($item['generation']['created_at'])) : ?>
-                                                    <p class="text-xs text-slate-500 theme-light:text-slate-500">
-                                                        Generated <?= htmlspecialchars($item['generation']['created_at'], ENT_QUOTES) ?>
-                                                    </p>
-                                                <?php endif; ?>
-                                            <?php else : ?>
-                                                <p class="text-sm text-slate-400 theme-light:text-slate-600">No tailored CV linked yet.</p>
-                                            <?php endif; ?>
-                                        </div>
-                                        <form method="post" action="/applications/<?= urlencode((string) $item['id']) ?>/generation" class="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
-                                            <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
-                                            <label for="<?= htmlspecialchars($failedGenerationFieldId, ENT_QUOTES) ?>" class="sr-only">Select tailored CV</label>
-                                            <select
-                                                id="<?= htmlspecialchars($failedGenerationFieldId, ENT_QUOTES) ?>"
-                                                name="generation_id"
-                                                class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400 md:min-w-[220px] theme-light:border-slate-300 theme-light:bg-white theme-light:text-slate-700 theme-light:focus:border-indigo-400 theme-light:focus:ring-indigo-200"
-                                            >
-                                                <option value="">No tailored CV</option>
-                                                <?php foreach ($generationOptions as $option) : ?>
-                                                    <?php $optionId = (int) $option['id']; ?>
-                                                    <option value="<?= htmlspecialchars((string) $optionId, ENT_QUOTES) ?>" <?= (isset($item['generation_id']) && (int) $item['generation_id'] === $optionId) ? 'selected' : '' ?>>
-                                                        <?= htmlspecialchars($option['label'], ENT_QUOTES) ?>
-                                                    </option>
-                                                <?php endforeach; ?>
-                                            </select>
-                                            <button type="submit" class="inline-flex items-center justify-center rounded-lg bg-slate-800 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:bg-slate-700 theme-light:bg-slate-900/10 theme-light:text-slate-700 theme-light:hover:bg-slate-200">
-                                                Update link
-                                            </button>
-                                        </form>
-                                    </div>
-                                    <?php if (empty($generationOptions)) : ?>
-                                        <p class="mt-3 text-xs text-slate-500 theme-light:text-slate-500">
-                                            Generate a tailored CV from the Tailor page to link it with this application.
-                                        </p>
-                                    <?php endif; ?>
-                                </div>
-                                <?php if (!empty($item['source_url'])) : ?>
-                                    <a href="<?= htmlspecialchars($item['source_url'], ENT_QUOTES) ?>" target="_blank" rel="noopener" class="mt-2 inline-flex items-center gap-2 text-xs text-indigo-300 hover:text-indigo-200 theme-light:text-indigo-600 theme-light:hover:text-indigo-500">
-                                        View listing
-                                        <svg aria-hidden="true" class="h-3 w-3" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                                            <path d="M7 17L17 7M7 7h10v10" stroke-linecap="round" stroke-linejoin="round"></path>
-                                        </svg>
-                                    </a>
-                                <?php endif; ?>
-                                <p class="mt-3 text-sm text-slate-300 theme-light:text-slate-600">
-                                    <?= nl2br(htmlspecialchars($item['description_preview'], ENT_QUOTES)) ?>
-                                </p>
-                            </article>
-                        <?php endforeach; ?>
-                    <?php endif; ?>
-                </div>
-        </section>
+    <section class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-xl theme-light:border-slate-200 theme-light:bg-white/90 theme-light:shadow-soft">
+        <header class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div class="space-y-1">
+                <h3 class="text-lg font-semibold text-white theme-light:text-slate-900">How to keep everything updated</h3>
+                <p class="text-sm text-slate-400 theme-light:text-slate-600">
+                    Log each opportunity on the dedicated Add posting page. Once saved, return here to monitor progress and click any card to jump to the full edit screen for status changes or deeper updates.
+                </p>
+            </div>
+            <a href="/applications/create" class="inline-flex items-center gap-2 rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-4 py-2 text-sm font-semibold text-indigo-100 transition hover:border-indigo-400 hover:text-white theme-light:border-indigo-200 theme-light:bg-indigo-50 theme-light:text-indigo-600 theme-light:hover:border-indigo-300 theme-light:hover:text-indigo-700">
+                Add another posting
+            </a>
+        </header>
+        <div class="mt-4 grid gap-4 text-sm text-slate-300 theme-light:text-slate-600 sm:grid-cols-3">
+            <div class="rounded-xl border border-slate-800 bg-slate-950/80 p-4 theme-light:border-slate-200 theme-light:bg-white">
+                <p class="font-semibold text-white theme-light:text-slate-900">Queued</p>
+                <p class="mt-1 text-xs">Roles waiting on materials or next steps remain visible in the first column.</p>
+            </div>
+            <div class="rounded-xl border border-slate-800 bg-slate-950/80 p-4 theme-light:border-slate-200 theme-light:bg-white">
+                <p class="font-semibold text-white theme-light:text-slate-900">Submitted</p>
+                <p class="mt-1 text-xs">Keep an eye on application dates and revisit descriptions before interviews.</p>
+            </div>
+            <div class="rounded-xl border border-slate-800 bg-slate-950/80 p-4 theme-light:border-slate-200 theme-light:bg-white">
+                <p class="font-semibold text-white theme-light:text-slate-900">Learnings</p>
+                <p class="mt-1 text-xs">Track feedback and reasons so you can refine your approach later.</p>
+            </div>
+        </div>
     </section>
 </div>
 <?php $body = ob_get_clean(); ?>


### PR DESCRIPTION
## Summary
- simplify the applications board to display kanban swimlanes and guidance only
- enhance the edit screen with tailored CV linking and deletion controls
- ensure the controller prepares generation context for the edit workflow

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e4fcab6aa4832e82c8acb29fcd0a8a