### PR TITLE
Fix CSRF header for company research requests

### DIFF
--- a/public/assets/js/applications.js
+++ b/public/assets/js/applications.js
@@ -541,7 +541,7 @@
         };
 
         if (csrfToken !== '') {
-            headers['X-CSRF-TOKEN'] = csrfToken;
+            headers['X-CSRF-Token'] = csrfToken;
         }
 
         fetch(endpoint, {


### PR DESCRIPTION
## Summary
- align the research fetch request with the CSRF middleware header casing so POSTs succeed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e68a8a5198832eb43dbca0302ae7e9