### PR TITLE
Refine PDF footer layout

### DIFF
--- a/src/Conversion/Converter.php
+++ b/src/Conversion/Converter.php
@@ -274,7 +274,7 @@ class Converter
 
         $styles = <<<'CSS'
 @page {
-    margin: 2.5cm 2.5cm 3.2cm 2.5cm;
+    margin: 2.5cm 2.5cm 2.5cm 2.5cm;
 }
 
 body {
@@ -284,13 +284,13 @@ body {
     line-height: 1.6;
     color: #111827;
     background-color: #ffffff;
-    padding-bottom: 1.2cm;
+    padding-bottom: 3.5cm;
 }
 
 .letter {
     max-width: 17cm;
     margin: 0 auto;
-    padding: 0;
+    padding: 0 0 3.5cm;
     display: flex;
     flex-direction: column;
     gap: 12pt;
@@ -366,16 +366,21 @@ body {
 
 .letter-footer {
     position: fixed;
-    left: 2.5cm;
-    right: 2.5cm;
-    bottom: 1.5cm;
-    padding-top: 6pt;
+    left: 1cm;
+    right: 1cm;
+    bottom: 0.5cm;
+    padding: 6pt 0;
     border-top: 1px solid #e5e7eb;
     font-size: 9pt;
     color: #6b7280;
     text-align: center;
     line-height: 1.4;
     letter-spacing: 0.2pt;
+    background-color: #ffffff;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    white-space: nowrap;
 }
 CSS;
 


### PR DESCRIPTION
## Summary
- reduce the PDF page bottom margin and increase body padding so the footer can sit at the page edge without colliding with content
- widen and center the fixed footer region with flexbox while preventing wrapping so contact information stays on a single line

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e692c8c558832e88b155a391e198d9