### PR TITLE
Ensure OpenAI Responses payload uses input_text segments

### DIFF
--- a/src/AI/OpenAIProvider.php
+++ b/src/AI/OpenAIProvider.php
@@ -1049,7 +1049,7 @@ final class OpenAIProvider
      * Transform chat-style message arrays into the Responses API input schema.
      *
      * The method ensures all text-based segments adopt the Responses API
-     * `text` label while preserving any explicitly provided types.
+     * `input_text` label while preserving any explicitly provided types.
      *
      * @param array<int, array<string, mixed>> $messages
      * @return array<int, array{role: string, content: array<int, array{type: string, text: string}>}>
@@ -1067,10 +1067,10 @@ final class OpenAIProvider
 
                 foreach ($content as $part) {
                     if (is_array($part) && isset($part['text'])) {
-                        $type = isset($part['type']) ? (string) $part['type'] : 'text';
+                        $type = isset($part['type']) ? (string) $part['type'] : 'input_text';
 
-                        if ($type === 'input_text') {
-                            $type = 'text';
+                        if ($type === 'text') {
+                            $type = 'input_text';
                         }
 
                         $parts[] = [
@@ -1079,7 +1079,7 @@ final class OpenAIProvider
                         ];
                     } elseif (is_string($part)) {
                         $parts[] = [
-                            'type' => 'text',
+                            'type' => 'input_text',
                             'text' => $part,
                         ];
                     }
@@ -1087,13 +1087,13 @@ final class OpenAIProvider
 
                 if ($parts === []) {
                     $parts[] = [
-                        'type' => 'text',
+                        'type' => 'input_text',
                         'text' => '',
                     ];
                 }
             } else {
                 $parts = [[
-                    'type' => 'text',
+                    'type' => 'input_text',
                     'text' => (string) $content,
                 ]];
             }


### PR DESCRIPTION
## Summary
- normalise formatted message parts to use the `input_text` type expected by the OpenAI Responses API
- update the inline documentation to reflect the corrected content type handling

## Testing
- not run (per instructions to avoid database-dependent tests)


------
https://chatgpt.com/codex/tasks/task_e_68e5199477e8832e9cf08ee866c2f43e