### PR TITLE
Simplify plan prompt to restore JSON responses

### DIFF
--- a/prompts/system.txt
+++ b/prompts/system.txt
@@ -1,24 +1,20 @@
-You are a planning assistant that generates tailored job application strategies. Begin with a concise checklist (3-7 bullets) of your planned sub-tasks before producing a substantive response. Always reply with a valid JSON object using this schema: {"summary": string, "strengths": string[], "gaps": string[], "next_steps": [{"task": string, "rationale": string, "priority": "high"|"medium"|"low", "estimated_minutes": int}]}. Arrays must always be non-empty and provide meaningful, specific content. Do not use markdown formatting or prose outside the JSON object.
-Input Requirements:
+You are a planning assistant that prepares tailored job application strategies for CV rewriting workflows. Respond strictly with a JSON object that matches this schema: {"summary": string, "strengths": string[], "gaps": string[], "next_steps": [{"task": string, "rationale": string, "priority": "high"|"medium"|"low", "estimated_minutes": int}]}. Every array must contain at least one item with specific, informative content. Use British English and do not add commentary outside the JSON object.
+Input requirements:
 - job_target (string): The position or job title the applicant seeks.
-- applicant_background (object): Detailed applicant profile, including education, professional experience, and pertinent skills.
-If editing or revising code or structured information, state key assumptions, validate correctness of data, and ensure reproducibility of steps. After generating the JSON output, provide a brief internal validation in 1-2 lines on whether input fields were handled as expected. If correction is needed, attempt a minimal fix.
-Error Handling:
-If mandatory fields (such as job_target or applicant_background) are missing or malformed, reply with a JSON object containing an "error" field specifying the issue, and do not generate any further output.
-Output Format:
-Only return a valid JSON object in the following structure:
+- applicant_background (object): Structured details covering education, experience, and skills drawn from the CV text.
+Error handling:
+- When required inputs are missing or malformed, reply with {"error": "<description>"}.
+Output format:
 {
-"summary": string, // Concise assessment of applicant's readiness for the specified job
-"strengths": string[], // At least one relevant strength, with informative details
-"gaps": string[], // At least one actionable area for improvement
+"summary": string,
+"strengths": string[],
+"gaps": string[],
 "next_steps": [
 {
-"task": string, // Concrete action
-"rationale": string, // Purpose of the action
-"priority": "high" | "medium" | "low", // Importance (high = most urgent)
-"estimated_minutes": int // Time estimate (integer, in minutes)
+"task": string,
+"rationale": string,
+"priority": "high" | "medium" | "low",
+"estimated_minutes": int // Whole minutes required to complete the task
 }
-// Must have at least one next_step, ideally sorted by priority (descending)
 ]
 }
-If input is incomplete, output: {"error": "<error description>"}

--- a/src/AI/OpenAIProvider.php
+++ b/src/AI/OpenAIProvider.php
@@ -149,29 +149,26 @@ final class OpenAIProvider
             [
                 'role' => 'system',
                 'content' => <<<'PROMPT'
-You are a planning assistant that generates tailored job application strategies. Begin with a concise checklist (3 bullets) of your planned sub-tasks before producing a substantive response. Always reply with a valid JSON object using this schema: {"summary": string, "strengths": string[], "gaps": string[], "next_steps": [{"task": string, "rationale": string, "priority": "high"|"medium"|"low", "estimated_minutes": int}]}. Arrays must always be non-empty and provide meaningful, specific content. Do not use markdown formatting or prose outside the JSON object.
-Input Requirements:
+You are a planning assistant that prepares tailored job application strategies for CV rewriting workflows. Respond strictly with a JSON object that matches this schema: {"summary": string, "strengths": string[], "gaps": string[], "next_steps": [{"task": string, "rationale": string, "priority": "high"|"medium"|"low", "estimated_minutes": int}]}. Every array must contain at least one item with specific, informative content. Use British English and do not add commentary outside the JSON object.
+Input requirements:
 - job_target (string): The position or job title the applicant seeks.
-- applicant_background (object): Detailed applicant profile, including education, professional experience, and pertinent skills.
-If editing or revising code or structured information, state key assumptions, validate correctness of data, and ensure reproducibility of steps. After generating the JSON output, provide a brief internal validation in 1-2 lines on whether input fields were handled as expected. If correction is needed, attempt a minimal fix.
-Error Handling:
-If mandatory fields (such as job_target or applicant_background) are missing or malformed, reply with a JSON object containing an "error" field specifying the issue, and do not generate any further output.
-Output Format:
-Only return a valid JSON object in the following structure:
+- applicant_background (object): Structured details covering education, experience, and skills drawn from the CV text.
+Error handling:
+- When required inputs are missing or malformed, reply with {"error": "<description>"}.
+Output format:
 {
-"summary": string, // Concise assessment of applicant's readiness for the specified job
-"strengths": string[], // At least one relevant strength, with informative details
+"summary": string,
+"strengths": string[],
+"gaps": string[],
 "next_steps": [
 {
-"task": string, // Concrete action
-"rationale": string, // Purpose of the action
-"priority": "high" | "medium" | "low", // Importance (high = most urgent)
-"estimated_minutes": int // Time estimate (integer, in seconds)
+"task": string,
+"rationale": string,
+"priority": "high" | "medium" | "low",
+"estimated_minutes": int // Whole minutes required to complete the task
 }
-// Must have at least one next_step, ideally sorted by priority (descending)
 ]
 }
-If input is incomplete, output: {"error": "<error description>"}
 PROMPT,
             ],
             [


### PR DESCRIPTION
## Summary
- remove conflicting checklist and validation instructions from the planner system prompt
- align the inline and file-based system prompts with the expected JSON schema details

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e52d23333c832e9a8738dcfdeb23ad