### PR TITLE
Refine PDF footer layout

### DIFF
--- a/src/Conversion/Converter.php
+++ b/src/Conversion/Converter.php
@@ -284,13 +284,13 @@ body {
     line-height: 1.6;
     color: #111827;
     background-color: #ffffff;
-    padding-bottom: 2.5cm;
+    padding-bottom: 3.5cm;
 }
 
 .letter {
     max-width: 17cm;
     margin: 0 auto;
-    padding: 0 0 2.5cm;
+    padding: 0;
     display: flex;
     flex-direction: column;
     gap: 12pt;


### PR DESCRIPTION
## Summary
- prevent cumulative bottom padding by keeping the footer clearance on the body and removing it from the inner letter container

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e69e37da2c832e9271008ff1257893