### PR TITLE
Restore fixes stranded on merged branches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
             "@php tests/OpenAIProviderDraftTest.php",
             "@php tests/ModelCatalogServiceTest.php",
             "@php tests/UsageServiceTest.php",
+            "@php tests/ConverterSecurityTest.php",
             "@php tests/DatabaseSchemaVerifierTest.php"
         ],
         "cs-fix": "@php -r \"echo 'Code style fixer not configured yet.' . PHP_EOL;\"",

--- a/src/Conversion/Converter.php
+++ b/src/Conversion/Converter.php
@@ -7,6 +7,7 @@ namespace App\Conversion;
 use App\DB;
 use DateTimeImmutable;
 use DOMDocument;
+use DOMXPath;
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\ConverterInterface;
 use League\CommonMark\Output\RenderedContentInterface;
@@ -280,43 +281,70 @@ class Converter
             LIBXML_HTML_NODEFDTD
         );
 
-        if ($loaded === true) {
-            $images = $document->getElementsByTagName('img');
-            $removals = [];
+        if ($loaded !== true) {
+            libxml_clear_errors();
+            libxml_use_internal_errors($priorSetting);
 
-            foreach ($images as $image) {
-                $source = $image->getAttribute('src');
+            return $html;
+        }
 
-                if ($source === '') {
-                    continue;
-                }
+        $xpath = new DOMXPath($document);
+        $resourceTags = [
+            'img',
+            'audio',
+            'video',
+            'source',
+            'track',
+            'iframe',
+            'embed',
+            'object',
+            'link',
+            'script',
+        ];
+        $attributeNames = ['src', 'href', 'poster', 'xlink:href', 'data'];
+        $queryParts = [];
 
-                if ($this->isRemotePath($source)) {
-                    $removals[] = $image;
+        foreach ($resourceTags as $tag) {
+            $queryParts[] = sprintf('local-name() = "%s"', $tag);
+        }
+
+        $nodes = $xpath->query(sprintf('//*[%s]', implode(' or ', $queryParts)));
+        $removals = [];
+
+        if ($nodes !== false) {
+            foreach ($nodes as $node) {
+                foreach ($attributeNames as $attribute) {
+                    if (!$node->hasAttribute($attribute)) {
+                        continue;
+                    }
+
+                    $value = trim($node->getAttribute($attribute));
+
+                    if ($value === '' || $this->isSafeEmbeddedResourceUrl($value)) {
+                        continue;
+                    }
+
+                    $removals[] = $node;
+                    break;
                 }
             }
+        }
 
-            foreach ($removals as $image) {
-                $parentNode = $image->parentNode;
-
-                if ($parentNode !== null) {
-                    $parentNode->removeChild($image);
-                }
+        foreach ($removals as $node) {
+            if ($node->parentNode !== null) {
+                $node->parentNode->removeChild($node);
             }
+        }
 
-            $body = $document->getElementsByTagName('body')->item(0);
+        $body = $document->getElementsByTagName('body')->item(0);
+        $sanitized = '';
 
-            if ($body !== null) {
-                $sanitized = '';
-
-                foreach ($body->childNodes as $childNode) {
-                    $sanitized .= $document->saveHTML($childNode);
-                }
-            } else {
-                $sanitized = $document->saveHTML();
+        if ($body !== null) {
+            foreach ($body->childNodes as $childNode) {
+                $sanitized .= $document->saveHTML($childNode);
             }
         } else {
-            $sanitized = $html;
+            $sanitized = $document->saveHTML();
         }
 
         libxml_clear_errors();
@@ -326,36 +354,17 @@ class Converter
     }
 
     /**
-     * Determine whether a given path references a remote or local resource with a scheme.
+     * Determine whether a referenced resource is safe to embed in a generated document.
      *
-     * PhpWord follows URLs that contain schemes or protocol relative prefixes, so the
-     * method identifies these patterns to block external resource fetching.
+     * Only self-contained data and CID resources are accepted. Relative paths and
+     * every externally resolvable scheme are rejected to prevent network and local
+     * filesystem access during DOCX or PDF rendering.
      */
-    private function isRemotePath(string $path): bool
+    private function isSafeEmbeddedResourceUrl(string $value): bool
     {
-        $trimmedPath = trim($path);
+        $normalized = strtolower(trim($value));
 
-        if ($trimmedPath === '') {
-            return false;
-        }
-
-        if (strpos($trimmedPath, '//') === 0) {
-            return true;
-        }
-
-        $scheme = parse_url($trimmedPath, PHP_URL_SCHEME);
-
-        if ($scheme === false || $scheme === null || $scheme === '') {
-            return false;
-        }
-
-        $normalizedScheme = strtolower($scheme);
-
-        if ($normalizedScheme === 'data') {
-            return false;
-        }
-
-        return in_array($normalizedScheme, ['http', 'https', 'ftp', 'ftps', 'file'], true);
+        return strpos($normalized, 'data:') === 0 || strpos($normalized, 'cid:') === 0;
     }
 
     /**

--- a/tests/ConverterSecurityTest.php
+++ b/tests/ConverterSecurityTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Conversion\Converter;
+
+require __DIR__ . '/../autoload.php';
+
+$converter = new Converter();
+$method = new ReflectionMethod(Converter::class, 'sanitizeHtmlForDocx');
+$method->setAccessible(true);
+
+$unsafeHtml = '<p>Candidate profile</p>'
+    . '<img src="https://attacker.example/tracker.png">'
+    . '<img src="../../private-file.png">'
+    . '<iframe src="file:///etc/passwd"></iframe>'
+    . '<object data="ftp://attacker.example/payload"></object>'
+    . '<script src="//attacker.example/script.js"></script>'
+    . '<img src="data:image/png;base64,AAAA">'
+    . '<a href="https://example.com/profile">Public profile</a>';
+
+$sanitized = $method->invoke($converter, $unsafeHtml);
+
+if (!is_string($sanitized)) {
+    throw new RuntimeException('The converter sanitizer did not return HTML.');
+}
+
+foreach (['attacker.example', '../../private-file.png', 'file:///etc/passwd'] as $blockedValue) {
+    if (strpos($sanitized, $blockedValue) !== false) {
+        throw new RuntimeException(sprintf('Unsafe resource remained in rendered HTML: %s', $blockedValue));
+    }
+}
+
+if (strpos($sanitized, 'data:image/png;base64,AAAA') === false) {
+    throw new RuntimeException('A self-contained image was removed by the sanitizer.');
+}
+
+if (strpos($sanitized, 'https://example.com/profile') === false) {
+    throw new RuntimeException('A normal hyperlink was removed by the resource sanitizer.');
+}
+
+echo 'ConverterSecurityTest passed' . PHP_EOL;


### PR DESCRIPTION
## What changed

- ports the previously merged DOCX resource-sanitization intent into the current mPDF/PhpWord converter
- blocks external and local resource resolution while preserving self-contained data/CID assets and normal hyperlinks
- restores combined rendering of research summaries and related sources on the applications page
- adds a regression test for document-conversion resource sanitization

## Why

A final ancestry audit after stale-branch cleanup found two patches that had been merged into intermediate branches after those branches' main pull requests were already complete. Their semantic changes were therefore not present on `main`.

## Validation

- `composer test`
- `php bin/smoke.php`
- PHP lint
- `node --check public/assets/js/applications.js`
- `git diff --check`