### PR TITLE
Add TASKS.md entry to track QR auth view lint warning

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -26,3 +26,7 @@
 - [ ] Add HTTP wiring for the delete flow, including a dedicated controller action that terminates the active session, calls the deletion service, expires authentication cookies, and redirects to a confirmation screen.
 - [ ] Extend the dashboard UI with a confirmation dialog and form that posts to the new endpoint using existing CSRF protections and accessible destructive-action styling.
 - [ ] Introduce automated verification that seeding test data and invoking the service wipes all related tables, and document manual QA steps for end-to-end validation.
+
+## 8. Resolve PHP lint warning in QR auth view
+- [ ] Remove the ineffective `use DateTimeInterface;` import from `resources/views/auth/qr.php` and switch the PHPDoc annotation to `\DateTimeInterface` so linting is warning-free.
+- [ ] Expand the lint script coverage so all PHP files are checked during routine verification, preventing view-level warnings from slipping through.


### PR DESCRIPTION
### Motivation
- Capture and track a PHP lint warning emitted by the QR authentication view so the ineffective import and lint coverage gap are remediated and prevented from recurring.

### Description
- Added a new "Resolve PHP lint warning in QR auth view" section to `TASKS.md` that recommends removing the ineffective `use DateTimeInterface;` from `resources/views/auth/qr.php` (use `\DateTimeInterface` in the PHPDoc) and expanding the lint script to check all PHP files.

### Testing
- Ran `composer test`, which reported no syntax errors for `public/index.php`, `src/Bootstrap.php`, and `src/Routes.php` and completed successfully.
- Performed a full-repository PHP lint sweep (`php -l` over all `*.php`) which completed but surfaced a `The use statement with non-compound name 'DateTimeInterface' has no effect` warning in `resources/views/auth/qr.php`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abf3d11524832eab0885d3881f9328)