### PR TITLE
Refresh OpenAI integration for GPT-5.4 and Responses `text.format`

### DIFF
--- a/resources/systemd/job-worker.env.example
+++ b/resources/systemd/job-worker.env.example
@@ -17,7 +17,7 @@ QUEUE_CONNECTION=database
 
 # OpenAI credentials used by the background worker when site settings are not configured.
 OPENAI_API_KEY=change-me
-OPENAI_MODEL_PLAN=gpt-5
-OPENAI_MODEL_DRAFT=gpt-5-mini
-OPENAI_TARIFF_JSON={"gpt-5":{"prompt":0.099,"completion":0.79},"gpt-5-mini":{"prompt":0.02,"completion":0.158},"gpt-5-nano":{"prompt":0.004,"completion":0.032}}
+OPENAI_MODEL_PLAN=gpt-5.4
+OPENAI_MODEL_DRAFT=gpt-5.4-mini
+OPENAI_TARIFF_JSON={"gpt-5.4":{"prompt":0.099,"completion":0.79},"gpt-5.4-mini":{"prompt":0.02,"completion":0.158},"gpt-5.4-nano":{"prompt":0.004,"completion":0.032}}
 OPENAI_MAX_TOKENS=2048

--- a/resources/views/home.php
+++ b/resources/views/home.php
@@ -179,7 +179,7 @@ if (is_string($generationIdRaw)) {
                     <div class="wizard-preview__options">
                         <div>
                             <span class="wizard-preview__option-label">Model</span>
-                            <span class="wizard-preview__option-value">GPT-5 Mini · Balanced performance</span>
+                            <span class="wizard-preview__option-value">GPT-5.4 Mini · Balanced performance</span>
                         </div>
                         <div>
                             <span class="wizard-preview__option-label">Thinking time</span>

--- a/resources/views/tailor.php
+++ b/resources/views/tailor.php
@@ -30,7 +30,7 @@ $wizardSteps = [
         'index' => 3,
         'title' => 'Set parameters',
         'summary' => 'Adjust the AI model and thinking time.',
-        'helper' => 'Higher thinking time gives GPT-5 more reasoning space.',
+        'helper' => 'Higher thinking time gives GPT-5.4 more reasoning space.',
     ],
     [
         'index' => 4,
@@ -252,7 +252,7 @@ $additionalHead = '<script src="/assets/js/tailor.js" defer></script>';
                             class="w-full accent-indigo-500"
                         >
                         <p class="text-xs text-slate-400">
-                            Give GPT-5 more time for complex roles. Thirty seconds is a balanced default.
+                            Give GPT-5.4 more time for complex roles. Thirty seconds is a balanced default.
                         </p>
                     </div>
                     <div class="space-y-2">

--- a/src/AI/OpenAIProvider.php
+++ b/src/AI/OpenAIProvider.php
@@ -49,8 +49,8 @@ final class OpenAIProvider
     private const INITIAL_BACKOFF_MS = 200;
     private const MAX_BACKOFF_MS = 4000;
 
-    private const PLAN_MODEL_FALLBACKS = ['gpt-5-mini', 'gpt-5-nano'];
-    private const DRAFT_MODEL_FALLBACKS = ['gpt-5-mini', 'gpt-5-nano'];
+    private const PLAN_MODEL_FALLBACKS = ['gpt-5.4-mini', 'gpt-5.4-nano'];
+    private const DRAFT_MODEL_FALLBACKS = ['gpt-5.4-mini', 'gpt-5.4-nano'];
 
     /** @var ClientInterface */
     private $client;
@@ -191,7 +191,9 @@ PROMPT,
                 'model' => $model,
                 'input' => $this->formatMessagesForResponses($messages),
                 'max_output_tokens' => $this->maxTokens,
-                'response_format' => $this->buildPlanJsonSchema(),
+                'text' => [
+                    'format' => $this->buildPlanJsonSchema(),
+                ],
             ];
 
             try {
@@ -686,7 +688,7 @@ PROMPT,
     }
 
     /**
-     * Attempt plan generation while gracefully falling back through response_format permutations.
+     * Attempt plan generation while gracefully falling back through structured-output permutations.
      *
      * @param array<string, mixed> $payload
      * @return array{content: string, usage: array<string, int>, response: array<string, mixed>}
@@ -698,8 +700,8 @@ PROMPT,
         } catch (RuntimeException $exception) {
             if ($this->shouldFallbackToLegacyResponseFormat($exception)) {
                 $strippedPayload = $payload;
-                unset($strippedPayload['response_format']);
-                error_log('Retrying plan request without response_format parameter: ' . $exception->getMessage());
+                unset($strippedPayload['text']);
+                error_log('Retrying plan request without text.format parameter: ' . $exception->getMessage());
 
                 try {
                     return $this->performChatRequest($strippedPayload, 'plan', $streamHandler);
@@ -709,8 +711,8 @@ PROMPT,
                     }
 
                     $jsonObjectPayload = $payload;
-                    $jsonObjectPayload['response_format'] = ['type' => 'json_object'];
-                    error_log('Retrying plan request with json_object response format after stripped response_format failure: ' . $strippedException->getMessage());
+                    $jsonObjectPayload['text'] = ['format' => ['type' => 'json_object']];
+                    error_log('Retrying plan request with json_object text.format after stripped schema failure: ' . $strippedException->getMessage());
 
                     return $this->performChatRequest($jsonObjectPayload, 'plan', $streamHandler);
                 }
@@ -721,8 +723,8 @@ PROMPT,
             }
 
             $jsonObjectPayload = $payload;
-            $jsonObjectPayload['response_format'] = ['type' => 'json_object'];
-            error_log('Falling back to json_object response format after plan request failure: ' . $exception->getMessage());
+            $jsonObjectPayload['text'] = ['format' => ['type' => 'json_object']];
+            error_log('Falling back to json_object text.format after plan request failure: ' . $exception->getMessage());
 
             return $this->performChatRequest($jsonObjectPayload, 'plan', $streamHandler);
         }
@@ -1055,8 +1057,8 @@ PROMPT,
     /**
      * Rewrite configured model identifiers into the canonical API-supported format.
      *
-     * Marketing materials occasionally reference dotted variants such as
-     * "gpt-5.0-mini" even though the API only recognises "gpt-5-mini". By
+     * Marketing materials occasionally reference dotted or role-specific variants such as
+     * "gpt-5.0-mini" even though the API may expose newer identifiers like "gpt-5.4-mini". By
      * normalising the identifier at read time we guarantee that every request and
      * fallback attempt references a model name accepted by OpenAI. Marketing aliases
      * such as "gpt-5-strategist" are collapsed into the corresponding production
@@ -1083,10 +1085,16 @@ PROMPT,
         }
 
         $aliases = [
-            'gpt-5-strategist' => 'gpt-5',
-            'gpt-5.0-strategist' => 'gpt-5',
-            'gpt5-strategist' => 'gpt-5',
-            'gpt5.0-strategist' => 'gpt-5',
+            'gpt-5-strategist' => 'gpt-5.4',
+            'gpt-5.0-strategist' => 'gpt-5.4',
+            'gpt5-strategist' => 'gpt-5.4',
+            'gpt5.0-strategist' => 'gpt-5.4',
+            'gpt-5-main' => 'gpt-5.4',
+            'gpt5-main' => 'gpt-5.4',
+            'gpt5' => 'gpt-5.4',
+            'gpt-5' => 'gpt-5.4',
+            'gpt-5-mini' => 'gpt-5.4-mini',
+            'gpt-5-nano' => 'gpt-5.4-nano',
         ];
 
         if (isset($aliases[$lower])) {
@@ -1122,9 +1130,9 @@ PROMPT,
     /**
      * Normalise the outgoing payload to match the latest OpenAI Responses API expectations.
      *
-     * This helper safeguards against legacy configuration values that still populate the
-     * deprecated `response` structure by migrating any provided schema into the supported
-     * top-level `response_format` field while stripping unsupported keys.
+     * This helper safeguards against legacy configuration values by migrating deprecated
+     * schema containers onto the current `text.format` field while preserving fallbacks for
+     * older parameter names used in historical payload builders.
      *
      * @param array<string, mixed> $payload
      * @return array<string, mixed>
@@ -1145,10 +1153,26 @@ PROMPT,
 
             unset($payload['response']);
 
-            if ($format !== null && !array_key_exists('response_format', $payload)) {
-                $payload['response_format'] = $format;
+            if ($format !== null) {
+                if (!isset($payload['text']) || !is_array($payload['text'])) {
+                    $payload['text'] = [];
+                }
+
+                if (!array_key_exists('format', $payload['text'])) {
+                    $payload['text']['format'] = $format;
+                }
             }
         }
+
+        if (array_key_exists('response_format', $payload) && (!isset($payload['text']) || !is_array($payload['text']) || !array_key_exists('format', $payload['text']))) {
+            if (!isset($payload['text']) || !is_array($payload['text'])) {
+                $payload['text'] = [];
+            }
+
+            $payload['text']['format'] = $payload['response_format'];
+        }
+
+        unset($payload['response_format']);
 
         return $payload;
     }
@@ -1567,11 +1591,10 @@ PROMPT,
     }
 
     /**
-     * Determine whether the failure indicates that the legacy response_format parameter is required.
+     * Determine whether the failure indicates that the modern text.format parameter is unsupported.
      *
-     * Some OpenAI models continue to expect the historic response_format key rather than the newer
-     * response.format structure. When that situation is detected we retry the request using the legacy
-     * parameter to maintain compatibility.
+     * Some model families and proxies still reject text.format and require unstructured output.
+     * When that situation is detected we retry the request without the structured output declaration.
      */
     private function shouldFallbackToLegacyResponseFormat(RuntimeException $exception): bool
     {
@@ -1631,11 +1654,13 @@ PROMPT,
     }
 
     /**
-     * Detect whether the message indicates the modern response_format parameter is unsupported or has moved.
+     * Detect whether the message indicates the structured output parameter is unsupported or has moved.
      */
     private function mentionsUnsupportedLegacyResponseFormat(string $message): bool
     {
-        $mentionsResponseFormat = strpos($message, 'response_format') !== false;
+        $mentionsResponseFormat = strpos($message, 'response_format') !== false
+            || strpos($message, 'text.format') !== false
+            || strpos($message, 'text[format]') !== false;
         $mentionsUnsupported = strpos($message, 'unsupported parameter') !== false
             || strpos($message, 'is unsupported') !== false
             || strpos($message, 'not supported') !== false;
@@ -1659,6 +1684,7 @@ PROMPT,
     private function mentionsUnsupportedSchema(string $message): bool
     {
         return strpos($message, 'response_format') !== false
+            || strpos($message, 'text.format') !== false
             || strpos($message, 'response.format') !== false
             || strpos($message, 'json_schema') !== false
             || strpos($message, 'structured output') !== false;

--- a/src/Controllers/GenerationController.php
+++ b/src/Controllers/GenerationController.php
@@ -16,9 +16,9 @@ final class GenerationController
 {
     /** @var array<int, array{value: string, label: string}> */
     private const MODELS = [
-        ['value' => 'gpt-5-mini', 'label' => 'GPT-5 Mini · Balanced performance'],
-        ['value' => 'gpt-5', 'label' => 'GPT-5 · Highest quality'],
-        ['value' => 'gpt-5-nano', 'label' => 'GPT-5 Nano · Fastest responses'],
+        ['value' => 'gpt-5.4-mini', 'label' => 'GPT-5.4 Mini · Balanced performance'],
+        ['value' => 'gpt-5.4', 'label' => 'GPT-5.4 · Highest quality'],
+        ['value' => 'gpt-5.4-nano', 'label' => 'GPT-5.4 Nano · Fastest responses'],
     ];
 
     /** @var GenerationRepository */

--- a/src/Services/UsageService.php
+++ b/src/Services/UsageService.php
@@ -160,13 +160,16 @@ class UsageService
         $key = strtolower($model);
 
         $aliases = [
-            'gpt-5-main' => 'gpt-5',
-            'gpt5-main' => 'gpt-5',
-            'gpt5' => 'gpt-5',
-            'gpt-5-strategist' => 'gpt-5',
-            'gpt-5.0-strategist' => 'gpt-5',
-            'gpt5-strategist' => 'gpt-5',
-            'gpt5.0-strategist' => 'gpt-5',
+            'gpt-5-main' => 'gpt-5.4',
+            'gpt5-main' => 'gpt-5.4',
+            'gpt5' => 'gpt-5.4',
+            'gpt-5' => 'gpt-5.4',
+            'gpt-5-mini' => 'gpt-5.4-mini',
+            'gpt-5-nano' => 'gpt-5.4-nano',
+            'gpt-5-strategist' => 'gpt-5.4',
+            'gpt-5.0-strategist' => 'gpt-5.4',
+            'gpt5-strategist' => 'gpt-5.4',
+            'gpt5.0-strategist' => 'gpt-5.4',
         ];
 
         if (isset($aliases[$key])) {

--- a/tests/OpenAIProviderPlanTest.php
+++ b/tests/OpenAIProviderPlanTest.php
@@ -144,12 +144,12 @@ $pdo->exec('CREATE TABLE api_usage (
 $settings = new SiteSettingsRepository($pdo);
 
 $firstFailure = new RequestException(
-    'response_format is unsupported',
+    'text.format is unsupported',
     new Request('POST', 'responses'),
     new Response(
         400,
         ['Content-Type' => 'application/json'],
-        json_encode(['error' => ['message' => 'response_format is unsupported on this model.']])
+        json_encode(['error' => ['message' => 'text.format is unsupported on this model.']])
     )
 );
 
@@ -199,16 +199,16 @@ if (count($requests) !== 2) {
 $firstRequestBody = json_decode($requests[0]['options']['body'], true);
 $secondRequestBody = json_decode($requests[1]['options']['body'], true);
 
-if (!is_array($firstRequestBody) || !isset($firstRequestBody['response_format'])) {
-    throw new RuntimeException('Initial request payload is missing response_format.');
+if (!is_array($firstRequestBody) || !isset($firstRequestBody['text']['format'])) {
+    throw new RuntimeException('Initial request payload is missing text.format.');
 }
 
 if (isset($secondRequestBody['response'])) {
     throw new RuntimeException('Fallback request should not include the legacy response key.');
 }
 
-if (isset($secondRequestBody['response_format'])) {
-    throw new RuntimeException('Fallback request should not include response_format after stripping.');
+if (isset($secondRequestBody['text']['format'])) {
+    throw new RuntimeException('Fallback request should not include text.format after stripping.');
 }
 
 $decoded = json_decode($plan, true);
@@ -253,7 +253,7 @@ if (!is_array($initialFallbackRequest) || $initialFallbackRequest['model'] !== '
     throw new RuntimeException('Initial plan request did not target the configured missing model.');
 }
 
-if (!is_array($secondFallbackRequest) || $secondFallbackRequest['model'] !== 'gpt-5-mini') {
+if (!is_array($secondFallbackRequest) || $secondFallbackRequest['model'] !== 'gpt-5.4-mini') {
     throw new RuntimeException('Fallback plan request did not target the expected default model.');
 }
 
@@ -269,7 +269,7 @@ $_ENV['OPENAI_MODEL_PLAN'] = 'gpt-5.0-strategist';
 $_SERVER['OPENAI_MODEL_PLAN'] = 'gpt-5.0-strategist';
 
 $aliasSuccessPayload = $successPayload;
-$aliasSuccessPayload['model'] = 'gpt-5';
+$aliasSuccessPayload['model'] = 'gpt-5.4';
 
 $aliasClient = new FakeClient([
     $firstFailure,
@@ -288,11 +288,11 @@ if (count($aliasRequests) !== 2) {
 $aliasFirstRequest = json_decode($aliasRequests[0]['options']['body'], true);
 $aliasSecondRequest = json_decode($aliasRequests[1]['options']['body'], true);
 
-if (!is_array($aliasFirstRequest) || $aliasFirstRequest['model'] !== 'gpt-5') {
+if (!is_array($aliasFirstRequest) || $aliasFirstRequest['model'] !== 'gpt-5.4') {
     throw new RuntimeException('Initial alias plan request did not normalise the marketing model name.');
 }
 
-if (!is_array($aliasSecondRequest) || $aliasSecondRequest['model'] !== 'gpt-5') {
+if (!is_array($aliasSecondRequest) || $aliasSecondRequest['model'] !== 'gpt-5.4') {
     throw new RuntimeException('Second alias plan request did not retain the normalised model identifier.');
 }
 


### PR DESCRIPTION
### Motivation
- Move the integration to the latest model family and Responses API shape so structured outputs and model fallbacks align with current OpenAI recommendations.
- Keep robust backwards/sideways compatibility with legacy model aliases and older Responses payload shapes used in the codebase.

### Description
- Updated the OpenAI provider to prefer GPT-5.4 identifiers and changed plan/draft fallback lists to `gpt-5.4-*` variants while normalising legacy GPT-5 aliases to the GPT-5.4 canonical names in `normaliseConfiguredModel` and usage mapping.
- Migrated structured output requests from the older `response_format` shape to the Responses API `text.format` container and added defensive logic to accept `response`/`response_format` and rewrite them into `text.format` for compatibility.
- Retained and extended the existing fallback behaviour to strip `text.format` or fall back to a `json_object` declaration when models reject structured outputs, and adjusted logging messages accordingly.
- Updated selectable models and user-facing copy to GPT-5.4 variants, refreshed worker environment defaults in `resources/systemd/job-worker.env.example`, and adapted the provider unit test expectations to the new model/format.

### Testing
- Ran syntax checks with `php -l` on modified files and they all reported no syntax errors.
- Executed the provider regression test `tests/OpenAIProviderPlanTest.php` with `php tests/OpenAIProviderPlanTest.php` and it passed, verifying fallback and `text.format` behaviours.
- Observed the provider log path exercising the fallback flows (structured format rejection, stripped request, json_object fallback) during the test run and saw expected success.
- Database-dependent or environment-heavy tests were intentionally not executed per the request to avoid running tests that require a live database.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7e3c96724832ea1d5c8b0877f6cfb)