### PR TITLE
Make AI model settings easy to find

### DIFF
--- a/resources/views/schema-test.php
+++ b/resources/views/schema-test.php
@@ -11,7 +11,7 @@ $navLinks = [
     ['href' => '/applications', 'label' => 'Applications', 'current' => false],
     ['href' => '/profile/contact-details', 'label' => 'Contact details', 'current' => false],
     ['href' => '/usage', 'label' => 'Usage', 'current' => false],
-    ['href' => '/settings/models', 'label' => 'Settings', 'current' => false],
+    ['href' => '/settings/models', 'label' => 'AI models', 'current' => false],
     ['href' => '/retention', 'label' => 'Retention', 'current' => false],
     ['href' => '/settings/schema-test', 'label' => 'Schema test', 'current' => true],
 ];

--- a/resources/views/tailor.php
+++ b/resources/views/tailor.php
@@ -80,6 +80,12 @@ $additionalHead = '<script src="/assets/js/tailor.js" defer></script>';
         </div>
         <div class="flex flex-col gap-3 md:items-end">
             <a
+                href="/settings/models"
+                class="inline-flex items-center gap-2 rounded-lg border border-indigo-500/50 bg-indigo-500/10 px-4 py-2 text-sm font-medium text-indigo-100 transition hover:border-indigo-400 hover:bg-indigo-500/20"
+            >
+                AI model settings
+            </a>
+            <a
                 href="/"
                 class="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:bg-slate-800"
             >
@@ -225,7 +231,15 @@ $additionalHead = '<script src="/assets/js/tailor.js" defer></script>';
 
                 <div x-show="step === 3" x-cloak class="space-y-6">
                     <div class="space-y-3">
-                        <p class="text-sm font-medium text-slate-200">Model</p>
+                        <div class="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+                            <div>
+                                <p class="text-sm font-medium text-slate-200">Drafting model for this application</p>
+                                <p class="text-xs text-slate-400">This selection overrides the saved drafting default for this run.</p>
+                            </div>
+                            <a href="/settings/models" class="text-xs font-medium text-indigo-300 hover:text-indigo-200">
+                                Change analysis and default models
+                            </a>
+                        </div>
                         <div class="grid gap-3 md:grid-cols-3">
                             <template x-for="model in models" :key="model.value">
                                 <button

--- a/resources/views/usage.php
+++ b/resources/views/usage.php
@@ -10,7 +10,7 @@ $navLinks = [
     ['href' => '/applications', 'label' => 'Applications', 'current' => false],
     ['href' => '/profile/contact-details', 'label' => 'Contact details', 'current' => false],
     ['href' => '/usage', 'label' => 'Usage', 'current' => true],
-    ['href' => '/settings/models', 'label' => 'Settings', 'current' => false],
+    ['href' => '/settings/models', 'label' => 'AI models', 'current' => false],
     ['href' => '/retention', 'label' => 'Retention', 'current' => false],
 ];
 $additionalHead = <<<'HTML'

--- a/src/Controllers/ContactDetailsController.php
+++ b/src/Controllers/ContactDetailsController.php
@@ -158,7 +158,7 @@ final class ContactDetailsController
             'applications' => ['href' => '/applications', 'label' => 'Applications'],
             'contact' => ['href' => '/profile/contact-details', 'label' => 'Contact details'],
             'usage' => ['href' => '/usage', 'label' => 'Usage'],
-            'settings' => ['href' => '/settings/models', 'label' => 'Settings'],
+            'settings' => ['href' => '/settings/models', 'label' => 'AI models'],
             'retention' => ['href' => '/retention', 'label' => 'Retention'],
         ];
 

--- a/src/Controllers/DocumentController.php
+++ b/src/Controllers/DocumentController.php
@@ -1045,7 +1045,7 @@ final class DocumentController
             'applications' => ['href' => '/applications', 'label' => 'Applications'],
             'contact' => ['href' => '/profile/contact-details', 'label' => 'Contact details'],
             'usage' => ['href' => '/usage', 'label' => 'Usage'],
-            'settings' => ['href' => '/settings/models', 'label' => 'Settings'],
+            'settings' => ['href' => '/settings/models', 'label' => 'AI models'],
             'retention' => ['href' => '/retention', 'label' => 'Retention'],
         ];
 

--- a/src/Controllers/HomeController.php
+++ b/src/Controllers/HomeController.php
@@ -87,7 +87,7 @@ class HomeController
             'applications' => ['href' => '/applications', 'label' => 'Applications'],
             'contact' => ['href' => '/profile/contact-details', 'label' => 'Contact details'],
             'usage' => ['href' => '/usage', 'label' => 'Usage'],
-            'settings' => ['href' => '/settings/models', 'label' => 'Settings'],
+            'settings' => ['href' => '/settings/models', 'label' => 'AI models'],
             'retention' => ['href' => '/retention', 'label' => 'Retention'],
         ];
 

--- a/src/Controllers/JobApplicationController.php
+++ b/src/Controllers/JobApplicationController.php
@@ -680,7 +680,7 @@ final class JobApplicationController
             'applications' => ['href' => '/applications', 'label' => 'Applications'],
             'contact' => ['href' => '/profile/contact-details', 'label' => 'Contact details'],
             'usage' => ['href' => '/usage', 'label' => 'Usage'],
-            'settings' => ['href' => '/settings/models', 'label' => 'Settings'],
+            'settings' => ['href' => '/settings/models', 'label' => 'AI models'],
             'retention' => ['href' => '/retention', 'label' => 'Retention'],
         ];
 

--- a/src/Controllers/ModelSettingsController.php
+++ b/src/Controllers/ModelSettingsController.php
@@ -170,7 +170,7 @@ final class ModelSettingsController
             ['href' => '/documents', 'label' => 'Documents', 'current' => false],
             ['href' => '/applications', 'label' => 'Applications', 'current' => false],
             ['href' => '/usage', 'label' => 'Usage', 'current' => false],
-            ['href' => '/settings/models', 'label' => 'Settings', 'current' => true],
+            ['href' => '/settings/models', 'label' => 'AI models', 'current' => true],
         ];
     }
 }

--- a/src/Controllers/RetentionController.php
+++ b/src/Controllers/RetentionController.php
@@ -149,7 +149,7 @@ class RetentionController
             'applications' => ['href' => '/applications', 'label' => 'Applications'],
             'contact' => ['href' => '/profile/contact-details', 'label' => 'Contact details'],
             'usage' => ['href' => '/usage', 'label' => 'Usage'],
-            'settings' => ['href' => '/settings/models', 'label' => 'Settings'],
+            'settings' => ['href' => '/settings/models', 'label' => 'AI models'],
             'retention' => ['href' => '/retention', 'label' => 'Retention'],
         ];
 

--- a/src/Controllers/TailorController.php
+++ b/src/Controllers/TailorController.php
@@ -213,7 +213,7 @@ final class TailorController
             'applications' => ['href' => '/applications', 'label' => 'Applications'],
             'contact' => ['href' => '/profile/contact-details', 'label' => 'Contact details'],
             'usage' => ['href' => '/usage', 'label' => 'Usage'],
-            'settings' => ['href' => '/settings/models', 'label' => 'Settings'],
+            'settings' => ['href' => '/settings/models', 'label' => 'AI models'],
             'retention' => ['href' => '/retention', 'label' => 'Retention'],
         ];
 


### PR DESCRIPTION
## What changed

- renames the generic authenticated navigation item from `Settings` to `AI models`
- adds a prominent `AI model settings` shortcut on the Tailor screen
- labels the per-application choice as the drafting model for that run
- links directly from the drafting step to the analysis and default model controls

## Why

The model controls existed in the merged code but were not discoverable enough. Production is also currently serving an older revision where `/settings/models` does not exist, making the absence especially confusing.

## Validation

- full `composer test` suite
- PHP lint across controllers and views
- JavaScript syntax check
- `git diff --check`