### PR TITLE
Normalize strategist plan model alias

### DIFF
--- a/src/Services/UsageService.php
+++ b/src/Services/UsageService.php
@@ -163,6 +163,10 @@ class UsageService
             'gpt-5-main' => 'gpt-5',
             'gpt5-main' => 'gpt-5',
             'gpt5' => 'gpt-5',
+            'gpt-5-strategist' => 'gpt-5',
+            'gpt-5.0-strategist' => 'gpt-5',
+            'gpt5-strategist' => 'gpt-5',
+            'gpt5.0-strategist' => 'gpt-5',
         ];
 
         if (isset($aliases[$key])) {

--- a/tests/OpenAIProviderPlanTest.php
+++ b/tests/OpenAIProviderPlanTest.php
@@ -269,7 +269,7 @@ $_ENV['OPENAI_MODEL_PLAN'] = 'gpt-5.0-strategist';
 $_SERVER['OPENAI_MODEL_PLAN'] = 'gpt-5.0-strategist';
 
 $aliasSuccessPayload = $successPayload;
-$aliasSuccessPayload['model'] = 'gpt-5-strategist';
+$aliasSuccessPayload['model'] = 'gpt-5';
 
 $aliasClient = new FakeClient([
     $firstFailure,
@@ -288,11 +288,11 @@ if (count($aliasRequests) !== 2) {
 $aliasFirstRequest = json_decode($aliasRequests[0]['options']['body'], true);
 $aliasSecondRequest = json_decode($aliasRequests[1]['options']['body'], true);
 
-if (!is_array($aliasFirstRequest) || $aliasFirstRequest['model'] !== 'gpt-5-strategist') {
+if (!is_array($aliasFirstRequest) || $aliasFirstRequest['model'] !== 'gpt-5') {
     throw new RuntimeException('Initial alias plan request did not normalise the marketing model name.');
 }
 
-if (!is_array($aliasSecondRequest) || $aliasSecondRequest['model'] !== 'gpt-5-strategist') {
+if (!is_array($aliasSecondRequest) || $aliasSecondRequest['model'] !== 'gpt-5') {
     throw new RuntimeException('Second alias plan request did not retain the normalised model identifier.');
 }
 


### PR DESCRIPTION
## Summary
- normalise the configured OpenAI plan model so legacy "strategist" aliases map to the supported GPT-5 identifier
- expand usage model alias handling to keep analytics consistent with the canonical model names
- refresh the OpenAI provider plan test to cover the new alias normalisation behaviour

## Testing
- php tests/OpenAIProviderPlanTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e4fd9b5158832e81c782433693a1ac