### PR TITLE
Recenter job application tailoring workflow

### DIFF
--- a/public/assets/js/application-form.js
+++ b/public/assets/js/application-form.js
@@ -1,0 +1,97 @@
+(function () {
+    'use strict';
+
+    /**
+     * Resolve the CSRF token from the shared meta element.
+     *
+     * @returns {string} The current CSRF token or an empty string.
+     */
+    const csrfToken = function () {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+
+        return meta ? String(meta.getAttribute('content') || '') : '';
+    };
+
+    /**
+     * Update the inline import status message for the active form.
+     *
+     * @param {HTMLElement|null} element The message node beside the URL field.
+     * @param {string} message The message to display.
+     * @param {boolean} isError Whether the message represents an error.
+     * @returns {void}
+     */
+    const setStatus = function (element, message, isError) {
+        if (!element) {
+            return;
+        }
+
+        element.textContent = message;
+        element.classList.remove('hidden', 'text-indigo-200', 'text-rose-200');
+        element.classList.add(isError ? 'text-rose-200' : 'text-indigo-200');
+    };
+
+    /**
+     * Import the job description from the URL field into the current form.
+     *
+     * @param {HTMLButtonElement} button The clicked import button.
+     * @returns {Promise<void>} Completes after the import request resolves.
+     */
+    const importDescription = async function (button) {
+        const form = button.closest('form');
+        const urlInput = form ? form.querySelector('[name="source_url"]') : null;
+        const titleInput = form ? form.querySelector('[name="title"]') : null;
+        const descriptionInput = form ? form.querySelector('[name="description"]') : null;
+        const status = form ? form.querySelector('[data-fetch-description-status]') : null;
+        const sourceUrl = urlInput ? String(urlInput.value || '') : '';
+
+        button.disabled = true;
+        setStatus(status, 'Importing job advert…', false);
+
+        try {
+            const response = await fetch('/applications/fetch-description', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+                    'X-CSRF-Token': csrfToken(),
+                },
+                body: new URLSearchParams({ source_url: sourceUrl, _token: csrfToken() }).toString(),
+            });
+            const payload = await response.json();
+
+            if (!response.ok || payload.status !== 'ok') {
+                throw new Error(payload.message || 'Unable to import the job advert.');
+            }
+
+            if (titleInput && titleInput.value.trim() === '' && payload.data.title) {
+                titleInput.value = payload.data.title;
+            }
+
+            if (descriptionInput) {
+                descriptionInput.value = payload.data.description || '';
+            }
+
+            setStatus(status, 'Imported. Review the text before saving.', false);
+        } catch (error) {
+            setStatus(status, error && error.message ? error.message : 'Unable to import the job advert.', true);
+        } finally {
+            button.disabled = false;
+        }
+    };
+
+    /**
+     * Attach import handlers to all job posting forms on the page.
+     *
+     * @returns {void}
+     */
+    const initialise = function () {
+        const buttons = document.querySelectorAll('[data-fetch-description]');
+
+        buttons.forEach(function (button) {
+            button.addEventListener('click', function () {
+                importDescription(button);
+            });
+        });
+    };
+
+    document.addEventListener('DOMContentLoaded', initialise);
+}());

--- a/public/index.php
+++ b/public/index.php
@@ -6,6 +6,7 @@ use App\Bootstrap;
 use App\Controllers\AuthController;
 use App\Applications\JobApplicationRepository;
 use App\Applications\JobApplicationService;
+use App\Applications\JobPostingFetcher;
 use App\AI\OpenAIProvider;
 use App\Contacts\ContactDetailsRepository;
 use App\Contacts\ContactDetailsService;
@@ -116,11 +117,16 @@ $container->set(JobApplicationRepository::class, static function (Container $c):
     return new JobApplicationRepository($c->get(\PDO::class));
 });
 
+$container->set(JobPostingFetcher::class, static function (): JobPostingFetcher {
+    return new JobPostingFetcher();
+});
+
 $container->set(JobApplicationService::class, static function (Container $c): JobApplicationService {
     return new JobApplicationService(
         $c->get(JobApplicationRepository::class),
         $c->get(GenerationRepository::class),
-        $c->get(DocumentRepository::class)
+        $c->get(DocumentRepository::class),
+        $c->get(JobPostingFetcher::class)
     );
 });
 

--- a/resources/views/applications-create.php
+++ b/resources/views/applications-create.php
@@ -6,6 +6,7 @@
 /** @var array<string, string> $form */
 /** @var string|null $status */
 /** @var string|null $csrfToken */
+$additionalHead = '<script src="/assets/js/application-form.js" defer></script>';
 ?>
 <?php ob_start(); ?>
 <div class="space-y-8">
@@ -67,14 +68,18 @@
 
             <div class="space-y-2">
                 <label for="source_url" class="text-sm font-medium text-slate-200">Source URL</label>
-                <input
-                    type="url"
-                    id="source_url"
-                    name="source_url"
-                    value="<?= htmlspecialchars($form['source_url'] ?? '', ENT_QUOTES) ?>"
-                    placeholder="https://"
-                    class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400"
-                >
+                <div class="flex gap-2">
+                    <input
+                        type="url"
+                        id="source_url"
+                        name="source_url"
+                        value="<?= htmlspecialchars($form['source_url'] ?? '', ENT_QUOTES) ?>"
+                        placeholder="https://"
+                        class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                    >
+                    <button type="button" data-fetch-description class="shrink-0 rounded-lg border border-indigo-400/50 bg-indigo-500/10 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-indigo-100 transition hover:border-indigo-300 hover:bg-indigo-500/20">Import</button>
+                </div>
+                <p data-fetch-description-status class="hidden text-xs text-indigo-200"></p>
                 <p class="text-xs text-slate-500">Storing the link lets you revisit the listing whenever you need more detail.</p>
             </div>
 

--- a/resources/views/applications-edit.php
+++ b/resources/views/applications-edit.php
@@ -8,9 +8,13 @@
 /** @var array<string, string> $failureReasons */
 /** @var array<string, mixed> $application */
 /** @var array<int, array{id: int, label: string}> $generationOptions */
+/** @var array<int, array{id: int, label: string}> $cvOptions */
+/** @var array<int, array{value: string, label: string}> $modelOptions */
+/** @var string $defaultPrompt */
 /** @var array<string, mixed>|null $linkedGeneration */
 /** @var string|null $status */
 /** @var string|null $csrfToken */
+$additionalHead = '<script src="/assets/js/application-form.js" defer></script>';
 ?>
 <?php ob_start(); ?>
 <div class="space-y-8">
@@ -73,14 +77,18 @@
 
             <div class="space-y-2">
                 <label for="source_url" class="text-sm font-medium text-slate-200">Source URL</label>
-                <input
-                    type="url"
-                    id="source_url"
-                    name="source_url"
-                    value="<?= htmlspecialchars($form['source_url'] ?? '', ENT_QUOTES) ?>"
-                    placeholder="https://"
-                    class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400"
-                >
+                <div class="flex gap-2">
+                    <input
+                        type="url"
+                        id="source_url"
+                        name="source_url"
+                        value="<?= htmlspecialchars($form['source_url'] ?? '', ENT_QUOTES) ?>"
+                        placeholder="https://"
+                        class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                    >
+                    <button type="button" data-fetch-description class="shrink-0 rounded-lg border border-indigo-400/50 bg-indigo-500/10 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-indigo-100 transition hover:border-indigo-300 hover:bg-indigo-500/20">Import</button>
+                </div>
+                <p data-fetch-description-status class="hidden text-xs text-indigo-200"></p>
                 <p class="text-xs text-slate-500">Keeping the original link handy makes it easy to revisit requirements.</p>
             </div>
 
@@ -220,6 +228,33 @@
                 <?php endif; ?>
             </section>
 
+
+            <section class="space-y-4 rounded-2xl border border-emerald-500/40 bg-emerald-500/10 p-5 shadow-xl theme-light:border-emerald-200 theme-light:bg-emerald-50">
+                <header class="space-y-1">
+                    <p class="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-200 theme-light:text-emerald-700">Prime workflow</p>
+                    <h4 class="text-base font-semibold text-white theme-light:text-slate-900">Tailor this application from your master CV</h4>
+                    <p class="text-xs text-emerald-100/80 theme-light:text-emerald-700">Queue a tailored CV and cover letter using this saved job description, then automatically link the result back to this tracker card.</p>
+                </header>
+                <form method="post" action="/applications/<?= urlencode((string) ($application['id'] ?? '')) ?>/tailor" class="space-y-3">
+                    <input type="hidden" name="_token" value="<?= htmlspecialchars((string) $csrfToken, ENT_QUOTES) ?>">
+                    <input type="hidden" name="model" value="gpt-5.4-mini">
+                    <input type="hidden" name="thinking_time" value="30">
+                    <textarea name="prompt" class="hidden"><?= htmlspecialchars((string) $defaultPrompt, ENT_QUOTES) ?></textarea>
+                    <label for="cv_document_id" class="text-xs font-semibold uppercase tracking-wide text-emerald-100 theme-light:text-emerald-700">Master CV</label>
+                    <select id="cv_document_id" name="cv_document_id" class="w-full rounded-lg border border-emerald-400/40 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 theme-light:border-emerald-200 theme-light:bg-white theme-light:text-slate-700" required>
+                        <option value="">Select your master CV</option>
+                        <?php foreach ($cvOptions as $option) : ?>
+                            <option value="<?= htmlspecialchars((string) $option['id'], ENT_QUOTES) ?>"><?= htmlspecialchars($option['label'], ENT_QUOTES) ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                    <button type="submit" class="w-full rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-400" <?= empty($cvOptions) ? 'disabled' : '' ?>>
+                        Queue tailored CV and link it
+                    </button>
+                    <?php if (empty($cvOptions)) : ?>
+                        <p class="text-xs text-emerald-100/80 theme-light:text-emerald-700">Upload a CV document first so this application can be tailored.</p>
+                    <?php endif; ?>
+                </form>
+            </section>
             <section class="space-y-3 rounded-2xl border border-rose-500/40 bg-rose-500/10 p-4 text-xs text-rose-100 theme-light:border-rose-200 theme-light:bg-rose-50 theme-light:text-rose-600">
                 <header class="space-y-1">
                     <h4 class="text-base font-semibold">Delete application</h4>

--- a/src/Applications/JobApplicationService.php
+++ b/src/Applications/JobApplicationService.php
@@ -31,6 +31,9 @@ class JobApplicationService
     /** @var DocumentRepository */
     private $documentRepository;
 
+    /** @var JobPostingFetcher */
+    private $postingFetcher;
+
     /**
      * Construct the object with its required dependencies.
      *
@@ -39,11 +42,13 @@ class JobApplicationService
     public function __construct(
         JobApplicationRepository $repository,
         GenerationRepository $generationRepository,
-        DocumentRepository $documentRepository
+        DocumentRepository $documentRepository,
+        ?JobPostingFetcher $postingFetcher = null
     ) {
         $this->repository = $repository;
         $this->generationRepository = $generationRepository;
         $this->documentRepository = $documentRepository;
+        $this->postingFetcher = $postingFetcher ?? new JobPostingFetcher();
     }
 
     /**
@@ -228,6 +233,82 @@ class JobApplicationService
         return $this->repository->updateStatus($application, $normalisedStatus, $normalisedReason);
     }
 
+
+    /**
+     * Import a public job advert URL into a normalised draft posting payload.
+     *
+     * This gives the core workflow a single mechanism for pulling a description
+     * from the web before the user saves and tracks the opportunity.
+     * @return array{title: string, source_url: string, description: string}
+     */
+    public function fetchPostingFromUrl(string $url): array
+    {
+        return $this->postingFetcher->fetch($url);
+    }
+
+    /**
+     * Queue tailored documents for an existing tracked application and link the result.
+     *
+     * The method connects the prime workflow: saved advert, master CV, generated
+     * tailored CV and cover letter, then the application tracker record.
+     */
+    public function tailorApplication(int $userId, int $applicationId, int $cvDocumentId, string $model, int $thinkingTime, string $prompt): JobApplication
+    {
+        $application = $this->repository->findForUser($userId, $applicationId);
+
+        if ($application === null) {
+            throw new RuntimeException('The requested job application could not be found.');
+        }
+
+        $jobDocument = $this->findJobDescriptionDocument($application);
+        $cvDocument = $this->documentRepository->findForUserByType($userId, $cvDocumentId, 'cv');
+
+        if ($jobDocument === null) {
+            throw new RuntimeException('Save the job description before tailoring documents for this application.');
+        }
+
+        if ($cvDocument === null) {
+            throw new RuntimeException('Select a master CV that belongs to your workspace.');
+        }
+
+        $generation = $this->generationRepository->create($userId, $jobDocument, $cvDocument, $model, $thinkingTime, $prompt);
+        $generationId = isset($generation['id']) ? (int) $generation['id'] : 0;
+
+        if ($generationId <= 0) {
+            throw new RuntimeException('The tailoring job was queued but could not be linked to this application.');
+        }
+
+        return $this->repository->updateGeneration($application, $generationId);
+    }
+
+
+    /**
+     * List master CV documents available for application-specific tailoring.
+     *
+     * Keeping this lookup in the service preserves user ownership boundaries for controllers.
+     * @return array<int, array{id: int, label: string}>
+     */
+    public function cvOptionsForUser(int $userId): array
+    {
+        $options = [];
+        $documents = $this->documentRepository->listForUserAndType($userId, 'cv');
+
+        foreach ($documents as $document) {
+            $id = $document->id();
+
+            if ($id === null) {
+                continue;
+            }
+
+            $options[] = [
+                'id' => $id,
+                'label' => $document->filename(),
+            ];
+        }
+
+        return $options;
+    }
+
     /**
      * Handle the generation listing workflow.
      *
@@ -352,6 +433,42 @@ class JobApplicationService
         }
 
         return $key;
+    }
+
+
+    /**
+     * Locate the stored document that mirrors an application's current job description.
+     *
+     * Reusing the existing document keeps the Tailor wizard, generated outputs, and
+     * application tracker attached to the same source posting text.
+     */
+    private function findJobDescriptionDocument(JobApplication $application): ?Document
+    {
+        $description = $application->description();
+
+        if ($description === '' || $application->id() === null) {
+            return null;
+        }
+
+        $sha256 = hash('sha256', $description . '|' . (string) $application->id());
+        $documents = $this->documentRepository->listForUserAndType($application->userId(), 'job_description');
+
+        foreach ($documents as $document) {
+            if ($document->sha256() === $sha256) {
+                return $document;
+            }
+        }
+
+        $this->storeJobDescriptionDocument($application);
+        $documents = $this->documentRepository->listForUserAndType($application->userId(), 'job_description');
+
+        foreach ($documents as $document) {
+            if ($document->sha256() === $sha256) {
+                return $document;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Applications/JobPostingFetcher.php
+++ b/src/Applications/JobPostingFetcher.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Applications;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\RequestException;
+use RuntimeException;
+
+use function html_entity_decode;
+use function is_string;
+use function mb_substr;
+use function preg_match;
+use function preg_replace;
+use function strip_tags;
+use function trim;
+
+final class JobPostingFetcher
+{
+    /** @var ClientInterface */
+    private $client;
+
+    /**
+     * Construct the fetcher with an HTTP client that can retrieve public job adverts.
+     */
+    public function __construct(?ClientInterface $client = null)
+    {
+        $this->client = $client ?? new Client([
+            'timeout' => 20,
+            'allow_redirects' => ['max' => 5],
+            'headers' => [
+                'User-Agent' => 'JobTracker/1.0 (+https://job.smeird.com)',
+                'Accept' => 'text/html,application/xhtml+xml,text/plain;q=0.9,*/*;q=0.8',
+            ],
+        ]);
+    }
+
+    /**
+     * Fetch a public job advert URL and return a normalised title and description.
+     *
+     * @return array{title: string, description: string, source_url: string}
+     */
+    public function fetch(string $url): array
+    {
+        $normalisedUrl = trim($url);
+
+        if ($normalisedUrl === '' || filter_var($normalisedUrl, FILTER_VALIDATE_URL) === false) {
+            throw new RuntimeException('Provide a valid job advert URL before importing.');
+        }
+
+        try {
+            $response = $this->client->request('GET', $normalisedUrl);
+        } catch (RequestException $exception) {
+            throw new RuntimeException('Unable to fetch that job advert. Paste the description manually if the job board blocks imports.', 0, $exception);
+        }
+
+        $body = (string) $response->getBody();
+        $description = $this->extractReadableText($body);
+
+        if ($description === '') {
+            throw new RuntimeException('The fetched page did not contain readable job description text.');
+        }
+
+        return [
+            'title' => $this->extractTitle($body),
+            'description' => mb_substr($description, 0, 60000),
+            'source_url' => $normalisedUrl,
+        ];
+    }
+
+    /**
+     * Extract a concise title from the fetched HTML document.
+     */
+    private function extractTitle(string $html): string
+    {
+        if (preg_match('/<title[^>]*>(.*?)<\/title>/is', $html, $matches) === 1 && isset($matches[1])) {
+            return trim(html_entity_decode(strip_tags((string) $matches[1]), ENT_QUOTES, 'UTF-8'));
+        }
+
+        if (preg_match('/<h1[^>]*>(.*?)<\/h1>/is', $html, $matches) === 1 && isset($matches[1])) {
+            return trim(html_entity_decode(strip_tags((string) $matches[1]), ENT_QUOTES, 'UTF-8'));
+        }
+
+        return '';
+    }
+
+    /**
+     * Convert HTML into readable plain text while removing scripts, styles, and excess spacing.
+     */
+    private function extractReadableText(string $html): string
+    {
+        $text = preg_replace('/<script\b[^>]*>.*?<\/script>/is', ' ', $html);
+        $text = preg_replace('/<style\b[^>]*>.*?<\/style>/is', ' ', is_string($text) ? $text : $html);
+        $text = preg_replace('/<\/(p|div|section|article|li|ul|ol|h[1-6]|br)>/i', "\n", is_string($text) ? $text : $html);
+        $text = strip_tags(is_string($text) ? $text : $html);
+        $text = html_entity_decode($text, ENT_QUOTES, 'UTF-8');
+        $text = preg_replace('/[ \t]+/', ' ', $text);
+        $text = preg_replace('/\n\s*\n\s*\n+/', "\n\n", is_string($text) ? $text : '');
+
+        return trim(is_string($text) ? $text : '');
+    }
+}

--- a/src/Controllers/JobApplicationController.php
+++ b/src/Controllers/JobApplicationController.php
@@ -7,6 +7,7 @@ namespace App\Controllers;
 use App\Applications\JobApplication;
 use App\Applications\JobApplicationRepository;
 use App\Applications\JobApplicationService;
+use App\Prompts\PromptLibrary;
 use App\Research\CompanyResearchService;
 use App\Views\Renderer;
 use DateTimeImmutable;
@@ -182,6 +183,7 @@ final class JobApplicationController
         $statusMessage = $request->getQueryParams()['status'] ?? null;
         $generations = $this->service->generationsForUser($userId);
         $generationOptions = $this->mapGenerationOptions($generations);
+        $cvOptions = $this->service->cvOptionsForUser($userId);
         $generationIndex = $this->indexGenerations($generations);
         $linkedGeneration = null;
 
@@ -206,7 +208,8 @@ final class JobApplicationController
                 [],
                 $statusMessage,
                 $generationOptions,
-                $linkedGeneration
+                $linkedGeneration,
+                $cvOptions
             )
         );
     }
@@ -261,6 +264,7 @@ final class JobApplicationController
 
         $generations = $this->service->generationsForUser($userId);
         $generationOptions = $this->mapGenerationOptions($generations);
+        $cvOptions = $this->service->cvOptionsForUser($userId);
         $generationIndex = $this->indexGenerations($generations);
         $linkedGeneration = null;
         $current = $result['application']->generationId();
@@ -272,8 +276,67 @@ final class JobApplicationController
         return $this->renderer->render(
             $response->withStatus(422),
             'applications-edit',
-            $this->editViewPayload($result['application'], $preparedForm, $result['errors'], null, $generationOptions, $linkedGeneration)
+            $this->editViewPayload($result['application'], $preparedForm, $result['errors'], null, $generationOptions, $linkedGeneration, $cvOptions)
         );
+    }
+
+
+    /**
+     * Import a job description from a public URL for the application form.
+     *
+     * Returning JSON lets create and edit screens share the same web-to-tracker capture mechanism.
+     */
+    public function fetchDescription(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $user = $request->getAttribute('user');
+
+        if ($user === null) {
+            return $this->jsonResponse($response, ['status' => 'error', 'message' => 'Authentication required.'], 401);
+        }
+
+        $data = $request->getParsedBody();
+        $url = is_array($data) && isset($data['source_url']) ? (string) $data['source_url'] : '';
+
+        try {
+            $posting = $this->service->fetchPostingFromUrl($url);
+        } catch (RuntimeException $exception) {
+            return $this->jsonResponse($response, ['status' => 'error', 'message' => $exception->getMessage()], 422);
+        }
+
+        return $this->jsonResponse($response, ['status' => 'ok', 'data' => $posting], 200);
+    }
+
+    /**
+     * Queue tailoring directly from a tracked job application.
+     *
+     * This endpoint keeps the advert, selected master CV, generated documents, and tracker link in one workflow.
+     * @param array<string, string> $args
+     */
+    public function tailor(ServerRequestInterface $request, ResponseInterface $response, array $args): ResponseInterface
+    {
+        $user = $request->getAttribute('user');
+
+        if ($user === null) {
+            return $response->withHeader('Location', '/auth/login')->withStatus(302);
+        }
+
+        $applicationId = isset($args['id']) ? (int) $args['id'] : 0;
+        $data = $request->getParsedBody();
+        $cvDocumentId = is_array($data) && isset($data['cv_document_id']) ? (int) $data['cv_document_id'] : 0;
+        $model = is_array($data) && isset($data['model']) ? trim((string) $data['model']) : 'gpt-5.4-mini';
+        $thinkingTime = is_array($data) && isset($data['thinking_time']) ? (int) $data['thinking_time'] : 30;
+        $prompt = is_array($data) && isset($data['prompt']) ? trim((string) $data['prompt']) : PromptLibrary::tailorPrompt();
+
+        try {
+            $this->service->tailorApplication((int) $user['user_id'], $applicationId, $cvDocumentId, $model, $thinkingTime, $prompt);
+            $message = 'Tailored CV job queued and linked to this application.';
+        } catch (RuntimeException $exception) {
+            $message = $exception->getMessage();
+        }
+
+        return $response
+            ->withHeader('Location', '/applications/' . $applicationId . '?status=' . rawurlencode($message))
+            ->withStatus(302);
     }
 
     /**
@@ -649,7 +712,8 @@ final class JobApplicationController
         array $errors,
         ?string $statusMessage,
         array $generationOptions,
-        ?array $linkedGeneration
+        ?array $linkedGeneration,
+        array $cvOptions = []
     ): array
     {
         $appliedAt = $application->appliedAt();
@@ -672,6 +736,9 @@ final class JobApplicationController
             'statusOptions' => $this->service->statusOptions(),
             'generationOptions' => $generationOptions,
             'linkedGeneration' => $linkedGeneration,
+            'cvOptions' => $cvOptions,
+            'modelOptions' => GenerationController::availableModels(),
+            'defaultPrompt' => PromptLibrary::tailorPrompt(),
             'application' => [
                 'id' => $application->id(),
                 'created_at' => $application->createdAt()->format('Y-m-d H:i'),

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -108,6 +108,10 @@ class Routes
             return $container->get(JobApplicationController::class)->store($request, $response);
         });
 
+        $app->post('/applications/fetch-description', function (Request $request, Response $response) use ($container) {
+            return $container->get(JobApplicationController::class)->fetchDescription($request, $response);
+        });
+
         $app->get('/applications/{id}', function (Request $request, Response $response, array $args) use ($container) {
             return $container->get(JobApplicationController::class)->edit($request, $response, $args);
         });
@@ -122,6 +126,10 @@ class Routes
 
         $app->post('/applications/{id}/generation', function (Request $request, Response $response, array $args) use ($container) {
             return $container->get(JobApplicationController::class)->updateGeneration($request, $response, $args);
+        });
+
+        $app->post('/applications/{id}/tailor', function (Request $request, Response $response, array $args) use ($container) {
+            return $container->get(JobApplicationController::class)->tailor($request, $response, $args);
         });
 
         $app->post('/applications/{id}/research', function (Request $request, Response $response, array $args) use ($container) {


### PR DESCRIPTION
### Motivation

- Restore and centralise the prime workflow: let users import job adverts into the tracker, pair a saved posting with a master CV, queue AI tailoring, and automatically link the generated tailored CV/cover letter back to the application record.
- Reduce friction and inconsistent mechanisms caused by fragmented edits across controllers and views by providing a single import path and application-level tailoring action.

### Description

- Added a `JobPostingFetcher` service (`src/Applications/JobPostingFetcher.php`) that fetches a public job advert URL, extracts a normalised title and readable description, and returns `{title, description, source_url}`.
- Extended `JobApplicationService` (`src/Applications/JobApplicationService.php`) with `fetchPostingFromUrl`, `tailorApplication`, `cvOptionsForUser`, and `findJobDescriptionDocument` to centralise import, CV lookups, and application-scoped tailoring logic, and injected a `JobPostingFetcher` dependency.
- Exposed new controller endpoints in `JobApplicationController` (`src/Controllers/JobApplicationController.php`) and routes (`src/Routes.php`): `POST /applications/fetch-description` to import a posting into the create/edit forms, and `POST /applications/{id}/tailor` to queue a tailored CV/cover letter from a saved application and link the generation back to the tracker.
- Wired the `JobPostingFetcher` into the DI container (`public/index.php`) and added the client-side import UI and behavior: updated templates `resources/views/applications-create.php` and `resources/views/applications-edit.php` to include an `Import` button and a new “Prime workflow” section on the edit screen for queuing tailored documents, and added `public/assets/js/application-form.js` to handle the fetch and populate form fields.

### Testing

- Ran PHP linter on modified runtime files with `php -l public/index.php && php -l src/Routes.php && php -l src/Applications/JobApplicationService.php && php -l src/Applications/JobPostingFetcher.php && php -l src/Controllers/JobApplicationController.php && php -l resources/views/applications-create.php && php -l resources/views/applications-edit.php`, which reported no syntax errors.
- No database-dependent integration tests were executed, consistent with the instruction to avoid tests requiring DB access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5256446e1c832eb59a69ff436b1e94)