### PR TITLE
Add polyfill for missing mb_strcut function

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require __DIR__ . '/src/Support/mbstring_polyfill.php';
+
 $autoloadPath = __DIR__ . '/vendor/autoload.php';
 
 if (!file_exists($autoloadPath)) {

--- a/src/Support/mbstring_polyfill.php
+++ b/src/Support/mbstring_polyfill.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+if (!function_exists('mb_strcut')) {
+    /**
+     * Provide a lightweight polyfill for mb_strcut when the mbstring extension is unavailable.
+     *
+     * The fallback relies on substr to deliver a byte-wise slice so conversion routines that
+     * depend on mb_strcut can continue operating in limited hosting environments.
+     */
+    function mb_strcut($string, $start, $length = null, $encoding = null)
+    {
+        $start = (int) $start;
+        $length = $length !== null ? (int) $length : null;
+
+        if ($start < 0) {
+            $start = 0;
+        }
+
+        $slice = $length === null
+            ? substr($string, $start)
+            : substr($string, $start, $length);
+
+        return $slice === false ? '' : $slice;
+    }
+}


### PR DESCRIPTION
## Summary
- add an mb_strcut polyfill so downloads continue to work when mbstring is unavailable
- ensure the polyfill is loaded before Composer's autoloader

## Testing
- not run (database-dependent tests were requested to be skipped)

------
https://chatgpt.com/codex/tasks/task_e_68e517114424832eb4c233b2e24cf79a